### PR TITLE
Fix #210 and #205 and probably more -- trying to resolve unfitting ASTs

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1352,6 +1352,13 @@ class AngularErrorVerifier extends ErrorVerifier
         super(errorReporter, library, typeProvider, inheritanceManager, false);
 
   @override
+  Object visitFunctionExpression(FunctionExpression exp) {
+    // error reported in [AngularResolverVisitor] but [ErrorVerifier] crashes
+    // because it isn't resolved
+    return null;
+  }
+
+  @override
   Object visitRethrowExpression(RethrowExpression exp) =>
       _reportUnacceptableNode(exp, "Rethrow");
 

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1159,7 +1159,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
   /**
    * Resolve the given [AstNode] ([expression] or [statement]) and report errors.
    */
-  void _resolveDartAstNode(AstNode astNode) {
+  void _resolveDartAstNode(AstNode astNode, bool acceptAssignment) {
     ClassElement classElement = view.classElement;
     LibraryElement library = classElement.library;
     {
@@ -1167,8 +1167,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
           library, view.source, typeProvider, errorListener);
       astNode.accept(visitor);
     }
-    ResolverVisitor resolver = new ResolverVisitor(
-        library, templateSource, typeProvider, errorListener);
+    ResolverVisitor resolver = new AngularResolverVisitor(
+        library, templateSource, typeProvider, errorListener, acceptAssignment);
     // fill the name scope
     ClassScope classScope = new ClassScope(resolver.nameScope, classElement);
     EnclosedScope localScope = new EnclosedScope(classScope);
@@ -1180,8 +1180,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
     // do resolve
     astNode.accept(resolver);
     // verify
-    ErrorVerifier verifier = new ErrorVerifier(errorReporter, library,
-        typeProvider, new InheritanceManager(library), false);
+    ErrorVerifier verifier = new AngularErrorVerifier(
+        errorReporter, library, typeProvider, new InheritanceManager(library));
     astNode.accept(verifier);
   }
 
@@ -1190,7 +1190,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
    */
   _resolveDartExpression(Expression expression) {
     if (expression != null) {
-      _resolveDartAstNode(expression);
+      _resolveDartAstNode(expression, false);
     }
   }
 
@@ -1209,7 +1209,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
             AngularWarningCode.OUTPUT_STATEMENT_REQUIRES_EXPRESSION_STATEMENT,
             [_getOutputStatementErrorDescription(statement)]));
       } else {
-        _resolveDartAstNode(statement);
+        _resolveDartAstNode(statement, true);
       }
     }
   }
