### PR TITLE
Fix issue #213 crashing *#h1 attribute

### DIFF
--- a/analyzer_plugin/lib/src/converter.dart
+++ b/analyzer_plugin/lib/src/converter.dart
@@ -122,8 +122,8 @@ class HtmlTreeConverter {
   TemplateAttribute _convertTemplateAttribute(
       html.Element element, String origName, bool starSugar) {
     int origNameOffset = _nameOffset(element, origName);
-    String value = element.attributes[origName];
     int valueOffset = _valueOffset(element, origName);
+    String value = valueOffset == null ? null : element.attributes[origName];
     String name;
     int nameOffset;
     List<AttributeInfo> virtualAttributes;
@@ -131,7 +131,7 @@ class HtmlTreeConverter {
       nameOffset = origNameOffset + '*'.length;
       name = _removePrefixSuffix(origName, '*', null);
       virtualAttributes = dartParser.parseTemplateVirtualAttributes(
-          nameOffset, name + (' ' * '="'.length) + value);
+          nameOffset, name + (' ' * '="'.length) + (value ?? ''));
     } else {
       name = origName;
       nameOffset = origNameOffset;

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -1501,6 +1501,25 @@ class TestPanel {}
     _assertElement("aaa}}").dart.getter.at('aaa; // 1');
   }
 
+  void test_erroroneousTemplate_starHash_noCrash() {
+    _addDartSource(r'''
+import 'dart:html';
+
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+  void handleClick(Element e) {}
+}
+''');
+    _addHtmlSource(r"""
+<h1 (click)='handleClick(myTargetElement)'>
+  <div *#myTargetElement></div>
+</h1>
+""");
+    _resolveSingleTemplate(dartSource);
+    // no assertion. Just don't crash.
+  }
+
   void test_localVariable_exportAs_notFound() {
     _addDartSource(r'''
 @Component(selector: 'test-panel')


### PR DESCRIPTION
Looks like 'value' is emptystr for templateAttributes without a value,
but valueOffset is null. Therefore later code sees the value as
existing but erroneous, and reports an error but the error can't be
hashed since it contains a null.

This is already specifically avoided inside text attributes, expression
attributes, and statement attributes. Now in template attributes too.

Of course, `<h1 *#h1></h1>` seems to cause angular to crash, but it
should actually be valid as the desugared form `<h1 template="#h1"></h1>`
is valid. (and so is the further desugared form `<template #h1><h1>...`).
But we report an error anyways: 'did you mean let?'. So while I don't
want to assert that error or a different one, I do want to assert it
doesn't crash, so that's all the test does even though 'no crash' tests
are usually considered an antipattern/code smell.

Lastly make sure you don't concat 'null' in desugaring the template,
ie, parsing `<h1 template="#h1 null">`. Was empty string before, which
is what we need to keep.