### PR TITLE
Preliminary autocompletion work for review

### DIFF
--- a/analyzer_plugin/lib/src/model.dart
+++ b/analyzer_plugin/lib/src/model.dart
@@ -2,6 +2,7 @@ library angular2.src.analysis.analyzer_plugin.src.model;
 
 import 'package:analyzer/dart/element/element.dart' as dart;
 import 'package:analyzer/dart/element/type.dart' as dart;
+import 'package:analyzer/dart/ast/ast.dart' as dart;
 import 'package:analyzer/src/generated/source.dart' show Source, SourceRange;
 import 'package:analyzer/src/generated/utilities_general.dart';
 import 'package:analyzer/task/model.dart' show AnalysisTarget;
@@ -243,6 +244,25 @@ class ResolvedRange {
   }
 }
 
+class EmbeddedExpression {
+  /**
+   * The [SourceRange] where [element] is referenced.
+   */
+  final SourceRange range;
+
+  /**
+   * The [Expression] referenced at [range].
+   */
+  final dart.Expression expression;
+
+  EmbeddedExpression(this.range, this.expression);
+
+  @override
+  String toString() {
+    return '$range=[$expression]';
+  }
+}
+
 /**
  * An Angular template.
  * Templates can be embedded into Dart.
@@ -265,6 +285,11 @@ class Template {
    */
   final List<ResolvedRange> ranges = <ResolvedRange>[];
 
+  /**
+   * The [EmbeddedExpression]s of the template.
+   */
+  final List<EmbeddedExpression> embeddedExpressions = <EmbeddedExpression>[];
+
   Template(this.view, this.element);
 
   /**
@@ -275,6 +300,16 @@ class Template {
     assert(range.offset != null);
     assert(range.offset >= 0);
     ranges.add(new ResolvedRange(range, element));
+  }
+
+  /**
+   * Records that the given [expression] occurs at given [range].
+   */
+  void addExpression(SourceRange range, dart.Expression expression) {
+    assert(range != null);
+    assert(range.offset != null);
+    assert(range.offset >= 0);
+    embeddedExpressions.add(new EmbeddedExpression(range, expression));
   }
 
   @override

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -644,7 +644,9 @@ class TemplateResolver {
    */
   Expression _parseDartExpression(int offset, String code) {
     Token token = _scanDartCode(offset, code);
-    return _parseDartExpressionAtToken(token);
+    Expression expression = _parseDartExpressionAtToken(token);
+    template.addExpression(new SourceRange(offset, code.length), expression);
+    return expression;
   }
 
   /**

--- a/server_plugin/bin/make_snapshot
+++ b/server_plugin/bin/make_snapshot
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 dart --snapshot=server.snapshot server.dart
+
+sudo cp server.snapshot /usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot

--- a/server_plugin/lib/plugin.dart
+++ b/server_plugin/lib/plugin.dart
@@ -3,7 +3,10 @@ library angular2.src.analysis.server_plugin;
 import 'package:analysis_server/plugin/analysis/analysis_domain.dart';
 import 'package:analysis_server/plugin/analysis/navigation/navigation.dart';
 import 'package:analysis_server/plugin/analysis/occurrences/occurrences.dart';
+import 'package:analysis_server/src/provisional/completion/completion.dart';
+import 'package:analysis_server/src/provisional/completion/dart/completion.dart';
 import 'package:angular_analyzer_server_plugin/src/analysis.dart';
+import 'package:angular_analyzer_server_plugin/src/completion.dart';
 import 'package:plugin/plugin.dart';
 
 /**
@@ -30,5 +33,9 @@ class AngularServerPlugin implements Plugin {
         new AngularNavigationContributor());
     registerExtension(OCCURRENCES_CONTRIBUTOR_EXTENSION_POINT_ID,
         new AngularOccurrencesContributor());
+    registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
+        () => new AngularTemplateCompletionContributor());
+    registerExtension(DART_COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
+        () => new AngularDartCompletionContributor());
   }
 }

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:analysis_server/src/provisional/completion/completion_core.dart';
+import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
+import 'package:analysis_server/src/services/completion/dart/type_member_contributor.dart';
+import 'package:analysis_server/src/services/completion/dart/inherited_reference_contributor.dart';
+import 'package:analyzer/task/dart.dart';
+import 'package:angular_analyzer_plugin/src/model.dart';
+import 'package:angular_analyzer_plugin/src/tasks.dart';
+
+import 'package:analysis_server/src/protocol_server.dart'
+    show CompletionSuggestion;
+
+import 'embedded_dart_completion_request.dart';
+
+class AngularDartCompletionContributor extends DartCompletionContributor {
+  /**
+   * Return a [Future] that completes with a list of suggestions
+   * for the given completion [request].
+   */
+  Future<List<CompletionSuggestion>> computeSuggestions(
+      DartCompletionRequest request) async {
+    List<Template> templates = request.context.computeResult(
+        new LibrarySpecificUnit(request.librarySource, request.source),
+        DART_TEMPLATES);
+
+    return new TemplateCompleter().computeSuggestions(request, templates);
+  }
+}
+
+class AngularTemplateCompletionContributor extends CompletionContributor {
+  /**
+   * Return a [Future] that completes with a list of suggestions
+   * for the given completion [request]. This will
+   * throw [AbortCompletion] if the completion request has been aborted.
+   */
+  Future<List<CompletionSuggestion>> computeSuggestions(
+      CompletionRequest request) async {
+    if (request.source.shortName.endsWith('.html')) {
+      List<Template> templates =
+          request.context.computeResult(request.source, HTML_TEMPLATES);
+
+      return new TemplateCompleter().computeSuggestions(request, templates);
+    }
+
+    return [];
+  }
+}
+
+class TemplateCompleter {
+  Future<List<CompletionSuggestion>> computeSuggestions(
+      CompletionRequest request, List<Template> templates) async {
+    List<CompletionSuggestion> suggestions = <CompletionSuggestion>[];
+    for (Template template in templates) {
+      for (EmbeddedExpression expression in template.embeddedExpressions) {
+        if (expression.range.offset <= request.offset &&
+            expression.range.offset + expression.range.length >=
+                request.offset) {
+          EmbeddedDartCompletionRequest dartRequest =
+              new EmbeddedDartCompletionRequest.from(
+                  request, expression.expression);
+
+          dartRequest.libraryElement = template.view.classElement.library;
+          TypeMemberContributor memberContributor = new TypeMemberContributor();
+          InheritedReferenceContributor inheritedContributor =
+              new InheritedReferenceContributor();
+          suggestions.addAll(inheritedContributor.computeSuggestionsForClass(
+              template.view.classElement, dartRequest,
+              skipChildClass: false));
+          suggestions
+              .addAll(await memberContributor.computeSuggestions(dartRequest));
+        }
+      }
+    }
+
+    return suggestions;
+  }
+}

