### PR TITLE
Track native DOM events on componets refs #101

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -80,11 +80,12 @@ class AttributeInfo {
 class DartTemplateResolver {
   final TypeProvider typeProvider;
   final List<Component> standardHtmlComponents;
+  final Map<String, OutputElement> standardHtmlEvents;
   final AnalysisErrorListener errorListener;
   final View view;
 
   DartTemplateResolver(this.typeProvider, this.standardHtmlComponents,
-      this.errorListener, this.view);
+      this.standardHtmlEvents, this.errorListener, this.view);
 
   Template resolve() {
     String templateText = view.templateText;
@@ -107,7 +108,8 @@ class DartTemplateResolver {
     // Create and resolve Template.
     Template template = new Template(view, _firstElement(document));
     view.template = template;
-    new TemplateResolver(typeProvider, standardHtmlComponents, errorListener)
+    new TemplateResolver(typeProvider, standardHtmlComponents,
+            standardHtmlEvents, errorListener)
         .resolve(template);
     return template;
   }
@@ -231,18 +233,20 @@ class ElementViewImpl implements ElementView {
 class HtmlTemplateResolver {
   final TypeProvider typeProvider;
   final List<Component> standardHtmlComponents;
+  final Map<String, OutputElement> standardHtmlEvents;
   final AnalysisErrorListener errorListener;
   final View view;
   final html.Document document;
 
   HtmlTemplateResolver(this.typeProvider, this.standardHtmlComponents,
-      this.errorListener, this.view, this.document);
+      this.standardHtmlEvents, this.errorListener, this.view, this.document);
 
   HtmlTemplate resolve() {
     HtmlTemplate template =
         new HtmlTemplate(view, _firstElement(document), view.templateUriSource);
     view.template = template;
-    new TemplateResolver(typeProvider, standardHtmlComponents, errorListener)
+    new TemplateResolver(typeProvider, standardHtmlComponents,
+            standardHtmlEvents, errorListener)
         .resolve(template);
     return template;
   }
@@ -420,6 +424,7 @@ class NodeInfo {
 class TemplateResolver {
   final TypeProvider typeProvider;
   final List<Component> standardHtmlComponents;
+  final Map<String, OutputElement> standardHtmlEvents;
   final AnalysisErrorListener errorListener;
 
   Template template;
@@ -431,6 +436,8 @@ class TemplateResolver {
   CompilationUnitElementImpl htmlCompilationUnitElement;
   ClassElementImpl htmlClassElement;
   MethodElementImpl htmlMethodElement;
+
+  Map<String, OutputElement> nativeDomOutputs;
 
   /**
    * The map from names of bound attributes to resolve expressions.
@@ -456,8 +463,8 @@ class TemplateResolver {
   Map<LocalVariableElement, LocalVariable> dartVariables =
       new HashMap<LocalVariableElement, LocalVariable>();
 
-  TemplateResolver(
-      this.typeProvider, this.standardHtmlComponents, this.errorListener);
+  TemplateResolver(this.typeProvider, this.standardHtmlComponents,
+      this.standardHtmlEvents, this.errorListener);
 
   void resolve(Template template) {
     this.template = template;
@@ -710,6 +717,18 @@ class TemplateResolver {
                 // Parameterized directives, use the lower bound
                 matched = true;
               }
+            }
+          }
+
+          // standard HTML events bubble up, so everything supports them
+          if (!matched) {
+            var standardHtmlEvent = standardHtmlEvents[attribute.propertyName];
+            if (standardHtmlEvent != null) {
+              matched = true;
+              eventType = standardHtmlEvent.eventType;
+              SourceRange range = new SourceRange(
+                  attribute.propertyNameOffset, attribute.propertyNameLength);
+              template.addRange(range, standardHtmlEvent);
             }
           }
         }

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -202,17 +202,17 @@ class BuildStandardHtmlComponentsTask extends AnalysisTask {
     // Build components in each unit.
     //
     Map<String, Component> components = <String, Component>{};
-    Map<String, OutputElement> standardEvents = <String, OutputElement>{};
+    Map<String, OutputElement> events = <String, OutputElement>{};
     for (ast.CompilationUnit unit in units) {
       Source source = unit.element.source;
-      unit.accept(new _BuildStandardHtmlComponentsVisitor(
-          components, standardEvents, source));
+      unit.accept(
+          new _BuildStandardHtmlComponentsVisitor(components, events, source));
     }
     //
     // Record outputs.
     //
     outputs[STANDARD_HTML_COMPONENTS] = components.values.toList();
-    outputs[STANDARD_HTML_ELEMENT_EVENTS] = standardEvents;
+    outputs[STANDARD_HTML_ELEMENT_EVENTS] = events;
   }
 
   /**
@@ -1381,13 +1381,13 @@ class _AnnotationProcessorMixin {
 
 class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   final Map<String, Component> components;
-  final Map<String, OutputElement> standardEvents;
+  final Map<String, OutputElement> events;
   final Source source;
 
   ClassElement classElement;
 
   _BuildStandardHtmlComponentsVisitor(
-      this.components, this.standardEvents, this.source);
+      this.components, this.events, this.source);
 
   @override
   void visitClassDeclaration(ast.ClassDeclaration node) {
@@ -1396,7 +1396,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
     if (classElement.name == 'HtmlElement') {
       List<OutputElement> outputElements = _buildOutputs(false);
       for (OutputElement outputElement in outputElements) {
-        standardEvents[outputElement.name] = outputElement;
+        events[outputElement.name] = outputElement;
       }
     }
     classElement = null;

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -122,6 +122,16 @@ final ListResultDescriptor<Component> STANDARD_HTML_COMPONENTS =
         'ANGULAR_STANDARD_HTML_COMPONENTS', const <Component>[]);
 
 /**
+ * The standard HtmlElement [OutputElement]s.
+ *
+ * This result is produced for the [AnalysisContext].
+ */
+final ResultDescriptor<Map<String, OutputElement>>
+    STANDARD_HTML_ELEMENT_EVENTS = new ResultDescriptor(
+        'ANGULAR_STANDARD_HTML_ELEMENT_EVENTS',
+        const <Map<String, OutputElement>>[]);
+
+/**
  * The [View]s with this HTML template file.
  *
  * The result is only available for HTML [Source]s.
@@ -156,7 +166,8 @@ final ListResultDescriptor<View> VIEWS_WITH_HTML_TEMPLATES =
         'ANGULAR_VIEWS_WITH_TEMPLATES', View.EMPTY_LIST);
 
 /**
- * A task that builds [STANDARD_HTML_COMPONENTS].
+ * A task that builds [STANDARD_HTML_COMPONENTS] and
+ * [STANDARD_HTML_ELEMENT_EVENTS].
  */
 class BuildStandardHtmlComponentsTask extends AnalysisTask {
   static const String UNITS = 'UNITS';
@@ -164,8 +175,10 @@ class BuildStandardHtmlComponentsTask extends AnalysisTask {
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
       'BuildStandardHtmlComponentsTask',
       createTask,
-      buildInputs,
-      <ResultDescriptor>[STANDARD_HTML_COMPONENTS]);
+      buildInputs, <ResultDescriptor>[
+    STANDARD_HTML_COMPONENTS,
+    STANDARD_HTML_ELEMENT_EVENTS
+  ]);
 
   BuildStandardHtmlComponentsTask(
       AnalysisContext context, AnalysisTarget target)
@@ -189,14 +202,17 @@ class BuildStandardHtmlComponentsTask extends AnalysisTask {
     // Build components in each unit.
     //
     Map<String, Component> components = <String, Component>{};
+    Map<String, OutputElement> standardEvents = <String, OutputElement>{};
     for (ast.CompilationUnit unit in units) {
       Source source = unit.element.source;
-      unit.accept(new _BuildStandardHtmlComponentsVisitor(components, source));
+      unit.accept(new _BuildStandardHtmlComponentsVisitor(
+          components, standardEvents, source));
     }
     //
     // Record outputs.
     //
     outputs[STANDARD_HTML_COMPONENTS] = components.values.toList();
+    outputs[STANDARD_HTML_ELEMENT_EVENTS] = standardEvents;
   }
 
   /**
@@ -1083,6 +1099,7 @@ class ComputeDirectivesInLibraryTask extends SourceBasedAnalysisTask {
 class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
   static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
   static const String HTML_COMPONENTS_INPUT = 'HTML_COMPONENTS_INPUT';
+  static const String HTML_EVENTS_INPUT = 'HTML_EVENTS_INPUT';
   static const String VIEWS_INPUT = 'VIEWS_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
@@ -1106,6 +1123,7 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
     //
     TypeProvider typeProvider = getRequiredInput(TYPE_PROVIDER_INPUT);
     List<Component> htmlComponents = getRequiredInput(HTML_COMPONENTS_INPUT);
+    Map<String, OutputElement> htmlEvents = getRequiredInput(HTML_EVENTS_INPUT);
     List<View> views = getRequiredInput(VIEWS_INPUT);
     //
     // Resolve inline view templates.
@@ -1114,7 +1132,7 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
     for (View view in views) {
       if (view.templateText != null) {
         Template template = new DartTemplateResolver(
-                typeProvider, htmlComponents, errorListener, view)
+                typeProvider, htmlComponents, htmlEvents, errorListener, view)
             .resolve();
         if (template != null) {
           templates.add(template);
@@ -1138,6 +1156,8 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
       TYPE_PROVIDER_INPUT: TYPE_PROVIDER.of(AnalysisContextTarget.request),
       HTML_COMPONENTS_INPUT:
           STANDARD_HTML_COMPONENTS.of(AnalysisContextTarget.request),
+      HTML_EVENTS_INPUT:
+          STANDARD_HTML_ELEMENT_EVENTS.of(AnalysisContextTarget.request),
       VIEWS_INPUT: VIEWS.of(target),
     };
   }
@@ -1213,6 +1233,7 @@ class ResolveHtmlTemplatesTask extends SourceBasedAnalysisTask {
 class ResolveHtmlTemplateTask extends AnalysisTask {
   static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
   static const String HTML_COMPONENTS_INPUT = 'HTML_COMPONENTS_INPUT';
+  static const String HTML_EVENTS_INPUT = 'HTML_EVENTS_INPUT';
   static const String HTML_DOCUMENT_INPUT = 'HTML_DOCUMENT_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
@@ -1245,13 +1266,14 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
     //
     TypeProvider typeProvider = getRequiredInput(TYPE_PROVIDER_INPUT);
     List<Component> htmlComponents = getRequiredInput(HTML_COMPONENTS_INPUT);
+    Map<String, OutputElement> htmlEvents = getRequiredInput(HTML_EVENTS_INPUT);
     html.Document document = getRequiredInput(HTML_DOCUMENT_INPUT);
     //
     // Resolve.
     //
     View view = target;
-    Template template = new HtmlTemplateResolver(
-            typeProvider, htmlComponents, errorListener, view, document)
+    Template template = new HtmlTemplateResolver(typeProvider, htmlComponents,
+            htmlEvents, errorListener, view, document)
         .resolve();
     //
     // Record outputs.
@@ -1270,6 +1292,8 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
       TYPE_PROVIDER_INPUT: TYPE_PROVIDER.of(AnalysisContextTarget.request),
       HTML_COMPONENTS_INPUT:
           STANDARD_HTML_COMPONENTS.of(AnalysisContextTarget.request),
+      HTML_EVENTS_INPUT:
+          STANDARD_HTML_ELEMENT_EVENTS.of(AnalysisContextTarget.request),
       HTML_DOCUMENT_INPUT: HTML_DOCUMENT.of(target.templateUriSource),
     };
   }
@@ -1357,16 +1381,24 @@ class _AnnotationProcessorMixin {
 
 class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   final Map<String, Component> components;
+  final Map<String, OutputElement> standardEvents;
   final Source source;
 
   ClassElement classElement;
 
-  _BuildStandardHtmlComponentsVisitor(this.components, this.source);
+  _BuildStandardHtmlComponentsVisitor(
+      this.components, this.standardEvents, this.source);
 
   @override
   void visitClassDeclaration(ast.ClassDeclaration node) {
     classElement = node.element;
     super.visitClassDeclaration(node);
+    if (classElement.name == 'HtmlElement') {
+      List<OutputElement> outputElements = _buildOutputs(false);
+      for (OutputElement outputElement in outputElements) {
+        standardEvents[outputElement.name] = outputElement;
+      }
+    }
     classElement = null;
   }
 
@@ -1401,7 +1433,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
    */
   Component _buildComponent(String tag, int tagOffset) {
     List<InputElement> inputElements = _buildInputs();
-    List<OutputElement> outputElements = _buildOutputs();
+    List<OutputElement> outputElements = _buildOutputs(true);
     return new Component(classElement,
         inputs: inputElements,
         outputs: outputElements,
@@ -1425,10 +1457,10 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
               accessor.variable.type);
         }
       }
-    });
+    }, false); // don't skip HtmlElement+ inputs, those belong to this component.
   }
 
