### PR TITLE
Implement issue #201 track global html attributes

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -90,6 +90,7 @@ class TemplateAttribute extends BoundAttributeInfo implements HasDirectives {
   final List<AttributeInfo> virtualAttributes;
   List<DirectiveBinding> boundDirectives = <DirectiveBinding>[];
   List<OutputBinding> boundStandardOutputs = <OutputBinding>[];
+  List<InputBinding> boundStandardInputs = <InputBinding>[];
   List<AbstractDirective> get directives =>
       boundDirectives.map((bd) => bd.boundDirective);
 
@@ -194,6 +195,7 @@ abstract class NodeInfo extends AngularAstNode {}
 abstract class HasDirectives {
   List<DirectiveBinding> get boundDirectives;
   List<OutputBinding> get boundStandardOutputs;
+  List<InputBinding> get boundStandardInputs;
 }
 
 /**
@@ -278,6 +280,7 @@ class ElementInfo extends NodeInfo implements HasDirectives {
   final TemplateAttribute templateAttribute;
   List<DirectiveBinding> boundDirectives = <DirectiveBinding>[];
   List<OutputBinding> boundStandardOutputs = <OutputBinding>[];
+  List<InputBinding> boundStandardInputs = <InputBinding>[];
   List<AbstractDirective> get directives =>
       boundDirectives.map((bd) => bd.boundDirective);
 

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -133,6 +133,17 @@ final ResultDescriptor<Map<String, OutputElement>>
         const <String, OutputElement>{});
 
 /**
+ * The standard HtmlElement [InputElement]s.
+ *
+ * This result is produced for the [AnalysisContext].
+ */
+final ResultDescriptor<Map<String, InputElement>>
+    STANDARD_HTML_ELEMENT_ATTRIBUTES =
+    new ResultDescriptor<Map<String, InputElement>>(
+        'ANGULAR_STANDARD_HTML_ELEMENT_ATTRIBUTES',
+        const <String, InputElement>{});
+
+/**
  * The [View]s with this HTML template file.
  *
  * The result is only available for HTML [Source]s.
@@ -178,7 +189,8 @@ class BuildStandardHtmlComponentsTask extends AnalysisTask {
       createTask,
       buildInputs, <ResultDescriptor>[
     STANDARD_HTML_COMPONENTS,
-    STANDARD_HTML_ELEMENT_EVENTS
+    STANDARD_HTML_ELEMENT_EVENTS,
+    STANDARD_HTML_ELEMENT_ATTRIBUTES
   ]);
 
   BuildStandardHtmlComponentsTask(
@@ -204,16 +216,18 @@ class BuildStandardHtmlComponentsTask extends AnalysisTask {
     //
     Map<String, Component> components = <String, Component>{};
     Map<String, OutputElement> events = <String, OutputElement>{};
+    Map<String, InputElement> attributes = <String, InputElement>{};
     for (ast.CompilationUnit unit in units) {
       Source source = unit.element.source;
-      unit.accept(
-          new _BuildStandardHtmlComponentsVisitor(components, events, source));
+      unit.accept(new _BuildStandardHtmlComponentsVisitor(
+          components, events, attributes, source));
     }
     //
     // Record outputs.
     //
     outputs[STANDARD_HTML_COMPONENTS] = components.values.toList();
     outputs[STANDARD_HTML_ELEMENT_EVENTS] = events;
+    outputs[STANDARD_HTML_ELEMENT_ATTRIBUTES] = attributes;
   }
 
   /**
@@ -1118,6 +1132,7 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
   static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
   static const String HTML_COMPONENTS_INPUT = 'HTML_COMPONENTS_INPUT';
   static const String HTML_EVENTS_INPUT = 'HTML_EVENTS_INPUT';
+  static const String HTML_ATTRIBUTES_INPUT = 'HTML_ATTRIBUTES_INPUT';
   static const String VIEWS_INPUT = 'VIEWS_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
@@ -1142,6 +1157,8 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
     TypeProvider typeProvider = getRequiredInput(TYPE_PROVIDER_INPUT);
     List<Component> htmlComponents = getRequiredInput(HTML_COMPONENTS_INPUT);
     Map<String, OutputElement> htmlEvents = getRequiredInput(HTML_EVENTS_INPUT);
+    Map<String, InputElement> htmlAttributes =
+        getRequiredInput(HTML_ATTRIBUTES_INPUT);
     List<View> views = getRequiredInput(VIEWS_INPUT);
     //
     // Resolve inline view templates.
@@ -1151,8 +1168,8 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
     for (View view in views) {
       if (view.templateText != null) {
         errorListener = new RecordingErrorListener();
-        Template template = new DartTemplateResolver(
-                typeProvider, htmlComponents, htmlEvents, errorListener, view)
+        Template template = new DartTemplateResolver(typeProvider,
+                htmlComponents, htmlEvents, htmlAttributes, errorListener, view)
             .resolve();
         if (template != null) {
           templates.add(template);
@@ -1180,6 +1197,8 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
           STANDARD_HTML_COMPONENTS.of(AnalysisContextTarget.request),
       HTML_EVENTS_INPUT:
           STANDARD_HTML_ELEMENT_EVENTS.of(AnalysisContextTarget.request),
+      HTML_ATTRIBUTES_INPUT:
+          STANDARD_HTML_ELEMENT_ATTRIBUTES.of(AnalysisContextTarget.request),
       VIEWS_INPUT: VIEWS.of(target),
     };
   }
@@ -1256,6 +1275,7 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
   static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
   static const String HTML_COMPONENTS_INPUT = 'HTML_COMPONENTS_INPUT';
   static const String HTML_EVENTS_INPUT = 'HTML_EVENTS_INPUT';
+  static const String HTML_ATTRIBUTES_INPUT = 'HTML_ATTRIBUTES_INPUT';
   static const String HTML_DOCUMENT_INPUT = 'HTML_DOCUMENT_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
@@ -1289,13 +1309,15 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
     TypeProvider typeProvider = getRequiredInput(TYPE_PROVIDER_INPUT);
     List<Component> htmlComponents = getRequiredInput(HTML_COMPONENTS_INPUT);
     Map<String, OutputElement> htmlEvents = getRequiredInput(HTML_EVENTS_INPUT);
+    Map<String, InputElement> htmlAttributes =
+        getRequiredInput(HTML_ATTRIBUTES_INPUT);
     html.Document document = getRequiredInput(HTML_DOCUMENT_INPUT);
     //
     // Resolve.
     //
     View view = target;
     Template template = new HtmlTemplateResolver(typeProvider, htmlComponents,
-            htmlEvents, errorListener, view, document)
+            htmlEvents, htmlAttributes, errorListener, view, document)
         .resolve();
     //
     // Record outputs.
@@ -1318,6 +1340,8 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
           STANDARD_HTML_COMPONENTS.of(AnalysisContextTarget.request),
       HTML_EVENTS_INPUT:
           STANDARD_HTML_ELEMENT_EVENTS.of(AnalysisContextTarget.request),
+      HTML_ATTRIBUTES_INPUT:
+          STANDARD_HTML_ELEMENT_ATTRIBUTES.of(AnalysisContextTarget.request),
       HTML_DOCUMENT_INPUT: HTML_DOCUMENT.of((target as View).templateUriSource),
     };
   }
@@ -1538,12 +1562,13 @@ class _AnnotationProcessorMixin {
 class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   final Map<String, Component> components;
   final Map<String, OutputElement> events;
+  final Map<String, InputElement> attributes;
   final Source source;
 
   ClassElement classElement;
 
   _BuildStandardHtmlComponentsVisitor(
-      this.components, this.events, this.source);
+      this.components, this.events, this.attributes, this.source);
 
   @override
   void visitClassDeclaration(ast.ClassDeclaration node) {
@@ -1553,6 +1578,10 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
       List<OutputElement> outputElements = _buildOutputs(false);
       for (OutputElement outputElement in outputElements) {
         events[outputElement.name] = outputElement;
+      }
+      List<InputElement> inputElements = _buildInputs(false);
+      for (InputElement inputElement in inputElements) {
+        attributes[inputElement.name] = inputElement;
       }
     }
     classElement = null;
@@ -1588,7 +1617,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
    * Return a new [Component] for the current [classElement].
    */
   Component _buildComponent(String tag, int tagOffset) {
-    List<InputElement> inputElements = _buildInputs();
+    List<InputElement> inputElements = _buildInputs(true);
     List<OutputElement> outputElements = _buildOutputs(true);
     return new Component(classElement,
         inputs: inputElements,
@@ -1597,7 +1626,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
             new SelectorName(tag, tagOffset, tag.length, source)));
   }
 
