### PR TITLE
Handle sanest and some of the crazier constant template expressions

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -2,6 +2,7 @@ library angular2.src.analysis.analyzer_plugin.src.tasks;
 
 import 'package:analyzer/src/context/cache.dart';
 import 'package:analyzer/dart/ast/ast.dart' as ast;
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/dart/ast/utilities.dart' as utils;
 import 'package:analyzer/src/generated/constant.dart';
@@ -367,16 +368,18 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
     if (expression == null) {
       return null;
     }
+
     // Extract its content.
-    String name;
+    String name = _getExpressionString(expression);
+    if (name == null) {
+      return null;
+    }
+
     int offset;
     if (expression is ast.SimpleStringLiteral) {
-      name = expression.value;
       offset = expression.contentsOffset;
     } else {
-      errorReporter.reportErrorForNode(
-          AngularWarningCode.STRING_VALUE_EXPECTED, expression);
-      return null;
+      offset = expression.offset;
     }
     // Create a new element.
     return new AngularElementImpl(name, offset, name.length, target.source);
@@ -658,17 +661,16 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
           AngularWarningCode.ARGUMENT_SELECTOR_MISSING, node);
       return null;
     }
-    // Compute the selector text.
-    String selectorStr;
-    int selectorOffset;
-    if (expression is ast.SimpleStringLiteral) {
-      selectorStr = expression.value;
-      selectorOffset = expression.contentsOffset;
-    } else {
-      errorReporter.reportErrorForNode(
-          AngularWarningCode.STRING_VALUE_EXPECTED, expression);
+    // Compute the selector text. Careful! Offsets may not be valid after this,
+    // however, at the moment we don't use them anyway.
+    OffsettingConstantEvaluator constantEvaluation =
+        _calculateStringWithOffsets(expression);
+    if (constantEvaluation == null) {
       return null;
     }
+
+    String selectorStr = constantEvaluation.value;
+    int selectorOffset = expression.offset;
     // Parse the selector text.
     Selector selector =
         Selector.parse(target.source, selectorOffset, selectorStr);
@@ -891,13 +893,16 @@ class BuildUnitViewsTask extends SourceBasedAnalysisTask
     {
       ast.Expression expression = _getNamedArgument(annotation, 'template');
       if (expression != null) {
+        templateOffset = expression.offset;
         definesTemplate = true;
-        if (expression is ast.SimpleStringLiteral) {
-          templateText = expression.value;
-          templateOffset = expression.contentsOffset;
+        OffsettingConstantEvaluator constantEvaluation =
+            _calculateStringWithOffsets(expression);
+
+        // highly dynamically generated constant expressions can't be validated
+        if (constantEvaluation == null || !constantEvaluation.offsetsAreValid) {
+          templateText = '';
         } else {
-          errorReporter.reportErrorForNode(
-              AngularWarningCode.STRING_VALUE_EXPECTED, expression);
+          templateText = constantEvaluation.value;
         }
       }
     }
@@ -1306,6 +1311,113 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
   }
 }
 
