### PR TITLE
Fix issue of template attrs being resolved twice, once without directives

### DIFF
--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -549,6 +549,30 @@ class TestPanel {
     _assertElement("item.").local.at('item [');
   }
 
+  void test_ngFor_variousKinds_useLowerIdentifier() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NgFor])
+class TestPanel {
+  List<String> items = [];
+}
+''');
+    _addHtmlSource(r"""
+<template ngFor let-item1 [ngForOf]='items' let-i='index' {{lowerEl}}>
+  {{item1.length}}
+</template>
+<li template="ngFor let item2 of items; let i=index" {{lowerEl}}>
+  {{item2.length}}
+</li>
+<li *ngFor="let item3 of items; let i=index" {{lowerEl}}>
+  {{item3.length}}
+</li>
+<div #lowerEl></div>
+""");
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
   void test_ngIf_star() {
     _addDartSource(r'''
 @Component(selector: 'test-panel')


### PR DESCRIPTION
This only applies to `<template ngFor...>`, note that the sugared template
syntaxes are handled differently and don't have this problem because the
sugared attributes are handled before the other attributes are.

No longer resolve template attributes before the template directives are
resolved. Still, we have to resolve the ngFor attribute before we can
put the ngFor variables in scope. So, split that apart from the other
types of vars that are defined based on directives. In the case of
resolving attributes for a template, do the ngFor resolution later but
not too late; in the case of sugared templates, do the same order.

Edit: fixes two tests: https://travis-ci.org/dart-lang/angular_analyzer_plugin/jobs/176588080 failure caused be the addition of input validation, which were revealed after merged with ngFor support since it added assertNewErrors to those tests