-  List<InputElement> _buildInputs() {
+  List<InputElement> _buildInputs(bool skipHtmlElement) {
     return _captureAspects(
         (Map<String, InputElement> inputMap, PropertyAccessorElement accessor) {
       String name = accessor.displayName;
@@ -1613,7 +1642,7 @@ class _BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
               accessor.variable.type);
         }
       }
-    }, false); // don't skip HtmlElement+ inputs, those belong to this component.
+    }, skipHtmlElement); // Either grabbing HtmlElement attrs or skipping them
   }
 
   List<OutputElement> _buildOutputs(bool skipHtmlElement) {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -171,6 +171,28 @@ class TitleComponent {
     expect(boundDirective.inputBindings.first.boundInput.name, 'title');
   }
 
+  void test_expression_nativeGlobalAttrBindingOnComponent() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: [SomeComponent])
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+
+@Component(selector: 'some-comp', template: '')
+class SomeComponent {
+}
+''');
+    _addHtmlSource(r"""
+<some-comp [hidden]='false'></some-comp>
+""");
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+    _assertElement('hidden').input.inCoreHtml;
+  }
+
   void test_expression_inputBinding_typeError() {
     _addDartSource(r'''
 @Component(selector: 'test-panel',

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -55,12 +55,6 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input.setter, isNotNull);
         expect(input.setterType.toString(), equals("String"));
       }