+class OffsettingConstantEvaluator extends utils.ConstantEvaluator {
+  bool offsetsAreValid = true;
+  Object value;
+  ast.AstNode lastUnoffsettableNode;
+
+  @override
+  Object visitAdjacentStrings(ast.AdjacentStrings node) {
+    StringBuffer buffer = new StringBuffer();
+    int lastEndingOffset = null;
+    for (ast.StringLiteral string in node.strings) {
+      Object value = string.accept(this);
+      if (identical(value, utils.ConstantEvaluator.NOT_A_CONSTANT)) {
+        return value;
+      }
+      // preserve offsets across the split by padding
+      if (lastEndingOffset != null) {
+        buffer.write(' ' * (string.offset - lastEndingOffset));
+      }
+      lastEndingOffset = string.offset + string.length;
+      buffer.write(value);
+    }
+    return buffer.toString();
+  }
+
+  @override
+  Object visitBinaryExpression(ast.BinaryExpression node) {
+    if (node.operator.type == TokenType.PLUS) {
+      Object leftOperand = node.leftOperand.accept(this);
+      if (identical(leftOperand, utils.ConstantEvaluator.NOT_A_CONSTANT)) {
+        return leftOperand;
+      }
+      Object rightOperand = node.rightOperand.accept(this);
+      if (identical(rightOperand, utils.ConstantEvaluator.NOT_A_CONSTANT)) {
+        return rightOperand;
+      }
+      // numeric or {@code null}
+      if (leftOperand is String && rightOperand is String) {
+        int gap = node.rightOperand.offset -
+            node.leftOperand.offset -
+            node.leftOperand.length;
+        return leftOperand + (' ' * gap) + rightOperand;
+      }
+    }
+
+    return super.visitBinaryExpression(node);
+  }
+
+  @override
+  Object visitStringInterpolation(ast.StringInterpolation node) {
+    offsetsAreValid = false;
+    lastUnoffsettableNode = node;
+    return super.visitStringInterpolation(node);
+  }
+
+  @override
+  Object visitMethodInvocation(ast.MethodInvocation node) {
+    offsetsAreValid = false;
+    lastUnoffsettableNode = node;
+    return super.visitMethodInvocation(node);
+  }
+
+  @override
+  Object visitParenthesizedExpression(ast.ParenthesizedExpression node) {
+    offsetsAreValid = false;
+    lastUnoffsettableNode = node;
+    int preGap = node.expression.offset - node.offset;
+    int postGap = node.offset +
+        node.length -
+        node.expression.offset -
+        node.expression.length;
+    Object value = super.visitParenthesizedExpression(node);
+    if (value is String) {
+      return ' ' * preGap + value + ' ' * postGap;
+    }
+
+    return value;
+  }
+
+  @override
+  Object visitSimpleStringLiteral(ast.SimpleStringLiteral node) {
+    int gap = node.contentsOffset - node.offset;
+    lastUnoffsettableNode = node;
+    return ' ' * gap + node.value + ' ';
+  }
+
+  @override
+  Object visitPrefixedIdentifier(ast.PrefixedIdentifier node) {
+    offsetsAreValid = false;
+    lastUnoffsettableNode = node;
+    return super.visitPrefixedIdentifier(node);
+  }
+
+  @override
+  Object visitPropertyAccess(ast.PropertyAccess node) {
+    offsetsAreValid = false;
+    lastUnoffsettableNode = node;
+    return super.visitPropertyAccess(node);
+  }
+
+  @override
+  Object visitSimpleIdentifier(ast.SimpleIdentifier node) {
+    offsetsAreValid = false;
+    lastUnoffsettableNode = node;
+    return super.visitSimpleIdentifier(node);
+  }
+}
+
 /**
  * Helper for processing Angular annotations.
  */
