### PR TITLE
When a declared (in|out)put is malformed, skip it to prevent crashes …

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -433,6 +433,9 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
       var nameRange = nameValueAndRanges.item4;
 
       PropertyAccessorElement setter = _resolveSetter(expression, name);
+      if (setter == null) {
+        return null;
+      }
 
       return new InputElement(boundName, boundRange.offset, boundRange.length,
           target.source, setter, nameRange, _getSetterType(setter));
@@ -452,6 +455,9 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
       var nameRange = nameValueAndRanges.item4;
 
       PropertyAccessorElement getter = _resolveGetter(expression, name);
+      if (getter == null) {
+        return null;
+      }
 
       var eventType = getEventType(getter, name);
 

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -402,6 +402,11 @@ class ComponentA {
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
     computeResult(target, DIRECTIVES_IN_UNIT);
     expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<InputElement> inputs = component.inputs;
+    // the bad input should NOT show up, it is not usable see github #183
+    expect(inputs, hasLength(0));
     // validate
     fillErrorListener(DIRECTIVES_ERRORS);
     errorListener.assertErrorsWithCodes(
@@ -421,6 +426,30 @@ class ComponentA {
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
     computeResult(target, DIRECTIVES_IN_UNIT);
     expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    // validate
+    fillErrorListener(DIRECTIVES_ERRORS);
+    errorListener.assertErrorsWithCodes(
+        <ErrorCode>[StaticTypeWarningCode.UNDEFINED_SETTER]);
+  }
+
+  void test_hasError_UndefinedSetter_shortSyntax_noInputMade() {
+    Source source = newSource(
+        '/test.dart',
+        r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'my-component', inputs: const ['noSetter'])
+class ComponentA {
+}
+''');
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DIRECTIVES_IN_UNIT);
+    expect(task, new isInstanceOf<BuildUnitDirectivesTask>());
+    List<AbstractDirective> directives = outputs[DIRECTIVES_IN_UNIT];
+    Component component = directives.single;
+    List<InputElement> inputs = component.inputs;
+    // the bad input should NOT show up, it is not usable see github #183
+    expect(inputs, hasLength(0));
     // validate
     fillErrorListener(DIRECTIVES_ERRORS);
     errorListener.assertErrorsWithCodes(


### PR DESCRIPTION
…refs #183

Used to create a malformed InputElement (or OutputElement) that was
added to the directive and crashed the server when used since it was in
a half complete state.

We could set it to something dynamic, but references won't be traceable
and it should be an error to use an erroneous input since that
erroneous input may have been written by someone else without analysis
and you would have a bad day if you were allowed to use such an input,
discussion in #183 on github.