-      {
-        InputElement input = inputs.singleWhere((i) => i.name == 'tabIndex');
-        expect(input, isNotNull);
-        expect(input.setter, isNotNull);
-        expect(input.setterType.toString(), equals("int"));
-      }
       expect(outputElements, hasLength(0));
       expect(inputs.where((i) => i.name == '_privateField'), hasLength(0));
     }
@@ -77,12 +71,6 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
         expect(input, isNotNull);
         expect(input.setter, isNotNull);
         expect(input.setterType.toString(), equals("bool"));
-      }
-      {
-        InputElement input = inputs.singleWhere((i) => i.name == 'tabIndex');
-        expect(input, isNotNull);
-        expect(input.setter, isNotNull);
-        expect(input.setterType.toString(), equals("int"));
       }
       expect(outputElements, hasLength(0));
     }
@@ -158,6 +146,27 @@ class BuildStandardHtmlComponentsTaskTest extends AbstractAngularTest {
       // used to happen from "hidden" which got truncated by 'on'.length
       OutputElement outputElement = outputElements['dden'];
       expect(outputElement, isNull);
+    }
+  }
+
+  test_buildStandardHtmlAttributes() {
+    computeResult(
+        AnalysisContextTarget.request, STANDARD_HTML_ELEMENT_ATTRIBUTES);
+    expect(task, new isInstanceOf<BuildStandardHtmlComponentsTask>());
+    // validate
+    Map<String, InputElement> inputElements =
+        outputs[STANDARD_HTML_ELEMENT_ATTRIBUTES];
+    {
+      InputElement input = inputElements['tabIndex'];
+      expect(input, isNotNull);
+      expect(input.setter, isNotNull);
+      expect(input.setterType.toString(), equals("int"));
+    }
+    {
+      InputElement input = inputElements['hidden'];
+      expect(input, isNotNull);
+      expect(input.setter, isNotNull);
+      expect(input.setterType.toString(), equals("bool"));
     }
   }
 }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -446,6 +446,7 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