@@ -1241,5 +1241,148 @@ class SingleScopeResolver extends AngularScopeVisitor {
     if (astNode != null) {
       astNode.accept(new _DartReferencesRecorder(template, dartVariables));
     }
+  }
+}
+
+/**
+ * Workaround for "This mixin application is invalid because all of the
+ * constructors in the base class 'ResolverVisitor' have optional parameters."
+ * in the definition of [AngularResolverVisitor].
+ *
+ * See https://github.com/dart-lang/sdk/issues/15101 for details
+ */
+class _IntermediateResolverVisitor extends ResolverVisitor {
+  _IntermediateResolverVisitor(LibraryElement library, Source source,
+      TypeProvider typeProvider, AnalysisErrorListener errorListener)
+      : super(library, source, typeProvider, errorListener);
+}
+
+/**
+ * Override the standard [ResolverVisitor] class to report unacceptable nodes,
+ * while suppressing secondary errors that would have been raised by
+ * [ResolverVisitor] if we let it see the bogus definitions.
+ */
+class AngularResolverVisitor extends _IntermediateResolverVisitor
+    with ReportUnacceptableNodesMixin {
+  final bool acceptAssignment;
+
+  AngularResolverVisitor(
+      LibraryElement library,
+      Source source,
+      TypeProvider typeProvider,
+      AnalysisErrorListener errorListener,
+      this.acceptAssignment)
+      : super(library, source, typeProvider, errorListener);
+
+  @override
+  Object visitAsExpression(AsExpression exp) {
+    // This means we generated this in a pipe, and its OK.
+    if (exp.asOperator.offset == 0) {
+      return super.visitAsExpression(exp);
+    } else {
+      return _reportUnacceptableNode(exp, "As expression");
+    }
+  }
+
+  @override
+  Object visitIsExpression(IsExpression exp) =>
+      _reportUnacceptableNode(exp, "Is expression");
+
+  @override
+  Object visitThrowExpression(ThrowExpression exp) =>
+      _reportUnacceptableNode(exp, "Throw");
+
+  @override
+  Object visitSuperExpression(SuperExpression exp) =>
+      _reportUnacceptableNode(exp, "Super references");
+
+  @override
+  Object visitAssignmentExpression(AssignmentExpression exp) {
+    // Only block reassignment of locals, not poperties. Resolve elements to
+    // check that.
+    exp.leftHandSide.accept(elementResolver);
+    VariableElement element = getOverridableStaticElement(exp.leftHandSide) ??
+        getOverridablePropagatedElement(exp.leftHandSide);
+    if ((element == null || element is PropertyInducingElement) &&
+        acceptAssignment) {
+      return super.visitAssignmentExpression(exp);
+    } else {
+      _reportUnacceptableNode(exp, "Assignment of locals");
+      return null;
+    }
+  }
+
+  @override
+  Object visitCascadeExpression(CascadeExpression exp) =>
+      _reportUnacceptableNode(exp, "Cascades");
+
+  @override
+  Object visitAwaitExpression(AwaitExpression exp) =>
+      _reportUnacceptableNode(exp, "Await");
+
+  @override
+  Object visitFunctionExpression(FunctionExpression exp) =>
+      _reportUnacceptableNode(exp, "Anonymous functions");
+
+  @override
+  Object visitSymbolLiteral(SymbolLiteral exp) =>
+      _reportUnacceptableNode(exp, "Symbol literal");
+
+  @override
+  Object visitNamedExpression(NamedExpression exp) =>
+      _reportUnacceptableNode(exp, "Named arguments");
+}
+
+/**
+ * Override the standard [ErrorVerifier] class to report unacceptable nodes,
+ * while suppressing secondary errors that would have been raised by
+ * [ErrorVerifier] if we let it see the bogus definitions.
+ */
+class AngularErrorVerifier extends ErrorVerifier
+    with ReportUnacceptableNodesMixin {
+  ErrorReporter errorReporter;
+  AngularErrorVerifier(ErrorReporter errorReporter, LibraryElement library,
+      TypeProvider typeProvider, InheritanceManager inheritanceManager)
+      : errorReporter = errorReporter,
+        super(errorReporter, library, typeProvider, inheritanceManager, false);
+
+  @override
+  Object visitRethrowExpression(RethrowExpression exp) =>
+      _reportUnacceptableNode(exp, "Rethrow");
+
+  @override
+  Object visitThisExpression(ThisExpression exp) =>
+      _reportUnacceptableNode(exp, "This references");
+
+  @override
+  Object visitListLiteral(ListLiteral list) {
+    if (list.typeArguments != null) {
+      _reportUnacceptableNode(list, "Typed list literals");
+      return null;
+    } else {
+      return super.visitListLiteral(list);
+    }
+  }
+
+  @override
+  Object visitMapLiteral(MapLiteral map) {
+    if (map.typeArguments != null) {
+      _reportUnacceptableNode(map, "Typed map literals");
+      return null;
+    } else {
+      return super.visitMapLiteral(map);
+    }
+  }
+
+  @override
+  Object visitInstanceCreationExpression(InstanceCreationExpression exp) =>
+      _reportUnacceptableNode(exp, "Usage of new");
+}
+
+abstract class ReportUnacceptableNodesMixin {
+  ErrorReporter get errorReporter;
+  void _reportUnacceptableNode(AstNode node, String description) {
+    errorReporter.reportErrorForNode(
+        AngularWarningCode.DISALLOWED_EXPRESSION, node, [description]);
   }
 }

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -281,6 +281,14 @@ class AngularWarningCode extends ErrorCode {
           "Syntax Error: unexpected {0}");
 
   /**
+   * An error code indicating that a mustache or other expression binding was an
+   * unsupported type such as an 'as' expression or a constructor
+   */
+  static const AngularWarningCode DISALLOWED_EXPRESSION =
+      const AngularWarningCode(
+          'DISALLOWED_EXPRESSION', "{0} not allowed in angular templates");
+
+  /**
    * An error code indicating that an output-bound statement
    * must be an [ExpressionStatement].
    */

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -628,6 +628,22 @@ class TestPanel {
         AngularWarningCode.DISALLOWED_EXPRESSION, code, "h1 = 4");
   }
 
