### PR TITLE
Statement handlers refs #36

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -715,6 +715,10 @@ class TemplateResolver {
         }
 
         Expression expression = attribute.expression;
+
+        //Check if bound == OUTPUT:
+        //  If so, branch off and deal as statement,
+        //  otherwise, continue stack
         if (expression == null) {
           expression = _resolveDartExpressionAt(valueOffset, value, eventType);
           attribute.expression = expression;

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -666,15 +666,6 @@ class TemplateResolver {
   }
 
   /**
-   * Record [ResolvedRange]s for the given [expression].
-   */
-  void _recordExpressionResolvedRanges(Expression expression) {
-    if (expression != null) {
-      expression.accept(new _DartReferencesRecorder(template, dartVariables));
-    }
-  }
-
-  /**
    * Record [ResolvedRange]s for the given [AstNode].
    */
   void _recordAstNodeResolvedRanges(AstNode astNode) {
@@ -785,7 +776,6 @@ class TemplateResolver {
           attribute.expression = expression;
         }
         if (expression != null) {
-          //_recordExpressionResolvedRanges(expression);
           _recordAstNodeResolvedRanges(expression);
         }
 
@@ -1106,7 +1096,6 @@ class TemplateResolver {
    */
   Expression _resolveExpression(int offset, String code) {
     Expression expression = _resolveDartExpressionAt(offset, code, null);
-    //_recordExpressionResolvedRanges(expression);
     _recordAstNodeResolvedRanges(expression);
     return expression;
   }

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -669,7 +669,7 @@ class TemplateResolver {
    * Record [ResolvedRange]s for the given [AstNode].
    */
   void _recordAstNodeResolvedRanges(AstNode astNode) {
-    if (astNode != null){
+    if (astNode != null) {
       astNode.accept(new _DartReferencesRecorder(template, dartVariables));
     }
   }
@@ -749,8 +749,9 @@ class TemplateResolver {
           }
 
           //TODO: Refactor the following chunk of statement resolver
-          List<Statement> statements = _resolveDartStatementsAt(valueOffset, value, eventType);
-          for (Statement statement in statements){
+          List<Statement> statements =
+              _resolveDartStatementsAt(valueOffset, value, eventType);
+          for (Statement statement in statements) {
             _recordAstNodeResolvedRanges(statement);
           }
 
@@ -1032,10 +1033,10 @@ class TemplateResolver {
    * Resolve the Dart statement with the given [code] at [offset].
    */
   List<Statement> _resolveDartStatementsAt(
-      int offset, String code, DartType eventType){
+      int offset, String code, DartType eventType) {
     code = code + ";";
     List<Statement> statements = _parseDartStatements(offset, code);
-    if (statements != null){
+    if (statements != null) {
       for (Statement statement in statements) {
         _resolveDartAstNode(statement, eventType);
       }

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1023,7 +1023,6 @@ class TemplateResolver {
           AngularWarningCode.TRAILING_EXPRESSION));
     }
     if (expression != null) {
-      //_resolveDartExpression(expression, eventType);
       _resolveDartAstNode(expression, eventType);
     }
     return expression;

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -769,9 +769,6 @@ class TemplateResolver {
 
         Expression expression = attribute.expression;
 
-        //Check if bound == OUTPUT:
-        //  If so, branch off and deal as statement,
-        //  otherwise, continue stack
         if (expression == null) {
           expression = _resolveDartExpressionAt(valueOffset, value, eventType);
           attribute.expression = expression;

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -84,7 +84,7 @@ class TestPanel {
 }
 ''');
     _addHtmlSource(r"""
-<div (click)='handleClick()'></div>
+<div (click)='handleClick($event)'></div>
 """);
     _resolveSingleTemplate(dartSource);
     expect(ranges, hasLength(1));
@@ -796,6 +796,82 @@ class GenericComponent<T extends String> {
     _resolveSingleTemplate(dartSource);
     assertErrorInCodeAtPosition(
         AngularWarningCode.TWO_WAY_BINDING_OUTPUT_TYPE_ERROR, code, "anInt");
+  }
+
+  void test_statement_eventBinding_single_statement_without_semicolon() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+''');
+    _addHtmlSource(r"""
+<div (click)='handleClick($event)'></div>
+""");
+    _resolveSingleTemplate(dartSource);
+    expect(ranges, hasLength(1));
+    _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
+    errorListener.assertNoErrors();
+  }
+
+  void test_statement_eventBinding_single_statement_with_semicolon() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+''');
+    _addHtmlSource(r"""
+<div (click)='handleClick($event);'></div>
+""");
+    _resolveSingleTemplate(dartSource);
+    expect(ranges, hasLength(1));
+    _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
+    errorListener.assertNoErrors();
+  }
+
+  void test_statement_eventBinding_double_statement() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+''');
+    _addHtmlSource(r"""
+<div (click)='handleClick($event); 5+5;'></div>
+""");
+    _resolveSingleTemplate(dartSource);
+    expect(ranges, hasLength(1));
+    errorListener.assertNoErrors();
+    _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
+  }
+
+  void test_statement_eventBinding_error_on_second_statement() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+''');
+    String code = r"""
+<div (click)='handleClick(); unknownFunction()'></div>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticTypeWarningCode.UNDEFINED_METHOD, code, "unknownFunction()");
   }
 
   void test_inheritedFields() {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -84,7 +84,7 @@ class TestPanel {
 }
 ''');
     _addHtmlSource(r"""
-<div (click)='handleClick($event)'></div>
+<div (click)='handleClick()'></div>
 """);
     _resolveSingleTemplate(dartSource);
     expect(ranges, hasLength(2));
@@ -836,7 +836,6 @@ class TestPanel {
 <div (click)='handleClick($event)'></div>
 """);
     _resolveSingleTemplate(dartSource);
-    expect(ranges, hasLength(1));
     _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
     errorListener.assertNoErrors();
   }
@@ -855,8 +854,24 @@ class TestPanel {
 <div (click)='handleClick($event);'></div>
 """);
     _resolveSingleTemplate(dartSource);
-    expect(ranges, hasLength(1));
     _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
+    errorListener.assertNoErrors();
+  }
+
+  void test_statement_eventBinding_return_statement() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+''');
+    _addHtmlSource(r"""
+<h2 (click)='return 5;'></h2>
+""");
+    _resolveSingleTemplate(dartSource);
     errorListener.assertNoErrors();
   }
 
@@ -874,7 +889,6 @@ class TestPanel {
 <div (click)='handleClick($event); 5+5;'></div>
 """);
     _resolveSingleTemplate(dartSource);
-    expect(ranges, hasLength(1));
     errorListener.assertNoErrors();
     _assertElement('handleClick').dart.method.at('handleClick(MouseEvent');
   }
@@ -890,12 +904,12 @@ class TestPanel {
 }
 ''');
     String code = r"""
-<div (click)='handleClick(); unknownFunction()'></div>
+<div (click)='handleClick($event); unknownFunction()'></div>
 """;
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);
     assertErrorInCodeAtPosition(
-        StaticTypeWarningCode.UNDEFINED_METHOD, code, "unknownFunction()");
+        StaticTypeWarningCode.UNDEFINED_METHOD, code, "unknownFunction");
   }
 
   void test_inheritedFields() {


### PR DESCRIPTION
Building on issue 36

Event handlers are able to take statements instead of expressions. I've created a similar stack for resolving statements and generalized _recordExpressionResolvedRanges and _resolveDartExpression to be more generic to resolve any AstNode (expression or statement). 

Added a separate path to resolve event statements within _resolveAttributeValues. This will be refactored in another pull request.