### PR TITLE
Issue 50 twoway binding validation

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -35,7 +35,7 @@ html.Element _firstElement(html.Node node) {
   return null;
 }
 
-enum AttributeBoundType { input, output }
+enum AttributeBoundType { input, output, twoway }
 
 /**
  * Information about an attribute.
@@ -300,7 +300,11 @@ class HtmlTreeConverter {
         AttributeBoundType bound = null;
         String propName = name;
         int propNameOffset = nameOffset;
-        if (propName.startsWith('[') && propName.endsWith(']')) {
+        if (propName.startsWith('[(') && propName.endsWith(')]')) {
+          propNameOffset += 2;
+          bound = AttributeBoundType.twoway;
+          propName = propName.substring(2, propName.length - 2);
+        } else if (propName.startsWith('[') && propName.endsWith(']')) {
           propNameOffset += 1;
           propName = propName.substring(1, propName.length - 1);
           bound = AttributeBoundType.input;
@@ -677,8 +681,10 @@ class TemplateResolver {
       }
       // bound
       if (attribute.bound != null) {
+        AngularWarningCode unboundErrorCode;
         var matched = false;
         if (attribute.bound == AttributeBoundType.output) {
+          unboundErrorCode = AngularWarningCode.NONEXIST_OUTPUT_BOUND;
           for (AbstractDirective directive in directives) {
             for (OutputElement output in directive.outputs) {
               if (output.name == attribute.propertyName) {
@@ -699,7 +705,46 @@ class TemplateResolver {
           _recordExpressionResolvedRanges(expression);
         }
 
-        if (attribute.bound == AttributeBoundType.input) {
+        if (attribute.bound == AttributeBoundType.twoway) {
+          if (!expression.isAssignable) {
+            errorListener.onError(new AnalysisError(
+              templateSource,
+              attribute.valueOffset,
+              attribute.value.length,
+              AngularWarningCode.TWO_WAY_BINDING_NOT_ASSIGNABLE,
+            ));
+          }
+
+          var outputMatched = false;
+          for (AbstractDirective directive in directives) {
+            for (OutputElement output in directive.outputs) {
+              if (output.name == attribute.propertyName + "Change") {
+                outputMatched = true;
+                if (!output.eventType.isAssignableTo(expression.bestType)) {
+                  errorListener.onError(new AnalysisError(
+                      templateSource,
+                      attribute.valueOffset,
+                      attribute.value.length,
+                      AngularWarningCode.TWO_WAY_BINDING_OUTPUT_TYPE_ERROR,
+                      [output.eventType, expression.bestType]));
+                }
+              }
+            }
+          }
+
+          if (!outputMatched) {
+            errorListener.onError(new AnalysisError(
+                templateSource,
+                attribute.nameOffset,
+                attribute.name.length,
+                AngularWarningCode.NONEXIST_TWOWAY_OUTPUT_BOUND,
+                [attribute.propertyName, attribute.propertyName + "Change"]));
+          }
+        }
+
+        if (attribute.bound == AttributeBoundType.input ||
+            attribute.bound == AttributeBoundType.twoway) {
+          unboundErrorCode = AngularWarningCode.NONEXIST_INPUT_BOUND;
           for (AbstractDirective directive in directives) {
             for (InputElement input in directive.inputs) {
               if (input.name == attribute.propertyName) {
@@ -720,13 +765,8 @@ class TemplateResolver {
         }
 
         if (!matched) {
-          errorListener.onError(new AnalysisError(
-              templateSource,
-              attribute.nameOffset,
-              attribute.name.length,
-              attribute.bound == AttributeBoundType.input
-                  ? AngularWarningCode.NONEXIST_INPUT_BOUND
-                  : AngularWarningCode.NONEXIST_OUTPUT_BOUND));
+          errorListener.onError(new AnalysisError(templateSource,
+              attribute.nameOffset, attribute.name.length, unboundErrorCode));
         }
 
         continue;

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -35,7 +35,7 @@ html.Element _firstElement(html.Node node) {
   return null;
 }
 
-enum AttributeBoundType { input, output, twoway }
+enum AttributeBoundType { input, output, twoWay }
 
 /**
  * Information about an attribute.
@@ -302,7 +302,7 @@ class HtmlTreeConverter {
         int propNameOffset = nameOffset;
         if (propName.startsWith('[(') && propName.endsWith(')]')) {
           propNameOffset += 2;
-          bound = AttributeBoundType.twoway;
+          bound = AttributeBoundType.twoWay;
           propName = propName.substring(2, propName.length - 2);
         } else if (propName.startsWith('[') && propName.endsWith(']')) {
           propNameOffset += 1;
@@ -705,7 +705,7 @@ class TemplateResolver {
           _recordExpressionResolvedRanges(expression);
         }
 
-        if (attribute.bound == AttributeBoundType.twoway) {
+        if (attribute.bound == AttributeBoundType.twoWay) {
           if (!expression.isAssignable) {
             errorListener.onError(new AnalysisError(
               templateSource,
@@ -737,13 +737,13 @@ class TemplateResolver {
                 templateSource,
                 attribute.nameOffset,
                 attribute.name.length,
-                AngularWarningCode.NONEXIST_TWOWAY_OUTPUT_BOUND,
+                AngularWarningCode.NONEXIST_TWO_WAY_OUTPUT_BOUND,
                 [attribute.propertyName, attribute.propertyName + "Change"]));
           }
         }
 
         if (attribute.bound == AttributeBoundType.input ||
-            attribute.bound == AttributeBoundType.twoway) {
+            attribute.bound == AttributeBoundType.twoWay) {
           unboundErrorCode = AngularWarningCode.NONEXIST_INPUT_BOUND;
           for (AbstractDirective directive in directives) {
             for (InputElement input in directive.inputs) {

--- a/analyzer_plugin/lib/src/selector.dart
+++ b/analyzer_plugin/lib/src/selector.dart
@@ -202,6 +202,7 @@ abstract class Selector {
     List<Selector> selectors = <Selector>[];
     int lastOffset = 0;
     Iterable<Match> matches = _regExp.allMatches(str);
+    int ignoring = 0;
     for (Match match in matches) {
       // no content should be skipped
       {
@@ -213,8 +214,21 @@ abstract class Selector {
       }
       // :not start
       if (match[1] != null) {
+        ignoring++;
         // TODO(scheglov) implement this
       }
+      // :not end
+      if (match[6] != null) {
+        ignoring--;
+        // TODO(scheglov) implement this
+      }
+
+      // Skip nots carefully until we support them! If we skip them
+      // carelessly, we break core selectors such as the one in ngModel
+      if (ignoring != 0) {
+        continue;
+      }
+
       // element name
       if (match[2] != null) {
         int nameOffset = offset + match.start;
@@ -238,10 +252,6 @@ abstract class Selector {
         selectors.add(new AttributeSelector(
             new SelectorName(name, nameOffset, name.length, source), match[5]));
         continue;
-      }
-      // :not end
-      if (match[6] != null) {
-        // TODO(scheglov) implement this
       }
       // or
       if (match[7] != null) {

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -120,12 +120,12 @@ class AngularWarningCode extends ErrorCode {
    * because an input was two way bound. The nonexist bound output is
    * an implementation detail, so give its own error.
    */