--- a/server_plugin/lib/src/embedded_dart_completion_request.dart
+++ b/server_plugin/lib/src/embedded_dart_completion_request.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+
+import 'package:analysis_server/src/provisional/completion/completion_core.dart';
+import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
+import 'package:analysis_server/src/services/completion/dart/optype.dart';
+import 'package:analysis_server/src/provisional/completion/dart/completion_target.dart';
+import 'package:analysis_server/src/services/search/search_engine.dart';
+import 'package:analyzer/src/generated/engine.dart' show AnalysisContext;
+import 'package:analyzer/src/dart/analysis/driver.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/file_system/file_system.dart';
+
+import 'package:analyzer/dart/ast/ast.dart';
+
+class EmbeddedDartCompletionRequest implements DartCompletionRequest {
+  factory EmbeddedDartCompletionRequest.from(
+      CompletionRequest request, AstNode dart) {
+    request.checkAborted();
+
+    Source libSource;
+    if (request.context != null) {
+      Source source = request.source;
+      libSource = source;
+    }
+
+    var dartRequest = new EmbeddedDartCompletionRequest._(
+        request.result,
+        request.context,
+        request.resourceProvider,
+        request.searchEngine,
+        libSource,
+        request.source,
+        request.offset);
+
+    dartRequest._updateTargets(dart);
+    return dartRequest;
+  }
+
+  EmbeddedDartCompletionRequest._(
+      this.result,
+      this.context,
+      this.resourceProvider,
+      this.searchEngine,
+      this.librarySource,
+      this.source,
+      this.offset) {}
+
+  /**
+   * Update the completion [target] and [dotTarget] based on the given [dart] AST
+   */
+  void _updateTargets(AstNode dart) {
+    dotTarget = null;
+    target = new CompletionTarget.forOffset(null, offset, entryPoint: dart);
+    opType = new OpType.forCompletion(target, offset);
+
+    // if the containing node IS the AST, it means the context decides what's
+    // completable. In that case, that's in our court only.
+    if (target.containingNode == dart) {
+      opType.includeReturnValueSuggestions = true;
+      opType.includeTypeNameSuggestions = true;
+      // only embedded statements should return void
+      opType.includeVoidReturnSuggestions = !(dart is Expression);
+    }
+
+    AstNode node = target.containingNode;
+    if (node is MethodInvocation) {
+      if (identical(node.methodName, target.entity)) {
+        dotTarget = node.realTarget;
+      } else if (node.isCascaded && node.operator.offset + 1 == target.offset) {
+        dotTarget = node.realTarget;
+      }
+    }
+    if (node is PropertyAccess) {
+      if (identical(node.propertyName, target.entity)) {
+        dotTarget = node.realTarget;
+      } else if (node.isCascaded && node.operator.offset + 1 == target.offset) {
+        dotTarget = node.realTarget;
+      }
+    }
+    if (node is PrefixedIdentifier) {
+      if (identical(node.identifier, target.entity)) {
+        dotTarget = node.prefix;
+      }
+    }
+  }
+
+  @override
+  AnalysisContext context;
+
+  @override
+  int offset;
+
+  @override
+  ResourceProvider resourceProvider;
+
+  @override
+  AnalysisResult result;
+
+  @override
+  SearchEngine searchEngine;
+
+  @override
+  Source source;
+
+  @override
+  String sourceContents;
+
+  @override
+  void checkAborted() {}
+
+  @override
+  OpType opType;
+
+  @override
+  CompletionTarget target;
+
+  /**
+   * Do nothing here, our expressions are already resolved.
+   */
+  @override
+  Future resolveContainingExpression(AstNode node) async {}
+
+  /**
+   * Do nothing here, our statements are already resolved.
+   */
+  @override
+  Future resolveContainingStatement(AstNode node) async {}
+
+  /**
+   * We don't use completions which rely on this
+   */
+  @override
+  Future<List<ImportElement>> resolveImports() async {
+    return [];
+  }
+
+  /**
+   * We don't use completions which rely on this
+   */
+  @override
+  Future<List<CompilationUnitElement>> resolveUnits() async {
+    return [];
+  }
+
+  @override
+  LibraryElement coreLib;
+
+  @override
+  Expression dotTarget;
+
+  @override
+  bool get includeIdentifiers {
+    return opType.includeIdentifiers;
+  }
+
+  /**
+   * We have to return non null or much code will view this as an isolated part
+   * file. We will use our template's libraryElement.
+   */
+  @override
+  LibraryElement libraryElement;
+
+  /**
+   * We have to return non null or much code will view this as an isolated part
+   * file. We will use our template's libraryElement.
+   */
+  @override
+  Source librarySource;
+
+  /**
+   * Answer the [DartType] for Object in dart:core
+   */
+  @override
+  DartType objectType;
+
+  /**
+   * Return the [SourceFactory] of the request.
+   */
+  @override
+  SourceFactory sourceFactory;
+}

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -86,7 +86,7 @@ class AnalysisDomainMock extends TypedMock implements AnalysisDomain {}
 class AnalysisTargetMock extends TypedMock implements AnalysisTarget {}
 
 @reflectiveTest
