### PR TITLE
Fix test which used nonexist html property that the mock sdk didn't know about

### DIFF
--- a/analyzer_plugin/test/mock_sdk.dart
+++ b/analyzer_plugin/test/mock_sdk.dart
@@ -180,6 +180,7 @@ class HtmlElement {
   int tabIndex;
   ElementStream<Event> get onChange => null;
   ElementStream<MouseEvent> get onClick => null;
+  bool hidden;
 }
 
 class AnchorElement extends HtmlElement {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -415,7 +415,7 @@ class TestPanel {
     _assertElement("length}}").dart.getter;
   }
 
-  void test_ngFor_star_itemVisibleInElement() {
+  void test_ngFor_star_itemHiddenInElement() {
     _addDartSource(r'''
 @Component(selector: 'test-panel')
 @View(templateUrl: 'test_panel.html', directives: const [NgFor])
@@ -424,12 +424,12 @@ class TestPanel {
 }
 ''');
     _addHtmlSource(r"""
-<li *ngFor='let item of items' [visible]='item != null'>
-</li>
+<h1 *ngFor='let item of items' [hidden]='item == null'>
+</h1>
 """);
     _resolveSingleTemplate(dartSource);
     errorListener.assertNoErrors();
-    _assertElement("item != null").local.at('item of items');
+    _assertElement("item == null").local.at('item of items');
   }
 
   void test_ngFor_templateAttribute() {


### PR DESCRIPTION
This broke when inputs were added, and the error was revealed when the ngFor branch added 'assertNoErrors' to the test.

Use h1 instead of li because h1 is in the mock sdk already and li is not...but adding li caused new resolved ranges in many tests, which would require updating those tests to get them passing again.

Still two more tests failing from the merge, likely the same overall reason (broken by inputs branch, revealed by assertNoErrors in ngFor branch) but with a different underlying cause.