### PR TITLE
Fix issue #199 option value not recognized

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1540,6 +1540,16 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   final Map<String, OutputElement> events;
   final Source source;
 
+  static const Map<String, String> specialElementClasses =
+      const <String, String>{
+    "OptionElement": 'option',
+    "DialogElementi": "dialog",
+    "MediaElement": "media",
+    "MenuItemElement": "menuitem",
+    "ModElement": "mod",
+    "PictureElement": "picture"
+  };
+
   ClassElement classElement;
 
   _BuildStandardHtmlComponentsVisitor(
@@ -1553,6 +1563,15 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
       List<OutputElement> outputElements = _buildOutputs(false);
       for (OutputElement outputElement in outputElements) {
         events[outputElement.name] = outputElement;
+      }
+    } else {
+      String specialTagName = specialElementClasses[classElement.name];
+      if (specialTagName != null) {
+        String tag = specialTagName;
+        // TODO any better offset we can do here?
+        int tagOffset = classElement.nameOffset + 'HTML'.length;
+        Component component = _buildComponent(tag, tagOffset);
+        components[tag] = component;
       }
     }
     classElement = null;

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1543,7 +1543,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   static const Map<String, String> specialElementClasses =
       const <String, String>{
     "OptionElement": 'option',
-    "DialogElementi": "dialog",
+    "DialogElement": "dialog",
     "MediaElement": "media",
     "MenuItemElement": "menuitem",
     "ModElement": "mod",

--- a/analyzer_plugin/test/mock_sdk.dart
+++ b/analyzer_plugin/test/mock_sdk.dart
@@ -246,6 +246,34 @@ class InputElement extends HtmlElement {
   String value;
   String validationMessage;
 }
+
+class OptionElement extends HtmlElement {                                        
+  factory OptionElement({String data: '', String value : '', bool selected: false}) {
+  }                                                                              
+                                                                                 
+  @DomName('HTMLOptionElement.HTMLOptionElement')                                
+  @DocsEditable()                                                                
+  factory OptionElement._([String data, String value, bool defaultSelected, bool selected]) {
+  }    
+}
+
+class TableSectionElement extends HtmlElement {
+
+  @DomName('HTMLTableSectionElement.rows')
+  List<TableRowElement> get rows => null;
+
+  TableRowElement addRow() {
+  }
+
+  TableRowElement insertRow(int index) => null;
+
+  factory TableSectionElement._() { throw new UnsupportedError("Not supported"); }
+
+  @Deprecated("Internal Use Only")
+  external static Type get instanceRuntimeType;
+
+  @Deprecated("Internal Use Only")
+  TableSectionElement.internal_() : super.internal_();
 ''');
 
   static const List<SdkLibrary> LIBRARIES = const [

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -38,6 +38,7 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
     List<Component> components = outputs[STANDARD_HTML_COMPONENTS];
     Map<String, Component> map = {};
     components.forEach((c) {
+      expect(c.classElement.name, isNot(equals("TableSectionElement")));
       map[c.selector.toString()] = c;
     });
     expect(map, isNotNull);
@@ -114,6 +115,8 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
     expect(map['h1'], isNotNull);
     expect(map['h2'], isNotNull);
     expect(map['h3'], isNotNull);
+    // has no mention of 'option' in the source, is hardcoded
+    expect(map['option'], isNotNull);
   }
 
   test_buildStandardHtmlEvents() {


### PR DESCRIPTION
Turns out that the option tag, as well as a few others, don't specify
their tagname anywhere in the source of the dartium html file we scan
to generate the standard html components, so it wasn't being recognized
as a component at all.

There's even one component in there that appears at first glance to be
an html component in the same boat, but it isn't. And there's a few
deprecated ones that are like that too. Skip those (testing the
former...the latter...that I care less about).

Just hardcoded a list, and tested that option works just to test that
my list takes effect. Could have tested the rest, but I don't usually
like it when test code and real code match up 1:1 like that would
appear.

Also modify the mock sdk to include the tested cases.