### PR TITLE
Fix issue #204 error when '<' is in binding.

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1161,6 +1161,11 @@ class SingleScopeResolver extends AngularScopeVisitor {
   void _resolveDartAstNode(AstNode astNode) {
     ClassElement classElement = view.classElement;
     LibraryElement library = classElement.library;
+    {
+      TypeResolverVisitor visitor = new TypeResolverVisitor(
+          library, view.source, typeProvider, errorListener);
+      astNode.accept(visitor);
+    }
     ResolverVisitor resolver = new ResolverVisitor(
         library, templateSource, typeProvider, errorListener);
     // fill the name scope

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2034,6 +2034,29 @@ class TestPanel {
     // no assertion...this throws in the github bug
   }
 
+  void test_angleBracketInMustacheNoCrash_githubBug204() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+''');
+    String code = r"""
+{{<}}
+    """;
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertErrorsWithCodes([
+      ParserErrorCode.EXPECTED_LIST_OR_MAP_LITERAL,
+      ParserErrorCode.EXPECTED_TOKEN,
+      ParserErrorCode.EXPECTED_TYPE_NAME,
+      StaticTypeWarningCode.NON_TYPE_AS_TYPE_ARGUMENT
+    ]);
+  }
+
   void _addDartSource(String code) {
     dartCode = '''
 import '/angular2/angular2.dart';


### PR DESCRIPTION
Missing resolution step compared to the regular resolution workflow.
Well, technically, we were missingtwo. But one of them: collecting
varibales, is not relevant to us.

This should be a good change for stability in general, though we
probably allow expression types we shouldn't like typed array list
literals that angular won't like.