### PR TITLE
Issue 42 typecheck inputs

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -148,6 +148,7 @@ class ElementInfo extends NodeInfo {
   final bool isTemplate;
   final bool hasTemplateAttribute;
   final List<AttributeInfo> attributes;
+  List<AbstractDirective> directives = <AbstractDirective>[];
 
   ElementInfo(
       this.localName,
@@ -623,7 +624,8 @@ class TemplateResolver {
   /**
    * Resolve values of [attributes].
    */
-  void _resolveAttributeValues(List<AttributeInfo> attributes) {
+  void _resolveAttributeValues(
+      List<AttributeInfo> attributes, List<AbstractDirective> directives) {
     for (AttributeInfo attribute in attributes) {
       int valueOffset = attribute.valueOffset;
       String value = attribute.value;
@@ -641,6 +643,36 @@ class TemplateResolver {
         if (expression != null) {
           _recordExpressionResolvedRanges(expression);
         }
+
+        var matched = false;
+        if (attribute.name.startsWith('[')) {
+          for (AbstractDirective directive in directives) {
+            for (InputElement input in directive.inputs) {
+              if (input.name == attribute.inputName) {
+                var attrType = expression.bestType;
+                var inputType = input.setter.variable.type;
+                if (!attrType.isAssignableTo(inputType)) {
+                  errorListener.onError(new AnalysisError(
+                      templateSource,
+                      attribute.valueOffset,
+                      attribute.value.length,
+                      AngularWarningCode.INPUT_BINDING_TYPE_ERROR,
+                      [attrType, inputType]));
+                }
+                matched = true;
+              }
+            }
+          }
+
+          if (!matched) {
+            errorListener.onError(new AnalysisError(
+                templateSource,
+                attribute.nameOffset,
+                attribute.name.length,
+                AngularWarningCode.NONEXIST_INPUT_BOUND));
+          }
+        }
+
         continue;
       }
       // text interpolations
@@ -720,7 +752,7 @@ class TemplateResolver {
         }
       }
       // process all non-template nodes
-      _resolveNodeNames(element, true, templateElements);
+      _resolveNodeDirectives(element, true, templateElements);
       _resolveNodeExpressions(element, true);
       // process templates with their sub-trees
       for (ElementInfo templateElement in templateElements) {
@@ -746,13 +778,13 @@ class TemplateResolver {
   _resolveNodeExpressions(NodeInfo node, bool enterTemplate) {
     if (node is ElementInfo) {
       if (node.isTemplate) {
-        _resolveAttributeValues(node.attributes);
+        _resolveAttributeValues(node.attributes, node.directives);
       }
       if (!enterTemplate && node.isOrHasTemplateAttribute) {
         return;
       }
       if (!node.isTemplate) {
-        _resolveAttributeValues(node.attributes);
+        _resolveAttributeValues(node.attributes, node.directives);
       }
     }
     if (node is TextInfo) {
@@ -763,7 +795,7 @@ class TemplateResolver {
     }
   }
 
-  _resolveNodeNames(
+  _resolveNodeDirectives(
       NodeInfo node, bool enterTemplate, List<ElementInfo> templateElements) {
     if (node is ElementInfo) {
       // skip template
@@ -771,13 +803,15 @@ class TemplateResolver {
         templateElements.add(node);
         return;
       }
-      // apply directives
-      bool tagIsStandard = _isStandardTagName(node.localName);
-      bool tagIsResolved = false;
+
       ElementView elementView = new ElementViewImpl(node.attributes, node);
+      bool tagIsResolved = false;
+      bool tagIsStandard = _isStandardTagName(node.localName);
+
       for (AbstractDirective directive in allDirectives) {
         Selector selector = directive.selector;
         if (selector.match(elementView, template)) {
+          node.directives.add(directive);
           if (selector is ElementNameSelector) {
             tagIsResolved = true;
           }
@@ -789,12 +823,14 @@ class TemplateResolver {
         _reportErrorForRange(node.openingNameSpan,
             AngularWarningCode.UNRESOLVED_TAG, [node.localName]);
       }
+
       // define local variables
       _defineLocalVariablesForAttributes(node.attributes);
     }
+
     // process children
     for (NodeInfo child in node.children) {
-      _resolveNodeNames(child, false, templateElements);
+      _resolveNodeDirectives(child, false, templateElements);
     }
   }
 
@@ -886,17 +922,20 @@ class TemplateResolver {
       attributeInfo.expression = expression;
       attributes.add(attributeInfo);
     }
-    // match directives
+    // match directives, requiring a match
     ElementView elementView = new ElementViewImpl(attributes, null);
+    var directives = <AbstractDirective>[];
     for (AbstractDirective directive in allDirectives) {
       if (directive.selector.match(elementView, template)) {
+        directives.add(directive);
         _defineDirectiveVariables(attributes, directive);
         _defineLocalVariablesForAttributes(attributes);
         _resolveAttributeNames(attributes, directive);
-        break;
       }
     }
-    _resolveAttributeValues(attributes);
+
+    // TODO: report error if no directives matched here?
+    _resolveAttributeValues(attributes, directives);
   }
 
   /**

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -96,6 +96,22 @@ class AngularWarningCode extends ErrorCode {
           'UNTERMINATED_MUSTACHE', 'Unterminated mustache');
 
   /**
+   * An error code indicating that a nonexist input was bound
+   */
+  static const AngularWarningCode NONEXIST_INPUT_BOUND =
+      const AngularWarningCode('NONEXIST_INPUT_BOUND',
+          'The bound input does not exist on any directives');
+
+  /**
+   * An error code indicating that a nonexist input was bound
+   */
+  static const AngularWarningCode INPUT_BINDING_TYPE_ERROR =
+      const AngularWarningCode(
+          'INPUT_BINDING_TYPE_ERROR',
+          'Attribute value expression (of type {0}) ' +
+              'is not assignable to component input (of type {1})');
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be


### PR DESCRIPTION
Make validating attribute values take the directives attached to the
component. In order to prevent double matching selectors (which, as
written now, would resolve their ranges twice), store them on the
ElementInfo object.

Also rename resolveNodeNames to resolveDirectives because that's what it
does.

Originally I had done some refactoring to not require a mutation of the
ElementInfo object, but due to the nature of #localRefs, it requires
more than one pass over the AST (one to resolve the directives and load
the local vars, and then another to typecheck the expressions with the
scope finalized). Therefore I could either mutate the AST or copy
it/produce a new IR, which seems unwarranted.

Tests; some were updated because they didn't have valid usages of inputs
and not. Others are new to test the new behavior.