### PR TITLE
Fix for issue #77 some dom events not recognized

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1382,7 +1382,8 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
 
   String _getDomName(Element element) {
     for (ElementAnnotation annotation in element.metadata) {
-      var value = annotation.constantValue ?? annotation.computeConstantValue();
+      // this has caching built in, so we can compute every time
+      var value = annotation.computeConstantValue();
       if (value != null && value.type is InterfaceType) {
         if (value.type.element.name == 'DomName') {
           return value.getField("name").toStringValue();

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart' as ast;
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/dart/ast/utilities.dart' as utils;
 import 'package:analyzer/src/generated/constant.dart';
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/generated/engine.dart';
@@ -1351,7 +1352,15 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   List<OutputElement> _buildOutputs() {
     return _captureAspects((Map<String, OutputElement> outputMap,
         PropertyAccessorElement accessor) {
-      String name = decapitalize(accessor.displayName.substring('on'.length));
+      String domName = _getDomName(accessor);
+      if (domName == null) {
+        return;
+      }
+
+      // Event domnames start with Element.on or Document.on
+      int offset = domName.indexOf(".") + ".on".length;
+      String name = domName.substring(offset);
+
       if (!outputMap.containsKey(name)) {
         if (accessor.isGetter) {
           var returntype =
@@ -1369,6 +1378,19 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
         }
       }
     });
+  }
+
+  String _getDomName(Element element) {
+    for (ElementAnnotation annotation in element.metadata) {
+      var value = annotation.constantValue ?? annotation.computeConstantValue();
+      if (value != null && value.type is InterfaceType) {
+        if (value.type.element.name == 'DomName') {
+          return value.getField("name").toStringValue();
+        }
+      }
+    }
+
+    return null;
   }
 
   List/*<T>*/ _captureAspects(CaptureAspectFn/*<T>*/ addAspect) {

--- a/analyzer_plugin/test/mock_sdk.dart
+++ b/analyzer_plugin/test/mock_sdk.dart
@@ -175,11 +175,18 @@ import 'dart:async';
 class Event {}
 class MouseEvent extends Event {}
 
+class DomName {
+  final String name;
+  const DomName(this.name);
+}
+
 abstract class ElementStream<T extends Event> implements Stream<T> {}
 
 class HtmlElement {
   int tabIndex;
+  @DomName('Element.onchange')
   ElementStream<Event> get onChange => null;
+  @DomName('Element.onclick')
   ElementStream<MouseEvent> get onClick => null;
   bool hidden;
 }
@@ -215,7 +222,8 @@ class InputElement extends HtmlElement {
   factory InputElement() => document.createElement("input");
   String value;
   String validationMessage;
-  ElementStream<Event> get onKeyup => null;
+  @DomName('Element.onkeyup')
+  ElementStream<Event> get onKeyUp => null;
 }
 ''');
 

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -47,7 +47,7 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
       expect(component.classElement.displayName, 'AnchorElement');
       expect(component.selector.toString(), 'a');
       List<InputElement> inputs = component.inputs;
-      List<OutputElement> outputElems = component.outputs;
+      List<OutputElement> outputElements = component.outputs;
       {
         InputElement input = inputs.singleWhere((i) => i.name == 'href');
         expect(input, isNotNull);
@@ -64,12 +64,12 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input.setter, isNotNull);
       }
       {
-        OutputElement output =
-            outputElems.singleWhere((o) => o.name == 'click');
-        expect(output, isNotNull);
-        expect(output.getter, isNotNull);
-        expect(output.eventType, isNotNull);
-        expect(output.eventType.toString(), equals("MouseEvent"));
+        OutputElement outputElement =
+            outputElements.singleWhere((o) => o.name == 'click');
+        expect(outputElement, isNotNull);
+        expect(outputElement.getter, isNotNull);
+        expect(outputElement.eventType, isNotNull);
+        expect(outputElement.eventType.toString(), equals("MouseEvent"));
       }
     }
     // button
@@ -79,7 +79,7 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
       expect(component.classElement.displayName, 'ButtonElement');
       expect(component.selector.toString(), 'button');
       List<InputElement> inputs = component.inputs;
-      List<OutputElement> outputElems = component.outputs;
+      List<OutputElement> outputElements = component.outputs;
       {
         InputElement input = inputs.singleWhere((i) => i.name == 'autofocus');
         expect(input, isNotNull);
@@ -91,12 +91,12 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input.setter, isNotNull);
       }
       {
-        OutputElement outputElem =
-            outputElems.singleWhere((o) => o.name == 'click');
-        expect(outputElem, isNotNull);
-        expect(outputElem.getter, isNotNull);
-        expect(outputElem.eventType, isNotNull);
-        expect(outputElem.eventType.toString(), equals('MouseEvent'));
+        OutputElement outputElement =
+            outputElements.singleWhere((o) => o.name == 'click');
+        expect(outputElement, isNotNull);
+        expect(outputElement.getter, isNotNull);
+        expect(outputElement.eventType, isNotNull);
+        expect(outputElement.eventType.toString(), equals('MouseEvent'));
       }
     }
     // input

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -47,6 +47,7 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
       expect(component.classElement.displayName, 'AnchorElement');
       expect(component.selector.toString(), 'a');
       List<InputElement> inputs = component.inputs;
+      List<OutputElement> outputElems = component.outputs;
       {
         InputElement input = inputs.singleWhere((i) => i.name == 'href');
         expect(input, isNotNull);
@@ -56,6 +57,18 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         InputElement input = inputs.singleWhere((i) => i.name == 'tabIndex');
         expect(input, isNotNull);
         expect(input.setter, isNotNull);
+      }
+      {
+        InputElement input = inputs.singleWhere((i) => i.name == 'tabIndex');
+        expect(input, isNotNull);
+        expect(input.setter, isNotNull);
+      }
+      {
+        OutputElement output = outputElems.singleWhere((o) => o.name == 'click');
+        expect(output, isNotNull);
+        expect(output.getter, isNotNull);
+        expect(output.eventType, isNotNull);
+        expect(output.eventType.toString(), equals("MouseEvent"));
       }
     }
     // button
@@ -83,6 +96,22 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(outputElem.getter, isNotNull);
         expect(outputElem.eventType, isNotNull);
         expect(outputElem.eventType.toString(), equals('MouseEvent'));
+      }
+    }
+    // input
+    {
+      Component component = map['input'];
+      expect(component, isNotNull);
+      expect(component.classElement.displayName, 'InputElement');
+      expect(component.selector.toString(), 'input');
+      List<OutputElement> outputElems = component.outputs;
+      {
+        // This one is important because it proves we're using @DomAttribute
+        // to generate the output name and not the method in the sdk.
+        OutputElement output = outputElems.singleWhere((o) => o.name == 'keyup');
+        expect(output, isNotNull);
+        expect(output.getter, isNotNull);
+        expect(output.eventType, isNotNull);
       }
     }
     // h1, h2, h3

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -64,7 +64,8 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input.setter, isNotNull);
       }
       {
-        OutputElement output = outputElems.singleWhere((o) => o.name == 'click');
+        OutputElement output =
+            outputElems.singleWhere((o) => o.name == 'click');
         expect(output, isNotNull);
         expect(output.getter, isNotNull);
         expect(output.eventType, isNotNull);
@@ -108,7 +109,8 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
       {
         // This one is important because it proves we're using @DomAttribute
         // to generate the output name and not the method in the sdk.
-        OutputElement output = outputElems.singleWhere((o) => o.name == 'keyup');
+        OutputElement output =
+            outputElems.singleWhere((o) => o.name == 'keyup');
         expect(output, isNotNull);
         expect(output.getter, isNotNull);
         expect(output.eventType, isNotNull);


### PR DESCRIPTION
Don't take the dart:html method name and chop off the 'on', that's not
how angular does it. Instead take the @DomName('Document.oneventname')
and get just the eventname out of that.

Previous tests used 'keyUp' as a testcase, but the correct angular is
'keyup'. Note that this difference is in dart:html and was kept in
mock_sdk.dart