-class AngularNavigationContributorTest extends _AbstractAngularTaskTest {
+class AngularNavigationContributorTest extends AbstractAngularTaskTest {
   String code;
 
   List<_RecordedNavigationRegion> regions = <_RecordedNavigationRegion>[];
@@ -106,7 +106,7 @@ class AngularNavigationContributorTest extends _AbstractAngularTaskTest {
   }
 
   void test_dart_templates() {
-    _addAngularSources();
+    addAngularSources();
     code = r'''
 import '/angular2/src/core/metadata.dart';
 
@@ -132,7 +132,7 @@ class User {
 ''';
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    _computeResult(target, DART_TEMPLATES);
+    computeResult(target, DART_TEMPLATES);
     // compute navigation regions
     new AngularNavigationContributor()
         .computeNavigation(collector, context, source, null, null);
@@ -181,7 +181,7 @@ class User {
   }
 
   void test_dart_view_templateUrl() {
-    _addAngularSources();
+    addAngularSources();
     code = r'''
 import '/angular2/src/core/metadata.dart';
 
@@ -195,10 +195,10 @@ class TextPanel {}
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      _computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
     }
     // compute Angular templates
-    _computeResult(htmlSource, HTML_TEMPLATES);
+    computeResult(htmlSource, HTML_TEMPLATES);
     // compute navigation regions
     new AngularNavigationContributor()
         .computeNavigation(collector, context, dartSource, null, null);
@@ -212,7 +212,7 @@ class TextPanel {}
   }
 
   void test_html_templates() {
-    _addAngularSources();
+    addAngularSources();
     String dartCode = r'''
 import '/angular2/src/core/metadata.dart';
 
@@ -233,10 +233,10 @@ class TextPanel {
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      _computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
     }
     // compute Angular templates
-    _computeResult(htmlSource, HTML_TEMPLATES);
+    computeResult(htmlSource, HTML_TEMPLATES);
     // compute navigation regions
     new AngularNavigationContributor()
         .computeNavigation(collector, context, htmlSource, null, null);
@@ -271,7 +271,7 @@ class TextPanel {
 }
 
 @reflectiveTest
-class AngularOccurrencesContributorTest extends _AbstractAngularTaskTest {
+class AngularOccurrencesContributorTest extends AbstractAngularTaskTest {
   String code;
 
   OccurrencesCollector collector = new OccurrencesCollectorMock();
@@ -285,7 +285,7 @@ class AngularOccurrencesContributorTest extends _AbstractAngularTaskTest {
   }
 
   void test_dart_templates() {
-    _addAngularSources();
+    addAngularSources();
     code = r'''
 import '/angular2/src/core/metadata.dart';
 
@@ -311,7 +311,7 @@ class ObjectContainer<T> {
 ''';
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    _computeResult(target, DART_TEMPLATES);
+    computeResult(target, DART_TEMPLATES);
     // compute navigation regions
     new AngularOccurrencesContributor()
         .computeOccurrences(collector, context, source);
@@ -389,7 +389,7 @@ class SourceMock extends TypedMock implements Source {
   String toString() => fullPath;
 }
 
-class _AbstractAngularTaskTest {
+class AbstractAngularTaskTest {
   MemoryResourceProvider resourceProvider = new MemoryResourceProvider();
   Source emptySource;
 
@@ -423,7 +423,7 @@ class _AbstractAngularTaskTest {
     analysisDriver = context.driver;
   }
 
-  void _addAngularSources() {
+  void addAngularSources() {
     newSource(
         '/angular2/angular2.dart',
         r'''
@@ -576,7 +576,7 @@ class NgFor {
 ''');
   }
 
-  void _computeResult(AnalysisTarget target, ResultDescriptor result) {
+  void computeResult(AnalysisTarget target, ResultDescriptor result) {
     task = analysisDriver.computeResult(target, result);
     expect(task.caughtException, isNull);
     outputs = task.outputs;

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -1,0 +1,198 @@
+import 'package:analysis_server/src/provisional/completion/completion_core.dart';
+import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/task/dart.dart';
+import 'package:angular_analyzer_server_plugin/src/completion.dart';
+import 'package:angular_analyzer_plugin/src/tasks.dart';
+import 'package:unittest/unittest.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'completion_contributor_test_util.dart';
+
+main() {
+  groupSep = ' | ';
+  defineReflectiveTests(DartCompletionContributorTest);
+  defineReflectiveTests(HtmlCompletionContributorTest);
+}
+
+@reflectiveTest
+class DartCompletionContributorTest
+    extends AbstractDartCompletionContributorTest {
+  @override
+  setUp() {
+    testFile = '/completionTest.dart';
+    super.setUp();
+  }
+
+  @override
+  DartCompletionContributor createContributor() {
+    return new AngularDartCompletionContributor();
+  }
+
+  test_completeMemberInMustache() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '{{^}}', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+  }
+
+  test_completeMemberInInputBinding() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '<h1 [hidden]="^"></h1>', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+  }
+
+  test_completeMemberInClassBinding() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '<h1 [class.my-class]="^"></h1>', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+  }
+
+  test_completeMemberInStyleBinding() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '<h1 [style.background-color]="^"></h1>', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+  }
+
+  test_completeMemberInAttrBinding() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '<h1 [attr.on-click]="^"></h1>', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+  }
+
+  test_completeMemberMustacheAttrBinding() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '<h1 title="{{^}}"></h1>', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+  }
+
+  test_completeMultipleMembers() async {
+    addTestSource('''
+import '/angular2/angular2.dart';
+@Component(template: '{{d^}}', selector: 'a')
+class MyComp {
+  String text;
+  String description;
+}
+    ''');
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+    assertSuggestGetter('description', 'String');
+  }
+}
+
+@reflectiveTest
+class HtmlCompletionContributorTest extends AbstractCompletionContributorTest {
+  @override
+  setUp() {
+    testFile = '/completionTest.html';
+    super.setUp();
+  }
+
+  @override
+  CompletionContributor createContributor() {
+    return new AngularTemplateCompletionContributor();
+  }
+
+  test_completeMemberInMustache() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('html file {{^}} with mustache');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('text', 'String');
+    assertSuggestMethod('toString', 'Object', 'String');
+    assertSuggestGetter('hashCode', 'int');
+  }
+
+  test_completeDotMemberInMustache() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('html file {{text.^}} with mustache');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter('length', 'int');
+  }
+}

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -1,0 +1,632 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library test.services.completion.dart.util;
+
+import 'dart:async';
+
+import 'package:analysis_server/plugin/protocol/protocol.dart' as protocol
+    show Element, ElementKind;
+import 'package:analysis_server/plugin/protocol/protocol.dart'
+    hide Element, ElementKind;
+import 'package:analysis_server/plugin/protocol/protocol.dart';
+import 'package:analysis_server/src/provisional/completion/completion_core.dart';
+import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
+import 'package:analysis_server/src/services/completion/completion_core.dart';
+import 'package:analysis_server/src/services/completion/completion_performance.dart';
+import 'package:analysis_server/src/services/completion/dart/completion_manager.dart'
+    show DartCompletionRequestImpl, ReplacementRange;
+import 'package:analysis_server/src/services/index/index.dart';
+import 'package:analysis_server/src/services/search/search_engine_internal.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/task/dart.dart';
+import 'package:unittest/unittest.dart';
+
+import 'analysis_test.dart';
+
+int suggestionComparator(CompletionSuggestion s1, CompletionSuggestion s2) {
+  String c1 = s1.completion.toLowerCase();
+  String c2 = s2.completion.toLowerCase();
+  return c1.compareTo(c2);
+}
+
+abstract class AbstractDartCompletionContributorTest
+    extends BaseCompletionContributorTest {
+  DartCompletionContributor contributor;
+  DartCompletionRequest request;
+
+  @override
+  void setUp() {
+    super.setUp();
+    contributor = createContributor();
+  }
+
+  DartCompletionContributor createContributor();
+
+  Future computeSuggestions([int times = 200]) async {
+    context.analysisPriorityOrder = [testSource];
+    CompletionRequestImpl baseRequest = new CompletionRequestImpl(
+        null,
+        context,
+        null,
+        searchEngine,
+        testSource,
+        completionOffset,
+        new CompletionPerformance());
+
+    // Build the request
+    Completer<DartCompletionRequest> requestCompleter =
+        new Completer<DartCompletionRequest>();
+    DartCompletionRequestImpl
+        .from(baseRequest)
+        .then((DartCompletionRequest request) {
+      requestCompleter.complete(request);
+    });
+    request = await performAnalysis(times, requestCompleter);
+
+    var range = new ReplacementRange.compute(request.offset, request.target);
+    replacementOffset = range.offset;
+    replacementLength = range.length;
+    Completer<List<CompletionSuggestion>> suggestionCompleter =
+        new Completer<List<CompletionSuggestion>>();
+
+    // Request completions
+    contributor
+        .computeSuggestions(request)
+        .then((List<CompletionSuggestion> computedSuggestions) {
+      suggestionCompleter.complete(computedSuggestions);
+    });
+
+    // Perform analysis until the suggestions have been computed
+    // or the max analysis cycles ([times]) has been reached
+    suggestions = await performAnalysis(times, suggestionCompleter);
+    expect(suggestions, isNotNull, reason: 'expected suggestions');
+  }
+}
+
+abstract class AbstractCompletionContributorTest
+    extends BaseCompletionContributorTest {
+  CompletionContributor contributor;
+  CompletionRequest request;
+
+  @override
+  void setUp() {
+    super.setUp();
+    contributor = createContributor();
+  }
+
+  CompletionContributor createContributor();
+
+  Future computeSuggestions([int times = 200]) async {
+    context.analysisPriorityOrder = [testSource];
+    CompletionRequestImpl request = new CompletionRequestImpl(
+        null,
+        context,
+        null,
+        searchEngine,
+        testSource,
+        completionOffset,
+        new CompletionPerformance());
+
+    // Build the request
+    Completer<CompletionRequest> requestCompleter =
+        new Completer<CompletionRequest>();
+    requestCompleter.complete(request);
+    request = await performAnalysis(times, requestCompleter);
+
+    replacementOffset = request.offset;
+    replacementLength = 0;
+    Completer<List<CompletionSuggestion>> suggestionCompleter =
+        new Completer<List<CompletionSuggestion>>();
+
+    // Request completions
+    contributor
+        .computeSuggestions(request)
+        .then((List<CompletionSuggestion> computedSuggestions) {
+      suggestionCompleter.complete(computedSuggestions);
+    });
+
+    // Perform analysis until the suggestions have been computed
+    // or the max analysis cycles ([times]) has been reached
+    suggestions = await performAnalysis(times, suggestionCompleter);
+    expect(suggestions, isNotNull, reason: 'expected suggestions');
+  }
+}
+
+abstract class BaseCompletionContributorTest extends AbstractAngularTaskTest {
+  Index index;
+  SearchEngineImpl searchEngine;
+  String testFile;
+  Source testSource;
+  int completionOffset;
+  int replacementOffset;
+  int replacementLength;
+  CompletionRequest request;
+  List<CompletionSuggestion> suggestions;
+
+  /**
+   * If `true` and `null` is specified as the suggestion's expected returnType
+   * then the actual suggestion is expected to have a `dynamic` returnType.
+   * Newer tests return `false` so that they can distinguish between
+   * `dynamic` and `null`.
+   * Eventually all tests should be converted and this getter removed.
+   */
+  bool get isNullExpectedReturnTypeConsideredDynamic => true;
+
+  void addTestSource(String content) {
+    expect(completionOffset, isNull, reason: 'Call addTestUnit exactly once');
+    completionOffset = content.indexOf('^');
+    expect(completionOffset, isNot(equals(-1)), reason: 'missing ^');
+    int nextOffset = content.indexOf('^', completionOffset + 1);
+    expect(nextOffset, equals(-1), reason: 'too many ^');
+    content = content.substring(0, completionOffset) +
+        content.substring(completionOffset + 1);
+    testSource = newSource(testFile, content);
+  }
+
+  void assertHasNoParameterInfo(CompletionSuggestion suggestion) {
+    expect(suggestion.parameterNames, isNull);
+    expect(suggestion.parameterTypes, isNull);
+    expect(suggestion.requiredParameterCount, isNull);
+    expect(suggestion.hasNamedParameters, isNull);
+  }
+
+  void assertHasParameterInfo(CompletionSuggestion suggestion) {
+    expect(suggestion.parameterNames, isNotNull);
+    expect(suggestion.parameterTypes, isNotNull);
+    expect(suggestion.parameterNames.length, suggestion.parameterTypes.length);
+    expect(suggestion.requiredParameterCount,
+        lessThanOrEqualTo(suggestion.parameterNames.length));
+    expect(suggestion.hasNamedParameters, isNotNull);
+  }
+
+  void assertNoSuggestions({CompletionSuggestionKind kind: null}) {
+    if (kind == null) {
+      if (suggestions.length > 0) {
+        failedCompletion('Expected no suggestions', suggestions);
+      }
+      return;
+    }
+    CompletionSuggestion suggestion = suggestions.firstWhere(
+        (CompletionSuggestion cs) => cs.kind == kind,
+        orElse: () => null);
+    if (suggestion != null) {
+      failedCompletion('did not expect completion: $completion\n  $suggestion');
+    }
+  }
+
+  void assertNotSuggested(String completion) {
+    CompletionSuggestion suggestion = suggestions.firstWhere(
+        (CompletionSuggestion cs) => cs.completion == completion,
+        orElse: () => null);
+    if (suggestion != null) {
+      failedCompletion('did not expect completion: $completion\n  $suggestion');
+    }
+  }
+
+  CompletionSuggestion assertSuggest(String completion,
+      {CompletionSuggestionKind csKind: CompletionSuggestionKind.INVOCATION,
+      int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      protocol.ElementKind elemKind: null,
+      bool isDeprecated: false,
+      bool isPotential: false,
+      String elemFile,
+      int elemOffset,
+      String paramName,
+      String paramType}) {
+    CompletionSuggestion cs =
+        getSuggest(completion: completion, csKind: csKind, elemKind: elemKind);
+    if (cs == null) {
+      failedCompletion('expected $completion $csKind $elemKind', suggestions);
+    }
+    expect(cs.kind, equals(csKind));
+    if (isDeprecated) {
+      expect(cs.relevance, equals(DART_RELEVANCE_LOW));
+    } else {
+      expect(cs.relevance, equals(relevance), reason: completion);
+    }
+    expect(cs.importUri, importUri);
+    expect(cs.selectionOffset, equals(completion.length));
+    expect(cs.selectionLength, equals(0));
+    expect(cs.isDeprecated, equals(isDeprecated));
+    expect(cs.isPotential, equals(isPotential));
+    if (cs.element != null) {
+      expect(cs.element.location, isNotNull);
+      expect(cs.element.location.file, isNotNull);
+      expect(cs.element.location.offset, isNotNull);
+      expect(cs.element.location.length, isNotNull);
+      expect(cs.element.location.startColumn, isNotNull);
+      expect(cs.element.location.startLine, isNotNull);
+    }
+    if (elemFile != null) {
+      expect(cs.element.location.file, elemFile);
+    }
+    if (elemOffset != null) {
+      expect(cs.element.location.offset, elemOffset);
+    }
+    if (paramName != null) {
+      expect(cs.parameterName, paramName);
+    }
+    if (paramType != null) {
+      expect(cs.parameterType, paramType);
+    }
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestClass(String name,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      bool isDeprecated: false,
+      String elemFile,
+      String elemName,
+      int elemOffset}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        isDeprecated: isDeprecated,
+        elemFile: elemFile,
+        elemOffset: elemOffset);
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.CLASS));
+    expect(element.name, equals(elemName ?? name));
+    expect(element.parameters, isNull);
+    expect(element.returnType, isNull);
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestClassTypeAlias(String name,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION}) {
+    CompletionSuggestion cs =
+        assertSuggest(name, csKind: kind, relevance: relevance);
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.CLASS_TYPE_ALIAS));
+    expect(element.name, equals(name));
+    expect(element.parameters, isNull);
+    expect(element.returnType, isNull);
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestConstructor(String name,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      int elemOffset}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        relevance: relevance, importUri: importUri, elemOffset: elemOffset);
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.CONSTRUCTOR));
+    int index = name.indexOf('.');
+    expect(element.name, index >= 0 ? name.substring(index + 1) : '');
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestEnum(String completion,
+      {bool isDeprecated: false}) {
+    CompletionSuggestion suggestion =
+        assertSuggest(completion, isDeprecated: isDeprecated);
+    expect(suggestion.isDeprecated, isDeprecated);
+    expect(suggestion.element.kind, protocol.ElementKind.ENUM);
+    return suggestion;
+  }
+
+  CompletionSuggestion assertSuggestEnumConst(String completion,
+      {int relevance: DART_RELEVANCE_DEFAULT, bool isDeprecated: false}) {
+    CompletionSuggestion suggestion = assertSuggest(completion,
+        relevance: relevance, isDeprecated: isDeprecated);
+    expect(suggestion.completion, completion);
+    expect(suggestion.isDeprecated, isDeprecated);
+    expect(suggestion.element.kind, protocol.ElementKind.ENUM_CONSTANT);
+    return suggestion;
+  }
+
+  CompletionSuggestion assertSuggestField(String name, String type,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      bool isDeprecated: false}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        elemKind: protocol.ElementKind.FIELD,
+        isDeprecated: isDeprecated);
+    // The returnType represents the type of a field
+    expect(cs.returnType, type != null ? type : 'dynamic');
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.FIELD));
+    expect(element.name, equals(name));
+    expect(element.parameters, isNull);
+    // The returnType represents the type of a field
+    expect(element.returnType, type != null ? type : 'dynamic');
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestFunction(String name, String returnType,
+      {CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      bool isDeprecated: false,
+      int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        isDeprecated: isDeprecated);
+    if (returnType != null) {
+      expect(cs.returnType, returnType);
+    } else if (isNullExpectedReturnTypeConsideredDynamic) {
+      expect(cs.returnType, 'dynamic');
+    }
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.FUNCTION));
+    expect(element.name, equals(name));
+    expect(element.isDeprecated, equals(isDeprecated));
+    String param = element.parameters;
+    expect(param, isNotNull);
+    expect(param[0], equals('('));
+    expect(param[param.length - 1], equals(')'));
+    if (returnType != null) {
+      expect(element.returnType, returnType);
+    } else if (isNullExpectedReturnTypeConsideredDynamic) {
+      expect(element.returnType, 'dynamic');
+    }
+    assertHasParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestFunctionTypeAlias(
+      String name, String returnType,
+      {bool isDeprecated: false,
+      int relevance: DART_RELEVANCE_DEFAULT,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      String importUri}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        isDeprecated: isDeprecated);
+    if (returnType != null) {
+      expect(cs.returnType, returnType);
+    } else if (isNullExpectedReturnTypeConsideredDynamic) {
+      expect(cs.returnType, 'dynamic');
+    } else {
+      expect(cs.returnType, isNull);
+    }
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.FUNCTION_TYPE_ALIAS));
+    expect(element.name, equals(name));
+    expect(element.isDeprecated, equals(isDeprecated));
+    // TODO (danrubel) Determine why params are null
+    //    String param = element.parameters;
+    //    expect(param, isNotNull);
+    //    expect(param[0], equals('('));
+    //    expect(param[param.length - 1], equals(')'));
+    expect(element.returnType,
+        equals(returnType != null ? returnType : 'dynamic'));
+    // TODO (danrubel) Determine why param info is missing
+    //    assertHasParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestGetter(String name, String returnType,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      bool isDeprecated: false}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        elemKind: protocol.ElementKind.GETTER,
+        isDeprecated: isDeprecated);
+    expect(cs.returnType, returnType != null ? returnType : 'dynamic');
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.GETTER));
+    expect(element.name, equals(name));
+    expect(element.parameters, isNull);
+    expect(element.returnType,
+        equals(returnType != null ? returnType : 'dynamic'));
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestMethod(
+      String name, String declaringType, String returnType,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      bool isDeprecated: false}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        isDeprecated: isDeprecated);
+    expect(cs.declaringType, equals(declaringType));
+    expect(cs.returnType, returnType != null ? returnType : 'dynamic');
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.METHOD));
+    expect(element.name, equals(name));
+    String param = element.parameters;
+    expect(param, isNotNull);
+    expect(param[0], equals('('));
+    expect(param[param.length - 1], equals(')'));
+    expect(element.returnType, returnType != null ? returnType : 'dynamic');
+    assertHasParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestName(String name,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.IDENTIFIER,
+      bool isDeprecated: false}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        isDeprecated: isDeprecated);
+    expect(cs.completion, equals(name));
+    expect(cs.element, isNull);
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestSetter(String name,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        elemKind: protocol.ElementKind.SETTER);
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.SETTER));
+    expect(element.name, equals(name));
+    // TODO (danrubel) assert setter param
+    //expect(element.parameters, isNull);
+    // TODO (danrubel) it would be better if this was always null
+    if (element.returnType != null) {
+      expect(element.returnType, 'dynamic');
+    }
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  CompletionSuggestion assertSuggestTopLevelVar(String name, String returnType,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,
+      String importUri}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind, relevance: relevance, importUri: importUri);
+    if (returnType != null) {
+      expect(cs.returnType, returnType);
+    } else if (isNullExpectedReturnTypeConsideredDynamic) {
+      expect(cs.returnType, 'dynamic');
+    }
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.TOP_LEVEL_VARIABLE));
+    expect(element.name, equals(name));
+    expect(element.parameters, isNull);
+    if (returnType != null) {
+      expect(element.returnType, returnType);
+    } else if (isNullExpectedReturnTypeConsideredDynamic) {
+      expect(element.returnType, 'dynamic');
+    }
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
+  /**
+   * Return a [Future] that completes with the containing library information
+   * after it is accessible via [context.getLibrariesContaining].
+   */
+  Future computeLibrariesContaining([int times = 200]) {
+    List<Source> libraries = context.getLibrariesContaining(testSource);
+    if (libraries.isNotEmpty) {
+      return new Future.value(libraries);
+    }
+    if (times == 0) {
+      fail('failed to determine libraries containing $testSource');
+    }
+    context.performAnalysisTask();
+    // We use a delayed future to allow microtask events to finish. The
+    // Future.value or Future() constructors use scheduleMicrotask themselves and
+    // would therefore not wait for microtask callbacks that are scheduled after
+    // invoking this method.
+    return new Future.delayed(
+        Duration.ZERO, () => computeLibrariesContaining(times - 1));
+  }
+
+  Future computeSuggestions([int times = 200]);
+
+  void failedCompletion(String message,
+      [Iterable<CompletionSuggestion> completions]) {
+    StringBuffer sb = new StringBuffer(message);
+    if (completions != null) {
+      sb.write('\n  found');
+      completions.toList()
+        ..sort(suggestionComparator)
+        ..forEach((CompletionSuggestion suggestion) {
+          sb.write('\n    ${suggestion.completion} -> $suggestion');
+        });
+    }
+    fail(sb.toString());
+  }
+
+  CompletionSuggestion getSuggest(
+      {String completion: null,
+      CompletionSuggestionKind csKind: null,
+      protocol.ElementKind elemKind: null}) {
+    CompletionSuggestion cs;
+    if (suggestions != null) {
+      suggestions.forEach((CompletionSuggestion s) {
+        if (completion != null && completion != s.completion) {
+          return;
+        }
+        if (csKind != null && csKind != s.kind) {
+          return;
+        }
+        if (elemKind != null) {
+          protocol.Element element = s.element;
+          if (element == null || elemKind != element.kind) {
+            return;
+          }
+        }
+        if (cs == null) {
+          cs = s;
+        } else {
+          failedCompletion('expected exactly one $cs',
+              suggestions.where((s) => s.completion == completion));
+        }
+      });
+    }
+    return cs;
+  }
+
+  Future/*<E>*/ performAnalysis/*<E>*/(int times, Completer/*<E>*/ completer) {
+    if (completer.isCompleted) {
+      return completer.future;
+    }
+    if (times == 0 || context == null) {
+      return new Future.value();
+    }
+    context.performAnalysisTask();
+    // We use a delayed future to allow microtask events to finish. The
+    // Future.value or Future() constructors use scheduleMicrotask themselves and
+    // would therefore not wait for microtask callbacks that are scheduled after
+    // invoking this method.
+    return new Future.delayed(
+        Duration.ZERO, () => performAnalysis(times - 1, completer));
+  }
+
+  void resolveSource(String path, String content) {
+    Source libSource = newSource(path, content);
+    var target = new LibrarySpecificUnit(libSource, libSource);
+    context.computeResult(target, RESOLVED_UNIT);
+  }
+
+  @override
+  void setUp() {
+    super.setUp();
+    index = createMemoryIndex();
+    searchEngine = new SearchEngineImpl(index);
+    addAngularSources();
+  }
+}


### PR DESCRIPTION
@scheglov if you can review this before I go too far, that would be great!


Copy some test code from analysis server to be able to write
autocompletion tests. Basic plugin to autocomplete and dart
autocomplete (which are separate pluggable things).

Store expressions in templates with their offsets so that we can get the
ASTs after the fact for autocomplete.

So far just returns a hardcoded result 'text' for anything that looks
like its completing an angular expression in dart code.