### PR TITLE
Support getters and setters with @Input and @Output refs #83

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -513,7 +513,25 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
       ast.VariableDeclaration variable = node.fields.variables.first;
       FieldElement fieldElement = variable.element;
       property = isInput ? fieldElement.setter : fieldElement.getter;
+    } else if (node is ast.MethodDeclaration) {
+      if (isInput && node.isSetter) {
+        property = node.element;
+      } else if (isOutput && node.isGetter) {
+        property = node.element;
+      } else {
+        errorReporter.reportErrorForNode(
+            isInput
+                ? AngularWarningCode.INPUT_ANNOTATION_PLACEMENT_INVALID
+                : AngularWarningCode.OUTPUT_ANNOTATION_PLACEMENT_INVALID,
+            new SourceRange(node.element.nameOffset, node.element.name.length));
+        return null;
+      }
     } else {
+      errorReporter.reportErrorForNode(
+          isInput
+              ? AngularWarningCode.INPUT_ANNOTATION_PLACEMENT_INVALID
+              : AngularWarningCode.OUTPUT_ANNOTATION_PLACEMENT_INVALID,
+          new SourceRange(node.element.nameOffset, node.element.name.length));
       return null;
     }
 

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -160,6 +160,22 @@ class AngularWarningCode extends ErrorCode {
           'Only assignable expressions can be two-way bound');
 
   /**
+   * An error code indicating that an @Input annottaion was used in the wrong
+   * place
+   */
+  static const AngularWarningCode INPUT_ANNOTATION_PLACEMENT_INVALID =
+      const AngularWarningCode('INPUT_ANNOTATION_PLACEMENT_INVALID',
+          'The @Input() annotation can only be put on properties and setters');
+
+  /**
+   * An error code indicating that an @Output annottaion was used in the wrong
+   * place
+   */
+  static const AngularWarningCode OUTPUT_ANNOTATION_PLACEMENT_INVALID =
+      const AngularWarningCode('OUTPUT_ANNOTATION_PLACEMENT_INVALID',
+          'The @Output() annotation can only be put on properties and getters');
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -235,12 +235,12 @@ class View {
 
 class Input {
   final String bindingPropertyName;
-  const InputMetadata([this.bindingPropertyName]);
+  const Input([this.bindingPropertyName]);
 }
 
 class Output {
   final String bindingPropertyName;
-  const OutputMetadata([this.bindingPropertyName]);
+  const Output([this.bindingPropertyName]);
 }
 ''');
     newSource(

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -681,7 +681,7 @@ import '/angular2/angular2.dart';
 @Component(selector: 'my-component')
 class MyComponent {
   @Output()
-  set someSetter(x) => null;
+  set someSetter(x) { }
 }
 ''';
     Source source = newSource('/test.dart', code);

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -414,6 +414,8 @@ class MyComponent {
   String firstField;
   @Input('secondInput')
   String secondField;
+  @Input()
+  String set someSetter() => null;
 }
 ''';
     Source source = newSource('/test.dart', code);
@@ -424,7 +426,7 @@ class MyComponent {
     List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
     Component component = directives.single;
     List<InputElement> inputs = component.inputs;
-    expect(inputs, hasLength(4));
+    expect(inputs, hasLength(5));
     {
       InputElement input = inputs[0];
       expect(input.name, 'leadingText');
@@ -463,6 +465,15 @@ class MyComponent {
       expect(input.setter, isNotNull);
       expect(input.setter.isSetter, isTrue);
       expect(input.setter.displayName, 'secondField');
+    }
+    {
+      InputElement input = inputs[4];
+      expect(input.name, 'someSetter');
+      expect(input.nameOffset, code.indexOf('someSetter'));
+      expect(input.setterRange, isNull);
+      expect(input.setter, isNotNull);
+      expect(input.setter.isSetter, isTrue);
+      expect(input.setter.displayName, 'someSetter');
     }
   }
 
@@ -523,6 +534,8 @@ class MyComponent {
   EventEmitter<int> outputThree;
   @Output('outputFour')
   EventEmitter fourthOutput;
+  @Output()
+  EventEmitter get someGetter() => null;
 }
 ''';
     Source source = newSource('/test.dart', code);
@@ -533,7 +546,7 @@ class MyComponent {
     List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
     Component component = directives.single;
     List<OutputElement> compOutputs = component.outputs;
-    expect(compOutputs, hasLength(4));
+    expect(compOutputs, hasLength(5));
     {
       OutputElement output = compOutputs[0];
       expect(output.name, 'outputOne');
@@ -581,6 +594,17 @@ class MyComponent {
       expect(output.eventType, isNotNull);
       expect(output.eventType.isDynamic, isTrue);
     }
+    {
+      OutputElement output = compOutputs[4];
+      expect(output.name, 'someGetter');
+      expect(output.nameOffset, code.indexOf('someGetter'));
+      expect(output.getterRange, isNull);
+      expect(output.getter, isNotNull);
+      expect(output.getter.isGetter, isTrue);
+      expect(output.getter.displayName, 'someGetter');
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.isDynamic, isTrue);
+    }
   }
 
   void test_outputs_notEventEmitterTypeError() {
@@ -615,6 +639,46 @@ class B {}
     // validate
     List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
     expect(directives, isEmpty);
+  }
+
+  void test_inputOnGetterIsError() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'my-component')
+class MyComponent {
+  @Input()
+  String get someGetter => null;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    fillErrorListener(DIRECTIVES_ERRORS);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INPUT_ANNOTATION_PLACEMENT_INVALID,
+        code,
+        "someGetter");
+  }
+
+  void test_outputOnSetterIsError() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'my-component')
+class MyComponent {
+  @Output()
+  set someSetter(x) => null;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    fillErrorListener(DIRECTIVES_ERRORS);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.OUTPUT_ANNOTATION_PLACEMENT_INVALID,
+        code,
+        "someSetter(");
   }
 }
 

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -406,6 +406,7 @@ import '/angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>',
     inputs: const ['leadingText', 'trailingText: tailText'])
 class MyComponent {
   String leadingText;
@@ -415,7 +416,7 @@ class MyComponent {
   @Input('secondInput')
   String secondField;
   @Input()
-  String set someSetter() => null;
+  set someSetter(String x) { }
 }
 ''';
     Source source = newSource('/test.dart', code);
@@ -475,6 +476,11 @@ class MyComponent {
       expect(input.setter.isSetter, isTrue);
       expect(input.setter.displayName, 'someSetter');
     }
+
+    // assert no syntax errors, etc
+    computeResult(source, DART_ERRORS);
+    fillErrorListener(DART_ERRORS);
+    errorListener.assertNoErrors();
   }
 
   void test_inputs_deprecatedProperties() {
@@ -483,6 +489,7 @@ import '/angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>',
     properties: const ['leadingText', 'trailingText: tailText'])
 class MyComponent {
   String leadingText;
@@ -526,6 +533,7 @@ import '/angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>',
     outputs: const ['outputOne', 'secondOutput: outputTwo'])
 class MyComponent {
   EventEmitter<MyComponent> outputOne;
@@ -535,7 +543,7 @@ class MyComponent {
   @Output('outputFour')
   EventEmitter fourthOutput;
   @Output()
-  EventEmitter get someGetter() => null;
+  EventEmitter get someGetter => null;
 }
 ''';
     Source source = newSource('/test.dart', code);
@@ -605,6 +613,11 @@ class MyComponent {
       expect(output.eventType, isNotNull);
       expect(output.eventType.isDynamic, isTrue);
     }
+
+    // assert no syntax errors, etc
+    computeResult(source, DART_ERRORS);
+    fillErrorListener(DART_ERRORS);
+    errorListener.assertNoErrors();
   }
 
   void test_outputs_notEventEmitterTypeError() {


### PR DESCRIPTION
Just a matter of supporting MethodDeclaration members as well, provided
each .isGetter or .isSetter. Report errors otherwise.