### PR TITLE
Support [attr.x], [class.x], [style.x], and [style.x.px] refs #82

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -695,10 +695,6 @@ class TemplateResolver {
       }
       // bound
       if (attribute.bound != null) {
-        if (!_validateBindingIsDartIdentifier(attribute)) {
-          continue;
-        }
-
         AngularWarningCode unboundErrorCode;
         var matched = false;
         if (attribute.bound == AttributeBoundType.output) {
@@ -801,31 +797,6 @@ class TemplateResolver {
         _resolveTextExpressions(valueOffset, value);
       }
     }
-  }
-
-  _validateBindingIsDartIdentifier(AttributeInfo attribute) {
-    // the other binding types don't need to be dart identifiers
-    if (attribute.bound == AttributeBoundType.input ||
-        attribute.bound == AttributeBoundType.output ||
-        attribute.bound == AttributeBoundType.twoWay) {
-      CharSequenceReader reader =
-          new CharSequenceReader(attribute.propertyName);
-      Scanner scanner = new Scanner(templateSource, reader, errorListener);
-      Token token = scanner.tokenize();
-      if (token.type != TokenType.IDENTIFIER ||
-          token.next.type != TokenType.EOF) {
-        errorListener.onError(new AnalysisError(
-            templateSource,
-            attribute.propertyNameOffset,
-            attribute.propertyName.length,
-            AngularWarningCode.INVALID_BINDING_NAME,
-            [attribute.propertyName]));
-
-        return false;
-      }
-    }
-
-    return true;
   }
 
   /**

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -35,7 +35,7 @@ html.Element _firstElement(html.Node node) {
   return null;
 }
 
-enum AttributeBoundType { input, output, twoWay }
+enum AttributeBoundType { input, output, twoWay, attr, clazz, style }
 
 /**
  * Information about an attribute.
@@ -307,7 +307,21 @@ class HtmlTreeConverter {
         } else if (propName.startsWith('[') && propName.endsWith(']')) {
           propNameOffset += 1;
           propName = propName.substring(1, propName.length - 1);
-          bound = AttributeBoundType.input;
+          if (propName.startsWith('class.')) {
+            bound = AttributeBoundType.clazz;
+            propName = propName.substring('class.'.length);
+            propNameOffset += 'class.'.length;
+          } else if (propName.startsWith('attr.')) {
+            bound = AttributeBoundType.attr;
+            propName = propName.substring('attr.'.length);
+            propNameOffset += 'attr.'.length;
+          } else if (propName.startsWith('style.')) {
+            propName = propName.substring('style.'.length);
+            propNameOffset += 'style.'.length;
+            bound = AttributeBoundType.style;
+          } else {
+            bound = AttributeBoundType.input;
+          }
         } else if (propName.startsWith('bind-')) {
           int bindLength = 'bind-'.length;
           propNameOffset += bindLength;
@@ -681,6 +695,10 @@ class TemplateResolver {
       }
       // bound
       if (attribute.bound != null) {
+        if (!_validateBindingIsDartIdentifier(attribute)) {
+          continue;
+        }
+
         AngularWarningCode unboundErrorCode;
         var matched = false;
         if (attribute.bound == AttributeBoundType.output) {
@@ -708,11 +726,10 @@ class TemplateResolver {
         if (attribute.bound == AttributeBoundType.twoWay) {
           if (!expression.isAssignable) {
             errorListener.onError(new AnalysisError(
-              templateSource,
-              attribute.valueOffset,
-              attribute.value.length,
-              AngularWarningCode.TWO_WAY_BINDING_NOT_ASSIGNABLE,
-            ));
+                templateSource,
+                attribute.valueOffset,
+                attribute.value.length,
+                AngularWarningCode.TWO_WAY_BINDING_NOT_ASSIGNABLE));
           }
 
           var outputMatched = false;
@@ -742,6 +759,14 @@ class TemplateResolver {
           }
         }
 
+        if (attribute.bound == AttributeBoundType.clazz) {
+          _resolveClassAttribute(attribute, expression);
+        } else if (attribute.bound == AttributeBoundType.style) {
+          _resolveStyleAttribute(attribute, expression);
+        } else if (attribute.bound == AttributeBoundType.attr) {
+          _resolveAttributeBoundAttribute(attribute, expression);
+        }
+
         if (attribute.bound == AttributeBoundType.input ||
             attribute.bound == AttributeBoundType.twoWay) {
           unboundErrorCode = AngularWarningCode.NONEXIST_INPUT_BOUND;
@@ -764,7 +789,7 @@ class TemplateResolver {
           }
         }
 
-        if (!matched) {
+        if (!matched && unboundErrorCode != null) {
           errorListener.onError(new AnalysisError(templateSource,
               attribute.nameOffset, attribute.name.length, unboundErrorCode));
         }
@@ -776,6 +801,118 @@ class TemplateResolver {
         _resolveTextExpressions(valueOffset, value);
       }
     }
+  }
+
+  _validateBindingIsDartIdentifier(AttributeInfo attribute) {
+    // the other binding types don't need to be dart identifiers
+    if (attribute.bound == AttributeBoundType.input ||
+        attribute.bound == AttributeBoundType.output ||
+        attribute.bound == AttributeBoundType.twoWay) {
+      CharSequenceReader reader =
+          new CharSequenceReader(attribute.propertyName);
+      Scanner scanner = new Scanner(templateSource, reader, errorListener);
+      Token token = scanner.tokenize();
+      if (token.type != TokenType.IDENTIFIER ||
+          token.next.type != TokenType.EOF) {
+        errorListener.onError(new AnalysisError(
+            templateSource,
+            attribute.propertyNameOffset,
+            attribute.propertyName.length,
+            AngularWarningCode.INVALID_BINDING_NAME,
+            [attribute.propertyName]));
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Quick regex to match the spec, but doesn't handle unicode. They can start
+   * with a dash, but if so must be followed by an alphabetic or underscore or
+   * escaped character. Cannot start with a number.
+   * https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+   */
+  static final RegExp _cssIdentifierRegexp =
+      new RegExp(r"^(-?[a-zA-Z_]|\\.)([a-zA-Z0-9\-_]|\\.)*$");
+
+  bool _isCssIdentifier(String input) {
+    return _cssIdentifierRegexp.hasMatch(input);
+  }
+
+  /**
+   * Resolve attributes of type [class.some-class]="someBoolExpr", ensuring
+   * the class is a valid css identifier and that the expression is of boolean
+   * type
+   */
+  _resolveClassAttribute(AttributeInfo attribute, Expression expression) {
+    if (!_isCssIdentifier(attribute.propertyName)) {
+      errorListener.onError(new AnalysisError(
+          templateSource,
+          attribute.propertyNameOffset,
+          attribute.propertyName.length,
+          AngularWarningCode.INVALID_HTML_CLASSNAME,
+          [attribute.propertyName]));
+    }
+
+    if (!expression.bestType.isAssignableTo(typeProvider.boolType)) {
+      errorListener.onError(new AnalysisError(
+        templateSource,
+        attribute.valueOffset,
+        attribute.value.length,
+        AngularWarningCode.CLASS_BINDING_NOT_BOOLEAN,
+      ));
+    }
+  }
+
+  /**
+   * Resolve attributes of type [style.color]="someExpr" and
+   * [style.background-width.px]="someNumExpr" which bind a css style property
+   * with optional units.
+   */
+  _resolveStyleAttribute(AttributeInfo attribute, Expression expression) {
+    var cssPropertyName = attribute.propertyName;
+    var dotpos = attribute.propertyName.indexOf('.');
+    if (dotpos != -1) {
+      cssPropertyName = attribute.propertyName.substring(0, dotpos);
+      var cssUnitName = attribute.propertyName.substring(dotpos + '.'.length);
+      if (!_isCssIdentifier(cssUnitName)) {
+        errorListener.onError(new AnalysisError(
+            templateSource,
+            attribute.propertyNameOffset + dotpos + 1,
+            cssUnitName.length,
+            AngularWarningCode.INVALID_CSS_UNIT_NAME,
+            [cssUnitName]));
+      }
+      if (!expression.bestType.isAssignableTo(typeProvider.numType)) {
+        errorListener.onError(new AnalysisError(
+            templateSource,
+            attribute.valueOffset,
+            attribute.value.length,
+            AngularWarningCode.CSS_UNIT_BINDING_NOT_NUMBER));
+      }
+    }
+
+    if (!_isCssIdentifier(cssPropertyName)) {
+      errorListener.onError(new AnalysisError(
+          templateSource,
+          attribute.propertyNameOffset,
+          cssPropertyName.length,
+          AngularWarningCode.INVALID_CSS_PROPERTY_NAME,
+          [cssPropertyName]));
+    }
+  }
+
+  /**
+   * Resolve attributes of type [attribute.some-attribute]="someExpr"
+   */
+  _resolveAttributeBoundAttribute(
+      AttributeInfo attribute, Expression expression) {
+    // TODO validate the type? Or against a dictionary?
+    // note that the attribute name is valid by definition as it was discovered
+    // within an attribute! (took me a while to realize why I couldn't make any
+    // failing tests for this)
   }
 
   /**

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -176,6 +176,61 @@ class AngularWarningCode extends ErrorCode {
           'The @Output() annotation can only be put on properties and getters');
 
   /**
+   * An error code indicating that a html classname was bound via
+   * [class.classname]="x" where classname is not a css identifier
+   * https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+   */
+  static const AngularWarningCode INVALID_HTML_CLASSNAME =
+      const AngularWarningCode('INVALID_HTML_CLASSNAME',
+          'The html classname {0} is not a valid classname');
+
+  /**
+   * An error code indicating that a html classname was bound via
+   * [class.classname]="x" where x was not a boolean
+   */
+  static const AngularWarningCode CLASS_BINDING_NOT_BOOLEAN =
+      const AngularWarningCode('CLASS_BINDING_NOT_BOOLEAN',
+          'Binding to a classname requires a boolean');
+
+  /**
+   * An error code indicating that a css property with a unit was bound via
+   * [style.property.unit]="x" where x was not a number
+   */
+  static const AngularWarningCode CSS_UNIT_BINDING_NOT_NUMBER =
+      const AngularWarningCode('CSS_UNIT_BINDING_NOT_NUMBER',
+          'Binding to a css property with a unit requires a number');
+
+  /**
+   * An error code indicating that a css property with a unit was bound via
+   * [style.property.unit]="x" where unit was not an identifier
+   * https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+   */
+  static const AngularWarningCode INVALID_CSS_UNIT_NAME =
+      const AngularWarningCode('INVALID_CSS_UNIT_NAME',
+          'The css unit {0} is not a valid css identifier');
+
+  /**
+   * An error code indicating that a css property bound via
+   * [style.property]="x" or [style.property.unit]="x" where property was not an
+   * identifier
+   * https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+   */
+  static const AngularWarningCode INVALID_CSS_PROPERTY_NAME =
+      const AngularWarningCode('INVALID_CSS_PROPERTY_NAME',
+          'The css property {0} is not a valid css identifier');
+
+  /**
+   * An error code indicating that a binding was not a * dart identifier, or
+   * [class.classname], or [attr.attrname], or [style.property], or
+   * [style.property.unit].
+   */
+  static const AngularWarningCode INVALID_BINDING_NAME =
+      const AngularWarningCode(
+          'INVALID_BINDING_NAME',
+          'The binding {} is not a valid dart identifer, attribute, style, ' +
+              'or class binding');
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -552,54 +552,6 @@ class TestPanel {
         AngularWarningCode.CSS_UNIT_BINDING_NOT_NUMBER, code, "notNumber");
   }
 