+  void test_expression_invocation_of_erroneous_assignment_no_crash() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+{{str = 4()}}
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str = 4()");
+  }
+
   void test_statements_setter_allowed() {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -633,15 +633,16 @@ class TestPanel {
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')
 class TestPanel {
   String str;
+  Function f;
 }
 ''');
     var code = r"""
-{{str = 4()}}
+{{str = (f)()}}
 """;
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);
     assertErrorInCodeAtPosition(
-        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str = 4()");
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str = (f)()");
   }
 
   void test_statements_setter_allowed() {
@@ -732,6 +733,22 @@ class TestPanel {
 ''');
     var code = r"""
 <h1 [hidden]="#symbol"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "#symbol");
+  }
+
+  void test_expression_symbol_invoked_noCrash() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="#symbol()"></h1>
 """;
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -532,6 +532,312 @@ class TestPanel {
         AngularWarningCode.UNOPENED_MUSTACHE, code, "}}");
   }
 
+  void test_expression_as_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1>{{str as String}}</h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str as String");
+  }
+
+  void test_expression_nested_as_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1>{{(str.isEmpty as String).isEmpty}}</h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(AngularWarningCode.DISALLOWED_EXPRESSION, code,
+        "str.isEmpty as String");
+  }
+
+  void test_expression_typed_list_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="<String>[].isEmpty"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "<String>[]");
+  }
+
+  void test_expression_setter_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="str = 'hey'"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str = 'hey'");
+  }
+
+  void test_expression_assignment_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 #h1 [hidden]="h1 = 4"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "h1 = 4");
+  }
+
+  void test_statements_assignment_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 #h1 (click)="h1 = 4"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "h1 = 4");
+  }
+
+  void test_statements_setter_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 #h1 (click)="str = 'hey'"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_expression_is_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="str is int"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str is int");
+  }
+
+  void test_expression_typed_map_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="<String, String>{}.keys.isEmpty"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "<String, String>{}");
+  }
+
+  void test_expression_func_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="(){}"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "(){}");
+  }
+
+  void test_expression_symbol_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="#symbol"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "#symbol");
+  }
+
+  void test_expression_await_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="await str"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    //This actually gets parsed as an identifier, which is OK. Still fails!
+    errorListener.assertErrorsWithCodes([
+      StaticWarningCode.UNDEFINED_IDENTIFIER,
+      AngularWarningCode.TRAILING_EXPRESSION
+    ]);
+  }
+
+  void test_expression_throw_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="throw str"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "throw str");
+  }
+
+  void test_expression_cascade_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="str..x"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "str..x");
+  }
+
+  void test_expression_new_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="new String().isEmpty"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "new String()");
+  }
+
+  void test_expression_named_args_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  bool callMe({String arg}) => true;
+}
+''');
+    var code = r"""
+<h1 [hidden]="callMe(arg: 'bob')"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "arg: 'bob'");
+  }
+
+  void test_expression_rethrow_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="rethrow"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "rethrow");
+  }
+
+  void test_expression_super_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="super.x"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "super");
+  }
+
+  void test_expression_this_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="this"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "this");
+  }
+
   void test_expression_attrBinding_valid() {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')
@@ -2090,7 +2396,8 @@ class TestPanel {
       ParserErrorCode.EXPECTED_LIST_OR_MAP_LITERAL,
       ParserErrorCode.EXPECTED_TOKEN,
       ParserErrorCode.EXPECTED_TYPE_NAME,
-      StaticTypeWarningCode.NON_TYPE_AS_TYPE_ARGUMENT
+      StaticTypeWarningCode.NON_TYPE_AS_TYPE_ARGUMENT,
+      AngularWarningCode.DISALLOWED_EXPRESSION
     ]);
   }
 

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -707,6 +707,22 @@ class TestPanel {
         AngularWarningCode.DISALLOWED_EXPRESSION, code, "(){}");
   }
 
+  void test_expression_func2_not_allowed() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+  String str;
+}
+''');
+    var code = r"""
+<h1 [hidden]="()=>x"></h1>
+""";
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.DISALLOWED_EXPRESSION, code, "()=>x");
+  }
+
   void test_expression_symbol_not_allowed() {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')


### PR DESCRIPTION
Not all of the dart AST is acceptable inside expressions in templates,
and some of the unacceptable ones were resulting in errors. We also
weren't reporting errors for types of things that didn't work inside
angular anyway.

Now catch:

* named arguments
* typed map & list literals (previously caused internal crash)
* anonymous function (#205)
* overriding locals (#210)
* overriding members in expressions (angular disallows this)
* symbols
* throw/rethrow
* new
* is & as
* double dot cascade operations
* this/super
* await (tests at least, already was treated as an identifier)

Also keep our pipes solution working which relied on creating
`AsExpression`s which I'm now blocking. Use the obviously synthetic
offset 0 to detect and let that through.

Fixing overriding of locals was messy. Went off of what the resolver
did: passed the element resolver into the left hand side and inspected
the result to see if it was a property or missing, otherwise block it
since that was causing the exception behind #210.