+    assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertSuggestGetter("(nameEvent)", "String");
     assertSuggestGetter("(click)", "MouseEvent",
         relevance: DART_RELEVANCE_DEFAULT - 1);
@@ -481,6 +482,37 @@ class OtherComp {
         relevance: DART_RELEVANCE_DEFAULT - 1);
   }
 
+  test_completeStandardInputNotSuggestedTwice() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag [hidden]="true" ^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested("[hidden]");
+    assertSuggestSetter("[name]");
+    assertSuggestGetter("(nameEvent)", "String");
+    assertSuggestGetter("(click)", "MouseEvent",
+        relevance: DART_RELEVANCE_DEFAULT - 1);
+  }
+
   test_completeInputSuggestsItself() async {
     Source dartSource = newSource(
         '/completionTest.dart',
@@ -508,6 +540,33 @@ class OtherComp {
     assertSuggestSetter("[name]");
   }
 
+  test_completeStandardInputSuggestsItself() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [OtherComp])
+class MyComp {
+}
+@Component(template: '', selector: 'my-tag')
+class OtherComp {
+  @Input() String name;
+  @Output() EventEmitter<String> nameEvent;
+}
+    ''');
+
+    addTestSource('<my-tag [hidden^></my-tag>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
+  }
+
   test_completeOutputNotSuggestedTwice() async {
     Source dartSource = newSource(
         '/completionTest.dart',
@@ -533,6 +592,7 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
+    assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertNotSuggested("(nameEvent)");
     assertSuggestGetter("(click)", "MouseEvent",
         relevance: DART_RELEVANCE_DEFAULT - 1);
@@ -590,6 +650,7 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
+    assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertSuggestGetter("(nameEvent)", "String");
     assertNotSuggested("(click)");
   }
@@ -676,6 +737,7 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
+    assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertNotSuggested("(nameEvent)");
     assertNotSuggested("(click)");
   }
@@ -735,6 +797,7 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertSuggestSetter("[name]");
+    assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertNotSuggested("(nameEvent)");
     assertNotSuggested("(click)");
   }
@@ -794,7 +857,9 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertNotSuggested("[name]");
+    assertNotSuggested("[hidden]");
     assertNotSuggested("(event)");
+    assertNotSuggested("(click)");
   }
 
   test_noCompleteEmptyTagContents() async {
@@ -822,7 +887,9 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertNotSuggested("[name]");
+    assertNotSuggested("[hidden]");
     assertNotSuggested("(event)");
+    assertNotSuggested("(click)");
   }
 
   test_noCompleteInOutputsOnTagNameCompletion() async {
@@ -850,6 +917,8 @@ class OtherComp {
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
     assertNotSuggested("[name]");
+    assertNotSuggested("[hidden]");
     assertNotSuggested("(event)");
+    assertNotSuggested("(click)");
   }
 }

--- a/server_plugin/test/mock_sdk.dart
+++ b/server_plugin/test/mock_sdk.dart
@@ -184,6 +184,8 @@ abstract class ElementStream<T extends Event> implements Stream<T> {}
 class HtmlElement {
   @DomName('Element.onclick')
   ElementStream<MouseEvent> get onClick => null;
+  @DomName('Element.hidden')
+  bool hidden;
 }
 
 class ButtonElement extends HtmlElement {


### PR DESCRIPTION
They can be used on components now and are scraped from the dartium
html source, just like standard html events.

Autocomplete them at a lower priority just like standard html events.