-  void test_expression_inputBindingWithDot_notRecognized() {
-    _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
-class TestPanel {
-  String title; // 1
-}
-''');
-    var code = r"""
-<span [unknown.dotstyle]='title'></span>
-""";
-    _addHtmlSource(code);
-    _resolveSingleTemplate(dartSource);
-    assertErrorInCodeAtPosition(
-        AngularWarningCode.INVALID_BINDING_NAME, code, "unknown.dotstyle");
-  }
-
-  void test_expression_outputBindingWithDot_notRecognized() {
-    _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
-class TestPanel {
-  String title; // 1
-}
-''');
-    var code = r"""
-<span (unknown.dotstyle)='title'></span>
-""";
-    _addHtmlSource(code);
-    _resolveSingleTemplate(dartSource);
-    assertErrorInCodeAtPosition(
-        AngularWarningCode.INVALID_BINDING_NAME, code, "unknown.dotstyle");
-  }
-
-  void test_expression_twoWayBindingWithDot_notRecognized() {
-    _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
-class TestPanel {
-  String title; // 1
-}
-''');
-    var code = r"""
-<span [(unknown.dotstyle)]='title'></span>
-""";
-    _addHtmlSource(code);
-    _resolveSingleTemplate(dartSource);
-    assertErrorInCodeAtPosition(
-        AngularWarningCode.INVALID_BINDING_NAME, code, "unknown.dotstyle");
-  }
-
   void test_inheritedFields() {
     _addDartSource(r'''
 class BaseComponent {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -379,6 +379,227 @@ class TestPanel {
         StaticWarningCode.UNDEFINED_IDENTIFIER, code, r"$event");
   }
 
+  void test_expression_attrBinding_valid() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+''');
+    var code = r"""
+<span [attr.aria-title]='text'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_expression_attrBinding_expressionTypeError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  int pixels;
+}
+''');
+    var code = r"""
+<span [attr.aria]='pixels.length'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticTypeWarningCode.UNDEFINED_GETTER, code, "length");
+  }
+
+  void test_expression_classBinding_valid() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+''');
+    var code = r"""
+<span [class.my-class]='text == null'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_expression_classBinding_invalidClassName() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String title;
+}
+''');
+    var code = r"""
+<span [class.invalid.class]='title == null'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_HTML_CLASSNAME, code, "invalid.class");
+  }
+
+  void test_expression_classBinding_typeError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String notBoolean;
+}
+''');
+    var code = r"""
+<span [class.aria]='notBoolean'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CLASS_BINDING_NOT_BOOLEAN, code, "notBoolean");
+  }
+
+  void test_expression_styleBinding_noUnit_valid() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+''');
+    var code = r"""
+<span [style.background-color]='text'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_expression_styleBinding_noUnit_invalidCssProperty() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String text; // 1
+}
+''');
+    var code = r"""
+<span [style.invalid*property]='text'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_CSS_PROPERTY_NAME, code, "invalid*property");
+  }
+
+  void test_expression_styleBinding_noUnit_expressionTypeError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  int noLength; // 1
+}
+''');
+    var code = r"""
+<span [style.background-color]='noLength.length'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticTypeWarningCode.UNDEFINED_GETTER, code, "length");
+  }
+
+  void test_expression_styleBinding_withUnit_invalidPropertyName() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  int pixels; // 1
+}
+''');
+    var code = r"""
+<span [style.border&radius.px]='pixels'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_CSS_PROPERTY_NAME, code, "border&radius");
+  }
+
+  void test_expression_styleBinding_withUnit_invalidUnitName() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  double pixels; // 1
+}
+''');
+    var code = r"""
+<span [style.border-radius.p|x]='pixels'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_CSS_UNIT_NAME, code, "p|x");
+  }
+
+  void test_expression_styleBinding_withUnit_typeError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String notNumber; // 1
+}
+''');
+    var code = r"""
+<span [style.border-radius.px]='notNumber'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CSS_UNIT_BINDING_NOT_NUMBER, code, "notNumber");
+  }
+
+  void test_expression_inputBindingWithDot_notRecognized() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String title; // 1
+}
+''');
+    var code = r"""
+<span [unknown.dotstyle]='title'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_BINDING_NAME, code, "unknown.dotstyle");
+  }
+
+  void test_expression_outputBindingWithDot_notRecognized() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String title; // 1
+}
+''');
+    var code = r"""
+<span (unknown.dotstyle)='title'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_BINDING_NAME, code, "unknown.dotstyle");
+  }
+
+  void test_expression_twoWayBindingWithDot_notRecognized() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String title; // 1
+}
+''');
+    var code = r"""
+<span [(unknown.dotstyle)]='title'></span>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_BINDING_NAME, code, "unknown.dotstyle");
+  }
+
   void test_inheritedFields() {
     _addDartSource(r'''
 class BaseComponent {


### PR DESCRIPTION
Validate binding names when they are~~n't a dart identifier or~~ one of
these special bindings. Check what we can easily check with these
including:

* class.x has a valid classname for x
* class.x is bound to a boolean
* style.x has a valid css identifier for x
* style.x.y has a valid css identifier for x
* style.x.y has a valid css identifier for y (units)
* style.x.y is bound to a number

Went to validate attr.x, but if x is an invalid attr name, then [attr.x]
is an invalid attr name. And there's no typechecking to be done here, at
least, not until we try to discover specific attributes and do stuff
with that (however...even that, I think it just all becomes strings
eventually with .toString(), making there nothing to check)

Used to validate the rest were valid dart identifers, but you can actually name an input something invalid like `@Input("blah-$%***foooooo(((")` and bind to that in your template!