-  static const AngularWarningCode NONEXIST_TWOWAY_OUTPUT_BOUND =
-      const AngularWarningCode('NONEXIST_TWOWAY_OUTPUT_BOUND',
-          'The two way binding {0} requires a bindable output of name {1}');
+  static const AngularWarningCode NONEXIST_TWO_WAY_OUTPUT_BOUND =
+      const AngularWarningCode('NONEXIST_TWO_WAY_OUTPUT_BOUND',
+          'The two-way binding {0} requires a bindable output of name {1}');
 
   /**
-   * An error code indicating that the output event in a two way binding
+   * An error code indicating that the output event in a two-way binding
    * doesn't match the input
    */
   static const AngularWarningCode TWO_WAY_BINDING_OUTPUT_TYPE_ERROR =

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -116,7 +116,27 @@ class AngularWarningCode extends ErrorCode {
           'The bound output does not exist on any directives');
 
   /**
-   * An error code indicating that a nonexist input was bound
+   * An error code indicating that a nonexist output was bound, perhaps
+   * because an input was two way bound. The nonexist bound output is
+   * an implementation detail, so give its own error.
+   */
+  static const AngularWarningCode NONEXIST_TWOWAY_OUTPUT_BOUND =
+      const AngularWarningCode('NONEXIST_TWOWAY_OUTPUT_BOUND',
+          'The two way binding {0} requires a bindable output of name {1}');
+
+  /**
+   * An error code indicating that the output event in a two way binding
+   * doesn't match the input
+   */
+  static const AngularWarningCode TWO_WAY_BINDING_OUTPUT_TYPE_ERROR =
+      const AngularWarningCode(
+          'TWO_WAY_BINDING_OUTPUT_TYPE_ERROR',
+          'Output event in two-way binding (of type {0}) ' +
+              'is not assignable to component input (of type {1})');
+
+  /**
+   * An error code indicating that an input was bound with a incorrectly
+   * typed expression
    */
   static const AngularWarningCode INPUT_BINDING_TYPE_ERROR =
       const AngularWarningCode(
@@ -130,6 +150,14 @@ class AngularWarningCode extends ErrorCode {
   static const AngularWarningCode OUTPUT_MUST_BE_EVENTEMITTER =
       const AngularWarningCode('OUTPUT_MUST_BE_EVENTEMMITTER',
           'Output (of name {0}) must return an EventEmitter');
+
+  /**
+   * An error code indicating that a two-way binding expression was not
+   * a assignable (and therefore could only be one-way bound...)
+   */
+  static const AngularWarningCode TWO_WAY_BINDING_NOT_ASSIGNABLE =
+      const AngularWarningCode('TWO_WAY_BINDING_NOT_ASSIGNABLE',
+          'Only assignable expressions can be two-way bound');
 
   /**
    * Initialize a newly created error code to have the given [name].

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -165,7 +165,7 @@ class TestPanel {
         AngularWarningCode.NONEXIST_INPUT_BOUND, code, "[title]");
   }
 
-  void test_expression_twowayBinding_valid() {
+  void test_expression_twoWayBinding_valid() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
     directives: const [TitleComponent], templateUrl: 'test_panel.html')
@@ -185,7 +185,7 @@ class TitleComponent {
     errorListener.assertNoErrors();
   }
 
-  void test_expression_twowayBinding_inputTypeError() {
+  void test_expression_twoWayBinding_inputTypeError() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
     directives: const [TitleComponent], templateUrl: 'test_panel.html')
@@ -207,7 +207,7 @@ class TitleComponent {
         AngularWarningCode.INPUT_BINDING_TYPE_ERROR, code, "text");
   }
 
-  void test_expression_twowayBinding_outputTypeError() {
+  void test_expression_twoWayBinding_outputTypeError() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
     directives: const [TitleComponent], templateUrl: 'test_panel.html')
@@ -229,7 +229,7 @@ class TitleComponent {
         AngularWarningCode.TWO_WAY_BINDING_OUTPUT_TYPE_ERROR, code, "text");
   }
 
-  void test_expression_twowayBinding_notAssignableError() {
+  void test_expression_twoWayBinding_notAssignableError() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
     directives: const [TitleComponent], templateUrl: 'test_panel.html')
@@ -253,7 +253,7 @@ class TitleComponent {
         "text.toUpperCase()");
   }
 
-  void test_expression_twowayBinding_noInputToBind() {
+  void test_expression_twoWayBinding_noInputToBind() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
     directives: const [TitleComponent], templateUrl: 'test_panel.html')
@@ -274,7 +274,7 @@ class TitleComponent {
         AngularWarningCode.NONEXIST_INPUT_BOUND, code, "[(title)]");
   }
 
-  void test_expression_twowayBinding_noOutputToBind() {
+  void test_expression_twoWayBinding_noOutputToBind() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
     directives: const [TitleComponent], templateUrl: 'test_panel.html')
@@ -292,7 +292,7 @@ class TitleComponent {
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);
     assertErrorInCodeAtPosition(
-        AngularWarningCode.NONEXIST_TWOWAY_OUTPUT_BOUND, code, "[(title)]");
+        AngularWarningCode.NONEXIST_TWO_WAY_OUTPUT_BOUND, code, "[(title)]");
   }
 
   void test_expression_inputBinding_bind() {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -165,6 +165,136 @@ class TestPanel {
         AngularWarningCode.NONEXIST_INPUT_BOUND, code, "[title]");
   }
 
+  void test_expression_twowayBinding_valid() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+@Directive(selector: '[titled]', template: '', inputs: 'title')
+class TitleComponent {
+  @Input() String title;
+  @Output() EventEmitter<String> titleChange;
+}
+''');
+    _addHtmlSource(r"""
+<span titled [(title)]='text'></span>
+""");
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_expression_twowayBinding_inputTypeError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+@Component(selector: 'title-comp', template: '', inputs: 'title')
+class TitleComponent {
+  @Input() int title;
+  @Output() EventEmitter<String> titleChange;
+}
+''');
+    var code = r"""
+<title-comp [(title)]='text'></title-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INPUT_BINDING_TYPE_ERROR, code, "text");
+  }
+
+  void test_expression_twowayBinding_outputTypeError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+@Component(selector: 'title-comp', template: '', inputs: 'title')
+class TitleComponent {
+  @Input() String title;
+  @Output() EventEmitter<int> titleChange;
+}
+''');
+    var code = r"""
+<title-comp [(title)]='text'></title-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TWO_WAY_BINDING_OUTPUT_TYPE_ERROR, code, "text");
+  }
+
+  void test_expression_twowayBinding_notAssignableError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+@Component(selector: 'title-comp', template: '', inputs: 'title')
+class TitleComponent {
+  @Input() String title;
+  @Output() EventEmitter<String> titleChange;
+}
+''');
+    var code = r"""
+<title-comp [(title)]="text.toUpperCase()"></title-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TWO_WAY_BINDING_NOT_ASSIGNABLE,
+        code,
+        "text.toUpperCase()");
+  }
+
+  void test_expression_twowayBinding_noInputToBind() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+@Component(selector: 'title-comp', template: '', inputs: 'title')
+class TitleComponent {
+  @Output() EventEmitter<String> titleChange;
+}
+''');
+    var code = r"""
+<title-comp [(title)]="text"></title-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.NONEXIST_INPUT_BOUND, code, "[(title)]");
+  }
+
+  void test_expression_twowayBinding_noOutputToBind() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+@Component(selector: 'title-comp', template: '', inputs: 'title')
+class TitleComponent {
+  @Input() String title;
+}
+''');
+    var code = r"""
+<title-comp [(title)]="text"></title-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.NONEXIST_TWOWAY_OUTPUT_BOUND, code, "[(title)]");
+  }
+
   void test_expression_inputBinding_bind() {
     _addDartSource(r'''
 @Component(selector: 'test-panel')

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -449,6 +449,28 @@ class TestPanel {}
     _assertElement("ccc=").output.at("ccc;");
   }
 
+  void test_twoWayReference() {
+    _addDartSource(r'''
+@Component(
+    selector: 'name-panel',
+@View(template: r"<div>AAA</div>")
+class NamePanel {
+  @Input() int value;
+  @Output() EventEmitter<int> valueChange;
+}
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NamePanel])
+class TestPanel {
+  int value;
+}
+''');
+    _addHtmlSource(r"""
+<name-panel [(value)]='value'></name-panel>
+""");
+    _resolveSingleTemplate(dartSource);
+    _assertElement("value)]").input.at("value;");
+  }
+
   void test_localVariable_camelCaseName() {
     _addDartSource(r'''
 import 'dart:html';


### PR DESCRIPTION
Support for #50 two-way binding validation

validate types (as an input), assignabliity, and change the way unbound
error types are tracked. For a two-way bound input named x of type t,
check that an ouput name xChange exists which is assignable to type t.

Smarter tactic of ignoring :not()s, so that core directives work