### PR TITLE
Refactoring TRAILING_EXPRESSION error into a more logical position

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -986,10 +986,11 @@ class TemplateResolver {
     _recordExpressionResolvedRanges(expression);
 
     if (expression.endToken.next.type != TokenType.EOF) {
+      int trailingExpressionBegin = expression.endToken.next.offset;
       errorListener.onError(new AnalysisError(
           templateSource,
-          expression.endToken.next.offset,
-          offset + code.length - expression.endToken.next.offset,
+          trailingExpressionBegin,
+          offset + code.length - trailingExpressionBegin,
           AngularWarningCode.TRAILING_EXPRESSION));
     }
     return expression;

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -925,9 +925,16 @@ class TemplateResolver {
   Expression _resolveDartExpressionAt(
       int offset, String code, DartType eventType) {
     Expression expression = _parseDartExpression(offset, code);
-    if (expression != null) {
-      _resolveDartExpression(expression, eventType);
+    //TODO: Once resolveDartStatement is implemented, remove 1st condition
+    if (eventType == null && expression.endToken.next.type != TokenType.EOF) {
+      int trailingExpressionBegin = expression.endToken.next.offset;
+      errorListener.onError(new AnalysisError(
+          templateSource,
+          trailingExpressionBegin,
+          offset + code.length - trailingExpressionBegin,
+          AngularWarningCode.TRAILING_EXPRESSION));
     }
+    _resolveDartExpression(expression, eventType);
     return expression;
   }
 
@@ -985,14 +992,6 @@ class TemplateResolver {
     Expression expression = _resolveDartExpressionAt(offset, code, null);
     _recordExpressionResolvedRanges(expression);
 
-    if (expression.endToken.next.type != TokenType.EOF) {
-      int trailingExpressionBegin = expression.endToken.next.offset;
-      errorListener.onError(new AnalysisError(
-          templateSource,
-          trailingExpressionBegin,
-          offset + code.length - trailingExpressionBegin,
-          AngularWarningCode.TRAILING_EXPRESSION));
-    }
     return expression;
   }
 

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -938,7 +938,9 @@ class TemplateResolver {
           offset + code.length - trailingExpressionBegin,
           AngularWarningCode.TRAILING_EXPRESSION));
     }
-    _resolveDartExpression(expression, eventType);
+    if (expression != null) {
+      _resolveDartExpression(expression, eventType);
+    }
     return expression;
   }
 
@@ -996,14 +998,6 @@ class TemplateResolver {
     Expression expression = _resolveDartExpressionAt(offset, code, null);
     _recordExpressionResolvedRanges(expression);
 
-    if (expression.endToken.next.type != TokenType.EOF) {
-      int trailingExpressionBegin = expression.endToken.next.offset;
-      errorListener.onError(new AnalysisError(
-          templateSource,
-          trailingExpressionBegin,
-          offset + code.length - trailingExpressionBegin,
-          AngularWarningCode.TRAILING_EXPRESSION));
-    }
     return expression;
   }
 

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -144,6 +144,10 @@ class AngularWarningCode extends ErrorCode {
           'Attribute value expression (of type {0}) ' +
               'is not assignable to component input (of type {1})');
 
+  static const AngularWarningCode TRAILING_EXPRESSION =
+      const AngularWarningCode(
+          'TRAILING_EXPRESSION', 'Expressions must end with an EOF');
+
   /**
    * An error code indicating that an @Output is not an EventEmitter
    */

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -552,6 +552,39 @@ class TestPanel {
         AngularWarningCode.CSS_UNIT_BINDING_NOT_NUMBER, code, "notNumber");
   }
 
+  void test_expression_detect_eof_post_semicolon() {
+    _addDartSource(r''' 
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html') 
+class TestPanel { 
+  String name = "TestPanel"; 
+} 
+''');
+
+    var code = r""" 
+<p>{{name; bad portion}}</p> 
+ """;
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TRAILING_EXPRESSION, code, "; bad portion");
+  }
+
+  void test_expression_detect_eof_ellipsis() {
+    _addDartSource(r''' 
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html') 
+class TestPanel { 
+  String name = "TestPanel"; 
+} 
+''');
+    var code = r""" 
+<p>{{name...}}</p> 
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TRAILING_EXPRESSION, code, "...");
+  }
+
   void test_inheritedFields() {
     _addDartSource(r'''
 class BaseComponent {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -756,7 +756,6 @@ class GenericComponent<T extends String> {
 ''');
     var code = r"""
 <generic-comp [(string)]="anInt"></generic-comp>
->>>>>>> 593afa40db6a1638b59d840716ca66bcc846f136
 """;
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -552,7 +552,7 @@ class TestPanel {
         AngularWarningCode.CSS_UNIT_BINDING_NOT_NUMBER, code, "notNumber");
   }
 
-  void test_expression_detect_eof_post_semicolon() {
+  void test_expression_detect_eof_post_semicolon_in_moustache() {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')
 class TestPanel {
@@ -569,7 +569,7 @@ class TestPanel {
         AngularWarningCode.TRAILING_EXPRESSION, code, "; bad portion");
   }
 
-  void test_expression_detect_eof_ellipsis() {
+  void test_expression_detect_eof_ellipsis_in_moustache() {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')
 class TestPanel {
@@ -578,6 +578,41 @@ class TestPanel {
 ''');
     var code = r"""
 <p>{{name...}}</p>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TRAILING_EXPRESSION, code, "...");
+  }
+
+  void test_expression_detect_eof_post_semicolon_in_property_binding() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  int a = 1;
+  int b = 1;
+}
+''');
+
+    var code = r"""
+<div [class.selected]="a == b; bad portion"></div>
+ """;
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TRAILING_EXPRESSION, code, "; bad portion");
+  }
+
+  void test_expression_detect_eof_ellipsis_in_property_binding() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  int a = 1;
+  int b = 1;
+}
+''');
+    var code = r"""
+<div [class.selected]="a==b..."></div>
 """;
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);


### PR DESCRIPTION
Previous modification (Issue 36) only impacted expressions within moustache. This change will also now impact property binding expressions. There is a quick flag to prevent false-positives on event binding expressions; this is temporary until event binding expressions are properly implemented.