### PR TITLE
Fix analyzer/frontend split dependency

### DIFF
--- a/analyzer_plugin/pubspec.yaml
+++ b/analyzer_plugin/pubspec.yaml
@@ -14,3 +14,5 @@ dev_dependencies:
 dependency_overrides:
   analyzer:
      path: ../../sdk/pkg/analyzer
+  front_end:
+     path: ../../sdk/pkg/front_end

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -342,7 +342,7 @@ class GatheringErrorListener implements AnalysisErrorListener {
    * order in which the errors were gathered is ignored.
    */
   void assertErrorsWithCodes(
-      [List<ErrorCode> expectedErrorCodes = ErrorCode.EMPTY_LIST]) {
+      [List<ErrorCode> expectedErrorCodes = const <ErrorCode>[]]) {
     StringBuffer buffer = new StringBuffer();
     //
     // Verify that the expected error codes have a non-empty message.

--- a/server_plugin/pubspec.yaml
+++ b/server_plugin/pubspec.yaml
@@ -18,3 +18,5 @@ dependency_overrides:
      path: ../../sdk/pkg/analyzer
   analysis_server:
      path: ../../sdk/pkg/analysis_server
+  front_end:
+     path: ../../sdk/pkg/front_end


### PR DESCRIPTION
Mostly just needed to hardcode the path for the frontend so we can
import a consistent version of the sdk. However, did also lose the
Errors.EMPTY_LIST constant for some reason, filled that in too.