-  List<OutputElement> _buildOutputs() {
+  List<OutputElement> _buildOutputs(bool skipHtmlElement) {
     return _captureAspects((Map<String, OutputElement> outputMap,
         PropertyAccessorElement accessor) {
       String domName = _getDomName(accessor);
@@ -1456,7 +1488,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
               accessor.nameLength, accessor.source, accessor, null, eventType);
         }
       }
-    });
+    }, skipHtmlElement); // Either grabbing HtmlElement events or skipping them
   }
 
   String _getDomName(Element element) {
@@ -1473,15 +1505,22 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
     return null;
   }
 
-  List/*<T>*/ _captureAspects(CaptureAspectFn/*<T>*/ addAspect) {
+  List/*<T>*/ _captureAspects(
+      CaptureAspectFn/*<T>*/ addAspect, bool skipHtmlElement) {
     Map<String, /*T*/ dynamic> aspectMap = <String, /*T*/ dynamic>{};
     Set<InterfaceType> visitedTypes = new Set<InterfaceType>();
 
     void addAspects(InterfaceType type) {
       if (type != null && visitedTypes.add(type)) {
-        type.accessors.forEach((/*T*/ dynamic t) => addAspect(aspectMap, t));
-        type.mixins.forEach(addAspects);
-        addAspects(type.superclass);
+        // The events defined here are handled specially because everything
+        // (even directives) can use them. Note, this leaves only a few
+        // special elements with outputs such as BodyElement, everything else
+        // relies on standardHtmlEvents checked after the outputs.
+        if (!skipHtmlElement || type.name != 'HtmlElement') {
+          type.accessors.forEach((/*T*/ dynamic t) => addAspect(aspectMap, t));
+          type.mixins.forEach(addAspects);
+          addAspects(type.superclass);
+        }
       }
     }
 

--- a/analyzer_plugin/test/mock_sdk.dart
+++ b/analyzer_plugin/test/mock_sdk.dart
@@ -182,12 +182,20 @@ class DomName {
 
 abstract class ElementStream<T extends Event> implements Stream<T> {}
 
-class HtmlElement {
+abstract class Element {
+  /// Stream of `cut` events handled by this [Element].
+  @DomName('Element.oncut')
+  ElementStream<Event> get onCut => null;
+}
+
+class HtmlElement extends Element {
   int tabIndex;
   @DomName('Element.onchange')
   ElementStream<Event> get onChange => null;
   @DomName('Element.onclick')
   ElementStream<MouseEvent> get onClick => null;
+  @DomName('Element.onkeyup')
+  ElementStream<Event> get onKeyUp => null;
   bool hidden;
 }
 
@@ -200,8 +208,12 @@ class AnchorElement extends HtmlElement {
   String href;
 }
 
+@DomName('HTMLBodyElement')
 class BodyElement extends HtmlElement {
   factory BodyElement() => document.createElement("body");
+
+  @DomName('HTMLBodyElement.onunload')
+  ElementStream<Event> get onUnload => null;
 }
 
 class ButtonElement extends HtmlElement {
@@ -222,8 +234,6 @@ class InputElement extends HtmlElement {
   factory InputElement() => document.createElement("input");
   String value;
   String validationMessage;
-  @DomName('Element.onkeyup')
-  ElementStream<Event> get onKeyUp => null;
 }
 ''');
 

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -87,8 +87,31 @@ class TestPanel {
 <div (click)='handleClick()'></div>
 """);
     _resolveSingleTemplate(dartSource);
-    expect(ranges, hasLength(1));
+    expect(ranges, hasLength(2));
+    _assertElement('click)').output.inCoreHtml;
     _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
+  }
+
+  void test_expression_nativeEventBindingOnComponent() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: [SomeComponent])
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+
+@Component(selector: 'some-comp', template: '')
+class SomeComponent {
+}
+''');
+    _addHtmlSource(r"""
+<some-comp (click)='handleClick($event)'></some-comp>
+""");
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+    _assertElement('click').output.inCoreHtml;
   }
 
   void test_expression_eventBinding_on() {
@@ -105,7 +128,8 @@ class TestPanel {
 <div on-click='handleClick()'></div>
 """);
     _resolveSingleTemplate(dartSource);
-    expect(ranges, hasLength(1));
+    expect(ranges, hasLength(2));
+    _assertElement('click=').output.inCoreHtml;
     _assertElement('handleClick()').dart.method.at('handleClick(MouseEvent');
   }
 

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -60,14 +60,7 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input.setter, isNotNull);
         expect(input.setterType.toString(), equals("int"));
       }
-      {
-        OutputElement outputElement =
-            outputElements.singleWhere((o) => o.name == 'click');
-        expect(outputElement, isNotNull);
-        expect(outputElement.getter, isNotNull);
-        expect(outputElement.eventType, isNotNull);
-        expect(outputElement.eventType.toString(), equals("MouseEvent"));
-      }
+      expect(outputElements, hasLength(0));
     }
     // button
     {
@@ -89,14 +82,7 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input.setter, isNotNull);
         expect(input.setterType.toString(), equals("int"));
       }
-      {
-        OutputElement outputElement =
-            outputElements.singleWhere((o) => o.name == 'click');
-        expect(outputElement, isNotNull);
-        expect(outputElement.getter, isNotNull);
-        expect(outputElement.eventType, isNotNull);
-        expect(outputElement.eventType.toString(), equals('MouseEvent'));
-      }
+      expect(outputElements, hasLength(0));
     }
     // input
     {
@@ -104,13 +90,20 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
       expect(component, isNotNull);
       expect(component.classElement.displayName, 'InputElement');
       expect(component.selector.toString(), 'input');
-      List<OutputElement> outputElems = component.outputs;
+      List<OutputElement> outputElements = component.outputs;
+      expect(outputElements, hasLength(0));
+    }
+    // body is one of the few elements with special events
+    {
+      Component component = map['body'];
+      expect(component, isNotNull);
+      expect(component.classElement.displayName, 'BodyElement');
+      expect(component.selector.toString(), 'body');
+      List<OutputElement> outputElements = component.outputs;
+      expect(outputElements, hasLength(1));
       {
-        // This one is important because it proves we're using @DomAttribute
-        // to generate the output name and not the method in the sdk.
-        OutputElement output =
-            outputElems.singleWhere((o) => o.name == 'keyup');
-        expect(output, isNotNull);
+        OutputElement output = outputElements[0];
+        expect(output.name, equals("unload"));
         expect(output.getter, isNotNull);
         expect(output.eventType, isNotNull);
       }
@@ -119,6 +112,41 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
     expect(map['h1'], isNotNull);
     expect(map['h2'], isNotNull);
     expect(map['h3'], isNotNull);
+  }
+
+  test_buildStandardHtmlEvents() {
+    computeResult(AnalysisContextTarget.request, STANDARD_HTML_ELEMENT_EVENTS);
+    expect(task, new isInstanceOf<BuildStandardHtmlComponentsTask>());
+    // validate
+    Map<String, OutputElement> outputElements =
+        outputs[STANDARD_HTML_ELEMENT_EVENTS];
+    {
+      // This one is important because it proves we're using @DomAttribute
+      // to generate the output name and not the method in the sdk.
+      OutputElement outputElement = outputElements['keyup'];
+      expect(outputElement, isNotNull);
+      expect(outputElement.getter, isNotNull);
+      expect(outputElement.eventType, isNotNull);
+    }
+    {
+      OutputElement outputElement = outputElements['cut'];
+      expect(outputElement, isNotNull);
+      expect(outputElement.getter, isNotNull);
+      expect(outputElement.eventType, isNotNull);
+    }
+    {
+      OutputElement outputElement = outputElements['click'];
+      expect(outputElement, isNotNull);
+      expect(outputElement.getter, isNotNull);
+      expect(outputElement.eventType, isNotNull);
+      expect(outputElement.eventType.toString(), equals('MouseEvent'));
+    }
+    {
+      OutputElement outputElement = outputElements['change'];
+      expect(outputElement, isNotNull);
+      expect(outputElement.getter, isNotNull);
+      expect(outputElement.eventType, isNotNull);
+    }
   }
 }
 


### PR DESCRIPTION
New `ResultDescriptor` to track the outputs of `HtmlElement` separately,
all elements at resolution stage can use them. No longer tracked on the
standard HTML components (now only a few special html components, such
as body).

When resolving events, check the standard html event when there's no
match otherwise.

Altered Mock SDK to better reflect the real dart html source, namely
* HtmlElement is not the root of the inheritance tree
* BodyElement has events not on HtmlElement
* keyup event is on HtmlElement, not InputElement
* Element (parent of HtmlElement) has events

No. 1 and 4 are important for correct implementation of
`_captureAspects`. Number 3 was a mistake I'd made when adding outputs.
Number two is an edge case.

Store everything in a nicely indexed map, because that's probably what
we should be doing everywhere for performance.

Resolving source ranges in _resolveAttributeValues() is new, but that's
where I see the code going in the future anyway, since resolving the
values requires resolving the names, so the two steps should probably be
eventually merged.