@@ -1337,6 +1449,31 @@ class _AnnotationProcessorMixin {
       Object value = expression.accept(_constantEvaluator);
       if (value is String) {
         return value;
+      }
+      errorReporter.reportErrorForNode(
+          AngularWarningCode.STRING_VALUE_EXPECTED, expression);
+    }
+    return null;
+  }
+
+  /**
+   * Returns the [String] value of the given [expression].
+   * If [expression] does not have a [String] value, reports an error
+   * and returns `null`.
+   */
+  OffsettingConstantEvaluator _calculateStringWithOffsets(
+      ast.Expression expression) {
+    if (expression != null) {
+      OffsettingConstantEvaluator evaluator = new OffsettingConstantEvaluator();
+      evaluator.value = expression.accept(evaluator);
+
+      if (evaluator.value is String) {
+        if (!evaluator.offsetsAreValid) {
+          errorReporter.reportErrorForNode(
+              AngularWarningCode.OFFSETS_CANNOT_BE_CREATED,
+              evaluator.lastUnoffsettableNode);
+        }
+        return evaluator;
       }
       errorReporter.reportErrorForNode(
           AngularWarningCode.STRING_VALUE_EXPECTED, expression);

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -275,6 +275,16 @@ class AngularWarningCode extends ErrorCode {
           "Syntax Error: unexpected {0}");
 
   /**
+   * An error code indicating that an output-bound statement
+   * must be an [ExpressionStatement].
+   */
+  static const AngularWarningCode OFFSETS_CANNOT_BE_CREATED =
+      const AngularWarningCode(
+          'OFFSETS_CANNOT_BE_CREATED',
+          "Errors cannot be tracked for the constant expression because it is" +
+              " too complex for errors to be mapped to locations in the file");
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be

--- a/analyzer_plugin/test/offsetting_constant_value_visitor_test.dart
+++ b/analyzer_plugin/test/offsetting_constant_value_visitor_test.dart
@@ -1,0 +1,148 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/src/dart/ast/utilities.dart' as utils;
+import 'package:analyzer/src/dart/scanner/reader.dart';
+import 'package:analyzer/src/dart/scanner/scanner.dart';
+import 'package:analyzer/src/generated/parser.dart';
+import 'package:angular_analyzer_plugin/src/tasks.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+import 'package:unittest/unittest.dart';
+
+main() {
+  groupSep = ' | ';
+  defineReflectiveTests(OffsettingConstantValueVisitorTest);
+}
+
+@reflectiveTest
+class OffsettingConstantValueVisitorTest {
+  void test_simpleString() {
+    assertCaretOffsetIsPreserved("'my template^'");
+    assertCaretOffsetIsPreserved("r'my template^'");
+    assertCaretOffsetIsPreserved('"my template^"');
+    assertCaretOffsetIsPreserved('r"my template^"');
+    assertCaretOffsetIsPreserved("'''my template^'''");
+    assertCaretOffsetIsPreserved("r'''my template^'''");
+  }
+
+  void test_parenthesizedString() {
+    assertCaretOffsetIsPreserved("('my template^')");
+    assertCaretOffsetIsPreserved("( 'my template^')");
+    assertCaretOffsetIsPreserved("(  'my template^')");
+    assertCaretOffsetIsPreserved("(\n'my template^')");
+  }
+
+  void test_adjacentStrings() {
+    assertCaretOffsetIsPreserved("'my template^' 'which continues'");
+    assertCaretOffsetIsPreserved("'my template' 'which continues ^'");
+    assertCaretOffsetIsPreserved("r'my template'    r'which continues ^'");
+    assertCaretOffsetIsPreserved("'my template'\n       'which continues ^'");
+    assertCaretOffsetIsPreserved("'no gap''then continue ^'");
+    assertCaretOffsetIsPreserved("'' 'after empty string ^'");
+    assertCaretOffsetIsPreserved(
+        "'my template'\n\n       'which continues' ' and continues ^'");
+  }
+
+  void test_concatenatedStrings() {
+    assertCaretOffsetIsPreserved("'my template^' + 'which continues'");
+    assertCaretOffsetIsPreserved("'my template' + 'which continues ^'");
+    assertCaretOffsetIsPreserved("r'my template' +    r'which continues ^'");
+    assertCaretOffsetIsPreserved("'my template' +\n       'which continues ^'");
+    assertCaretOffsetIsPreserved("'no gap'+'then continue ^'");
+    assertCaretOffsetIsPreserved("'' + 'after empty string ^'");
+    assertCaretOffsetIsPreserved(
+        "'my template' +\n\n       'which continues' + ' and continues ^'");
+  }
+
+  void test_concatenatedAfterParenthesis() {
+    assertCaretOffsetIsPreserved("('my template^') + 'which continues'");
+    assertCaretOffsetIsPreserved("('my template') + 'which continues^'");
+    assertCaretOffsetIsPreserved("('my template'  ) + 'which continues^'");
+    assertCaretOffsetIsPreserved("('my template'\n) + 'which continues^'");
+  }
+
+  void test_computedStringsLookRight() {
+    Expression expression =
+        _parseDartExpression("('my template'\n) + 'which continues^'");
+    Object value = expression.accept(new OffsettingConstantEvaluator());
+    expect(value, equals("  my template       which continues^ "));
+  }
+
+  void test_notStringComputation() {
+    Expression expression = _parseDartExpression("1 + 2");
+    Object value = expression.accept(new OffsettingConstantEvaluator());
+    expect(value, equals(3));
+  }
+
+  void test_error() {
+    Expression expression = _parseDartExpression("1 + 'hello'");
+    Object value = expression.accept(new OffsettingConstantEvaluator());
+    expect(value, equals(utils.ConstantEvaluator.NOT_A_CONSTANT));
+  }
+
+  void test_notOffsettableInterp() {
+    assertNotOffsettable(r"'hello $world'", at: 'world');
+  }
+
+  void test_notOffsettableInterpExpr() {
+    assertNotOffsettable(r"'hello ${world}'", at: 'world');
+  }
+
+  void test_notOffsettableGetter() {
+    assertNotOffsettable(r"'hello' + world ", at: 'world');
+  }
+
+  void test_notOffsettableMethod() {
+    assertNotOffsettable(r"'hello' + method() ", at: 'method()');
+  }
+
+  void test_notOffsettablePrefixedIdent() {
+    assertNotOffsettable(r"'hello' + prefixed.identifier ",
+        at: 'prefixed.identifier');
+  }
+
+  void assertNotOffsettable(String code, {String at}) {
+    Expression expression = _parseDartExpression(code);
+    int pos = code.indexOf(at);
+    int length = at.length;
+    expect(pos, greaterThan(-1),
+        reason: "```$code```` doesn't contain ```$at```");
+
+    OffsettingConstantEvaluator evaluator = new OffsettingConstantEvaluator();
+    Object value = expression.accept(evaluator);
+    expect(evaluator.offsetsAreValid, isFalse);
+    expect(evaluator.lastUnoffsettableNode, isNotNull);
+    expect(evaluator.lastUnoffsettableNode.offset, equals(pos),
+        reason: "The snippet didn't match the suspect node");
+    expect(evaluator.lastUnoffsettableNode.length, equals(length),
+        reason: "The snippet didn't match the suspect node");
+  }
+
+  void assertCaretOffsetIsPreserved(String code) {
+    int pos = code.indexOf('^');
+    expect(pos, greaterThan(-1), reason: 'the code should contain a caret');
+
+    Expression expression = _parseDartExpression(code);
+
+    OffsettingConstantEvaluator evaluator = new OffsettingConstantEvaluator();
+    Object value = expression.accept(evaluator);
+
+    if (value is String) {
+      expect(value.indexOf('^'), equals(pos),
+          reason: "```$value``` moved the caret");
+    } else {
+      fail("Expected string, got $value");
+    }
+  }
+
+  Token _scanDartCode(String code) {
+    CharSequenceReader reader = new CharSequenceReader(code);
+    Scanner scanner = new Scanner(null, reader, null);
+    return scanner.tokenize();
+  }
+
+  Expression _parseDartExpression(String code) {
+    Token token = _scanDartCode(code);
+    Parser parser = new Parser(null, null);
+    return parser.parseExpression(token);
+  }
+}

--- a/analyzer_plugin/test/test_all.dart
+++ b/analyzer_plugin/test/test_all.dart
@@ -6,6 +6,8 @@ import 'angular_work_manager_test.dart' as angular_work_manager_test;
 import 'resolver_test.dart' as resolver_test;
 import 'selector_test.dart' as selector_test;
 import 'tasks_test.dart' as tasks_test;
+import 'offsetting_constant_value_visitor_test.dart'
+    as offsetting_constant_value_visitor_test;
 
 /**
  * Utility for manually running all tests.
@@ -17,5 +19,6 @@ main() {
     resolver_test.main();
     selector_test.main();
     tasks_test.main();
+    offsetting_constant_value_visitor_test.main();
   });
 }


### PR DESCRIPTION
PR will fail to build until https://codereview.chromium.org/2586363004/ is merged.

Handle template: 'a' + 'b', etc.

Use ConstantEvaluator for most of the heavy lifting, but for things like
templates where we need to track offsets, use a special new visitor
(with tests) to pad in appropriately to match the constant expression
around operators, parens etc.

recognize when adding spaces can't fix stuff, and bail out.