### PR TITLE
Typecheck $event (#37) and ensure @Output are EventEmitters (#41)

### DIFF
--- a/analyzer_plugin/lib/src/model.dart
+++ b/analyzer_plugin/lib/src/model.dart
@@ -1,6 +1,7 @@
 library angular2.src.analysis.analyzer_plugin.src.model;
 
 import 'package:analyzer/dart/element/element.dart' as dart;
+import 'package:analyzer/dart/element/type.dart' as dart;
 import 'package:analyzer/src/generated/source.dart' show Source, SourceRange;
 import 'package:analyzer/src/generated/utilities_general.dart';
 import 'package:analyzer/task/model.dart' show AnalysisTarget;
@@ -196,6 +197,8 @@ class OutputElement extends AngularElementImpl {
 
   final dart.PropertyAccessorElement getter;
 
+  final dart.DartType eventType;
+
   /**
    * The [SourceRange] where [getter] is referenced in the input declaration.
    * May be the same as this element offset/length in shorthand variants where
@@ -204,7 +207,7 @@ class OutputElement extends AngularElementImpl {
   final SourceRange getterRange;
 
   OutputElement(String name, int nameOffset, int nameLength, Source source,
-      this.getter, this.getterRange)
+      this.getter, this.getterRange, this.eventType)
       : super(name, nameOffset, nameLength, source);
 
   @override

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -125,6 +125,13 @@ class AngularWarningCode extends ErrorCode {
               'is not assignable to component input (of type {1})');
 
   /**
+   * An error code indicating that an @Output is not an EventEmitter
+   */
+  static const AngularWarningCode OUTPUT_MUST_BE_EVENTEMITTER =
+      const AngularWarningCode('OUTPUT_MUST_BE_EVENTEMMITTER',
+          'Output (of name {0}) must return an EventEmitter');
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be

--- a/analyzer_plugin/test/mock_sdk.dart
+++ b/analyzer_plugin/test/mock_sdk.dart
@@ -173,6 +173,7 @@ library dart.html;
 import 'dart:async';
 
 class Event {}
+class MouseEvent extends Event {}
 
 abstract class ElementStream<T extends Event> implements Stream<T> {}
 


### PR DESCRIPTION
The parseDartExpression code defines a local scope, so have it accept a
nullable EventType thing to fill in the $event var on that scope rather
than have stuff outside of that function have to set up/tear down the
scope properly.

Track the event types of html components as well as the event types of
custom components, and store those in OuputElement since they have
different methods of being discovered