### PR TITLE
Allow Stream<T> and subtypes of it in outputs, refs #76

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -439,11 +439,11 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
 
   DartType getEventType(PropertyAccessorElement getter, String name) {
     if (getter != null && getter.type != null) {
-      var returntype = getter.type.returnType;
-      if (returntype != null && returntype is InterfaceType) {
+      var returnType = getter.type.returnType;
+      if (returnType != null && returnType is InterfaceType) {
         dart.DartType streamType = typeProvider.streamType;
         dart.DartType streamedType =
-            context.typeSystem.mostSpecificTypeArgument(returntype, streamType);
+            context.typeSystem.mostSpecificTypeArgument(returnType, streamType);
         if (streamedType != null) {
           return streamedType;
         } else {
@@ -1390,14 +1390,14 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
 
       if (!outputMap.containsKey(name)) {
         if (accessor.isGetter) {
-          var returntype =
+          var returnType =
               accessor.type == null ? null : accessor.type.returnType;
           DartType eventtype = null;
-          if (returntype != null && returntype is InterfaceType) {
+          if (returnType != null && returnType is InterfaceType) {
             // TODO allow subtypes of ElementStream? This is a generated file
             // so might not be necessary.
-            if (returntype.element.name == 'ElementStream') {
-              eventtype = returntype.typeArguments[0]; // may be null
+            if (returnType.element.name == 'ElementStream') {
+              eventtype = returnType.typeArguments[0]; // may be null
             }
           }
           outputMap[name] = new OutputElement(name, accessor.nameOffset,

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1392,16 +1392,16 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
         if (accessor.isGetter) {
           var returnType =
               accessor.type == null ? null : accessor.type.returnType;
-          DartType eventtype = null;
+          DartType eventType = null;
           if (returnType != null && returnType is InterfaceType) {
             // TODO allow subtypes of ElementStream? This is a generated file
             // so might not be necessary.
             if (returnType.element.name == 'ElementStream') {
-              eventtype = returnType.typeArguments[0]; // may be null
+              eventType = returnType.typeArguments[0]; // may be null
             }
           }
           outputMap[name] = new OutputElement(name, accessor.nameOffset,
-              accessor.nameLength, accessor.source, accessor, null, eventtype);
+              accessor.nameLength, accessor.source, accessor, null, eventType);
         }
       }
     });

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -627,6 +627,7 @@ import 'dart:async';
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>')
 class MyComponent {
   @Output()
   Stream<int> myOutput;
@@ -657,6 +658,7 @@ abstract class MyStream<T> implements Stream<T> { }
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>')
 class MyComponent {
   @Output()
   MyStream<int> myOutput;
@@ -687,6 +689,7 @@ class MyStream extends Stream<int> { }
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>')
 class MyComponent {
   @Output()
   MyStream myOutput;
@@ -717,6 +720,7 @@ class MyStream extends Stream { }
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>')
 class MyComponent {
   @Output()
   MyStream myOutput;
@@ -744,6 +748,7 @@ import '/angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>')
 class MyComponent {
   @Output()
   int badOutput;
@@ -763,6 +768,7 @@ import '/angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
+    template: '<p></p>')
 class MyComponent {
   @Output()
   int badOutput;

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -620,6 +620,124 @@ class MyComponent {
     errorListener.assertNoErrors();
   }
 
+  void test_outputs_streamIsOk() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'dart:async';
+
+@Component(
+    selector: 'my-component',
+class MyComponent {
+  @Output()
+  Stream<int> myOutput;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("int"));
+    }
+  }
+
+  void test_outputs_extendStreamIsOk() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'dart:async';
+
+abstract class MyStream<T> implements Stream<T> { }
+
+@Component(
+    selector: 'my-component',
+class MyComponent {
+  @Output()
+  MyStream<int> myOutput;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("int"));
+    }
+  }
+
+  void test_outputs_extendStreamSpecializedIsOk() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'dart:async';
+
+class MyStream extends Stream<int> { }
+
+@Component(
+    selector: 'my-component',
+class MyComponent {
+  @Output()
+  MyStream myOutput;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("int"));
+    }
+  }
+
+  void test_outputs_extendStreamUntypedIsOk() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'dart:async';
+
+class MyStream extends Stream { }
+
+@Component(
+    selector: 'my-component',
+class MyComponent {
+  @Output()
+  MyStream myOutput;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("dynamic"));
+    }
+  }
+
   void test_outputs_notEventEmitterTypeError() {
     String code = r'''
 import '/angular2/angular2.dart';
@@ -637,6 +755,33 @@ class MyComponent {
     fillErrorListener(DIRECTIVES_ERRORS);
     assertErrorInCodeAtPosition(
         AngularWarningCode.OUTPUT_MUST_BE_EVENTEMITTER, code, "badOutput");
+  }
+
+  void test_outputs_extendStreamNotStreamHasDynamicEventType() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(
+    selector: 'my-component',
+class MyComponent {
+  @Output()
+  int badOutput;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("dynamic"));
+    }
   }
 
   void test_noDirectives() {


### PR DESCRIPTION
Use the mostSpecificTypeArgument method API to get the stream type
regardless of the inheritance tree and generics defined within it.