### PR TITLE
Solve issue #103 generic inherited types still unresolved

### DIFF
--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -668,6 +668,60 @@ class GenericComponent<T> {
     errorListener.assertNoErrors();
   }
 
+  void test_expression_inputAndOutputBinding_genericDirectiveChild_ok() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [GenericComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String string;
+}
+class Generic<T> {
+  EventEmitter<T> output;
+  T input;
+
+  EventEmitter<T> twoWayChange;
+  T twoWay;
+}
+@Component(selector: 'generic-comp', template: '',
+    inputs: ['input', 'twoWay'], outputs: ['output', 'twoWayChange'])
+class GenericComponent<T> extends Generic<T> {
+}
+''');
+    var code = r"""
+<generic-comp (output)='$event.length' [input]="string" [(twoWay)]="string"></generic-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_expression_inputAndOutputBinding_extendGenericUnbounded_ok() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [GenericComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+  String string;
+}
+class Generic<T> {
+  EventEmitter<T> output;
+  T input;
+
+  EventEmitter<T> twoWayChange;
+  T twoWay;
+}
+@Component(selector: 'generic-comp', template: '',
+    inputs: ['input', 'twoWay'], outputs: ['output', 'twoWayChange'])
+class GenericComponent<T> extends Generic {
+}
+''');
+    var code = r"""
+<generic-comp (output)='$event.length' [input]="string" [(twoWay)]="string"></generic-comp>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
   void test_expression_inputAndOutputBinding_genericDirective_chain_ok() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -907,6 +907,93 @@ class MyComponent<T, A extends String, B extends A> {
     errorListener.assertNoErrors();
   }
 
+  void test_parameterizedInheritedInputsOutputs() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+class Generic<T> {
+  T input;
+  EventEmitter<T> output;
+}
+
+@Component(
+    selector: 'my-component',
+    template: '<p></p>',
+    inputs: const ['input'],
+    outputs: const ['output'])
+class MyComponent extends Generic {
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<InputElement> compInputs = component.inputs;
+    expect(compInputs, hasLength(1));
+    {
+      InputElement input = compInputs[0];
+      expect(input.name, 'input');
+      expect(input.setterType, isNotNull);
+      expect(input.setterType.toString(), equals("dynamic"));
+    }
+
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.name, 'output');
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("dynamic"));
+    }
+  }
+
+  void test_parameterizedInheritedInputsOutputsSpecified() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+class Generic<T> {
+  T input;
+  EventEmitter<T> output;
+}
+
+@Component(
+    selector: 'my-component',
+    template: '<p></p>',
+    inputs: const ['input'],
+    outputs: const ['output'])
+class MyComponent extends Generic<String> {
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<InputElement> compInputs = component.inputs;
+    expect(compInputs, hasLength(1));
+    {
+      InputElement input = compInputs[0];
+      expect(input.name, 'input');
+      expect(input.setterType, isNotNull);
+      expect(input.setterType.toString(), equals("String"));
+    }
+
+    List<OutputElement> compOutputs = component.outputs;
+    expect(compOutputs, hasLength(1));
+    {
+      OutputElement output = compOutputs[0];
+      expect(output.name, 'output');
+      expect(output.eventType, isNotNull);
+      expect(output.eventType.toString(), equals("String"));
+    }
+  }
+
   void test_noDirectives() {
     Source source = newSource(
         '/test.dart',


### PR DESCRIPTION
Move to a class-instantiation paradigm; instantiate the type to bounds
before building the component (still using custom instantiation logic
while issue #91 is blocked), and use that to resolve getters/setters up
the inheritance tree.

No change to the @Input() and @Output() workflows because those don't
involve inheritance.