### PR TITLE
Autocomplete outputs within other outputs, and standard events.

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -88,7 +88,10 @@ abstract class BoundAttributeInfo extends AttributeInfo {
 
 class TemplateAttribute extends BoundAttributeInfo implements HasDirectives {
   final List<AttributeInfo> virtualAttributes;
-  List<AbstractDirective> directives = <AbstractDirective>[];
+  List<DirectiveBinding> boundDirectives = <DirectiveBinding>[];
+  List<OutputBinding> boundStandardOutputs = <OutputBinding>[];
+  List<AbstractDirective> get directives =>
+      boundDirectives.map((bd) => bd.boundDirective);
 
   TemplateAttribute(String name, int nameOffset, String value, int valueOffset,
       String originalName, int originalNameOffset, this.virtualAttributes)
@@ -185,10 +188,61 @@ abstract class NodeInfo extends AngularAstNode {}
 
 /**
  * An AngularAstNode which has directives, such as [ElementInfo] and
- * [TemplateAttribute]
+ * [TemplateAttribute]. Contains an array of [DirectiveBinding]s because those
+ * contain more info than just the bound directive.
  */
 abstract class HasDirectives {
-  List<AbstractDirective> get directives;
+  List<DirectiveBinding> get boundDirectives;
+  List<OutputBinding> get boundStandardOutputs;
+}
+
+/**
+ * A binding to an [AbstractDirective], either on an [ElementInfo] or a
+ * [TemplateAttribute]. For each bound directive, there is a directive binding.
+ * Has [InputBinding]s and [OutputBinding]s which themselves indicate an
+ * [AttributeInfo] bound to an [InputElement] or [OutputElement] in the context
+ * of this [DirectiveBinding].
+ *
+ * Naming here is important: "bound directive" != "directive binding." 
+ */
+class DirectiveBinding {
+  final AbstractDirective boundDirective;
+  final List<InputBinding> inputBindings = [];
+  final List<OutputBinding> outputBindings = [];
+
+  DirectiveBinding(this.boundDirective);
+}
+
+/**
+ * A binding between an [ExpressionBoundAttribute] and an [InputElement].
+ * This is used in the context of a [DirectiveBinding] because each instance of
+ * a bound directive has different input bindings.
+ *
+ * Naming here is important: "bound input" != "input binding." 
+ */
+class InputBinding {
+  final InputElement boundInput;
+  final ExpressionBoundAttribute attribute;
+
+  InputBinding(this.boundInput, this.attribute);
+}
+
+/**
+ * A binding between an [BoundAttributeInfo] and an [OutputElement]. This is
+ * used in the context of a [DirectiveBinding] because each instance of a bound
+ * directive has different output bindings.
+ *
+ * Binds to an [BoundAttributeInfo] and not a [StatementsBoundAttribute] because
+ * it might be a two-way binding, and thats the greatest common subtype of
+ * statements bound and expression bound attributes.
+ *
+ * Naming here is important: "bound output" != "output binding." 
+ */
+class OutputBinding {
+  final OutputElement boundOutput;
+  final BoundAttributeInfo attribute;
+
+  OutputBinding(this.boundOutput, this.attribute);
 }
 
 /**
@@ -222,7 +276,10 @@ class ElementInfo extends NodeInfo implements HasDirectives {
   final bool isTemplate;
   final List<AttributeInfo> attributes;
   final TemplateAttribute templateAttribute;
-  List<AbstractDirective> directives = <AbstractDirective>[];
+  List<DirectiveBinding> boundDirectives = <DirectiveBinding>[];
+  List<OutputBinding> boundStandardOutputs = <OutputBinding>[];
+  List<AbstractDirective> get directives =>
+      boundDirectives.map((bd) => bd.boundDirective);
 
   ElementInfo(
       this.localName,

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -745,8 +745,8 @@ class PrepareEventScopeVisitor extends AngularScopeVisitor {
     DartType eventType = typeProvider.dynamicType;
     var matched = false;
 
-    for (AbstractDirective directive in directives) {
-      for (OutputElement output in directive.outputs) {
+    for (DirectiveBinding directiveBinding in attr.parent.boundDirectives) {
+      for (OutputElement output in directiveBinding.boundDirective.outputs) {
         //TODO what if this matches two directives?
         if (output.name == attr.name) {
           eventType = output.eventType;
@@ -754,6 +754,7 @@ class PrepareEventScopeVisitor extends AngularScopeVisitor {
           SourceRange range =
               new SourceRange(attr.nameOffset, attr.name.length);
           template.addRange(range, output);
+          directiveBinding.outputBindings.add(new OutputBinding(output, attr));
         }
       }
     }
@@ -766,6 +767,8 @@ class PrepareEventScopeVisitor extends AngularScopeVisitor {
         eventType = standardHtmlEvent.eventType;
         SourceRange range = new SourceRange(attr.nameOffset, attr.name.length);
         template.addRange(range, standardHtmlEvent);
+        attr.parent.boundStandardOutputs
+            .add(new OutputBinding(standardHtmlEvent, attr));
       }
     }
 
@@ -832,7 +835,7 @@ class DirectiveResolver extends AngularAstVisitor {
     for (AbstractDirective directive in allDirectives) {
       Selector selector = directive.selector;
       if (selector.match(elementView, template)) {
-        element.directives.add(directive);
+        element.boundDirectives.add(new DirectiveBinding(directive));
         if (selector is ElementNameSelector) {
           tagIsResolved = true;
         }
@@ -858,7 +861,7 @@ class DirectiveResolver extends AngularAstVisitor {
     ElementView elementView = new ElementViewImpl(attr.virtualAttributes, null);
     for (AbstractDirective directive in allDirectives) {
       if (directive.selector.match(elementView, template)) {
-        attr.directives.add(directive);
+        attr.boundDirectives.add(new DirectiveBinding(directive));
       }
     }
   }
@@ -980,11 +983,14 @@ class SingleScopeResolver extends AngularScopeVisitor {
           AngularWarningCode.TWO_WAY_BINDING_NOT_ASSIGNABLE));
     }
 
-    for (AbstractDirective directive in directives) {
-      for (OutputElement output in directive.outputs) {
+    for (DirectiveBinding directiveBinding
+        in attribute.parent.boundDirectives) {
+      for (OutputElement output in directiveBinding.boundDirective.outputs) {
         if (output.name == attribute.name + "Change") {
           outputMatched = true;
           var eventType = output.eventType;
+          directiveBinding.outputBindings
+              .add(new OutputBinding(output, attribute));
 
           // half-complete-code case: ensure the expression is actually there
           if (attribute.expression != null &&
@@ -1019,8 +1025,9 @@ class SingleScopeResolver extends AngularScopeVisitor {
   void _resolveInputBoundAttributeValues(ExpressionBoundAttribute attribute) {
     bool inputMatched = false;
 
-    for (AbstractDirective directive in directives) {
-      for (InputElement input in directive.inputs) {
+    for (DirectiveBinding directiveBinding
+        in attribute.parent.boundDirectives) {
+      for (InputElement input in directiveBinding.boundDirective.inputs) {
         if (input.name == attribute.name) {
           // half-complete-code case: ensure the expression is actually there
           if (attribute.expression != null) {
@@ -1040,6 +1047,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
           SourceRange range =
               new SourceRange(attribute.nameOffset, attribute.name.length);
           template.addRange(range, input);
+          directiveBinding.inputBindings
+              .add(new InputBinding(input, attribute));
 
           inputMatched = true;
         }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -451,6 +451,206 @@ class OtherComp {
         relevance: DART_RELEVANCE_DEFAULT - 1);
   }
 
+  test_completeInputNotSuggestedTwice() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag [name]="\'bob\'" ^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested("[name]");
+    assertSuggestGetter("(nameEvent)", "String");
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
+  }
+
+  test_completeInputSuggestsItself() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag [name^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestSetter("[name]");
+  }
+
+  test_completeOutputNotSuggestedTwice() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag (nameEvent)="" ^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestSetter("[name]");
+    assertNotSuggested("(nameEvent)");
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
+  }
+
+  test_completeOutputSuggestsItself() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag (nameEvent^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter("(nameEvent)", "String");
+  }
+
+  test_completeStdOutputNotSuggestedTwice() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag (click)="" ^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestSetter("[name]");
+    assertSuggestGetter("(nameEvent)", "String");
+    assertNotSuggested("(click)");
+  }
+
+  test_completeStdOutputSuggestsItself() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag (click^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
+  }
+
+  test_completeInputOutputNotSuggestedAfterTwoWay() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+  String name;
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameChange;
+}
+    ''');
+
+    addTestSource('<my-tag [(name)]="name" ^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested("[name]");
+    assertNotSuggested("(nameEvent)");
+  }
+
   test_completeInputStarted() async {
     Source dartSource = newSource(
         '/completionTest.dart',

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -447,6 +447,8 @@ class OtherComp {
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
     assertSuggestGetter("(nameEvent)", "String");
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
   }
 
   test_completeInputStarted() async {
@@ -475,6 +477,37 @@ class OtherComp {
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
     assertNotSuggested("(nameEvent)");
+    assertNotSuggested("(click)");
+  }
+
+  test_completeOutputStarted() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag (^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter("(nameEvent)", "String");
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
+    assertNotSuggested("[name]");
   }
 
   test_completeInputReplacing() async {
@@ -503,9 +536,10 @@ class OtherComp {
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
     assertNotSuggested("(nameEvent)");
+    assertNotSuggested("(click)");
   }
 
-  test_noCompleteInputInCloseTag() async {
+  test_completeOutputReplacing() async {
     Source dartSource = newSource(
         '/completionTest.dart',
         '''
@@ -517,6 +551,37 @@ class MyComp {
 @Component(template: '', selector: 'my-tag')
 class OtherComp {
   @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag (^output)="4"></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestGetter("(nameEvent)", "String");
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
+    assertNotSuggested("[name]");
+  }
+
+  test_noCompleteInOutputInCloseTag() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter event;
 }
     ''');
 
@@ -529,6 +594,7 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertNotSuggested("[name]");
+    assertNotSuggested("(event)");
   }
 
   test_noCompleteEmptyTagContents() async {
@@ -543,6 +609,7 @@ class MyComp {
 @Component(template: '', selector: 'my-tag')
 class OtherComp {
   @Input() String name;
+  @Output() EventEmitter event;
 }
     ''');
 
@@ -555,9 +622,10 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertNotSuggested("[name]");
+    assertNotSuggested("(event)");
   }
 
-  test_noCompleteInputsOnTagNameCompletion() async {
+  test_noCompleteInOutputsOnTagNameCompletion() async {
     Source dartSource = newSource(
         '/completionTest.dart',
         '''
@@ -569,6 +637,7 @@ class MyComp {
 @Component(template: '', selector: 'my-tag')
 class OtherComp {
   @Input() String name;
+  @Output() EventEmitter event;
 }
     ''');
 
@@ -581,5 +650,6 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertNotSuggested("[name]");
+    assertNotSuggested("(event)");
   }
 }


### PR DESCRIPTION
Suggest outputs in the middle of writing them.

Suggest events like click, mouseover, etc, all at lower priority than
other directive outputs, though ideally they would be at the same
priority on standard dom. Could adjust that later.

Tests that they are suggested at the right times at the right priority.