### PR TITLE
Fix issue #220 *deferred error. Change ngFor autocomplete strategy

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -52,37 +52,40 @@ abstract class AttributeInfo extends AngularAstNode {
   final String value;
   final int valueOffset;
 
-  int get offset => nameOffset;
-  int get length => valueOffset == null
-      ? name.length
-      : valueOffset + value.length - nameOffset;
+  final String originalName;
+  final int originalNameOffset;
 
-  AttributeInfo(this.name, this.nameOffset, this.value, this.valueOffset);
+  int get offset => originalNameOffset;
+  int get length => valueOffset == null
+      ? originalName.length
+      : valueOffset + value.length - originalNameOffset;
+
+  AttributeInfo(this.name, this.nameOffset, this.value, this.valueOffset,
+      this.originalName, this.originalNameOffset);
 
   int get valueLength => value != null ? value.length : 0;
 
   @override
   String toString() {
-    return '([$name, $nameOffset], [$value, $valueOffset, $valueLength])';
+    return '([$name, $nameOffset], [$value, $valueOffset, $valueLength], ' +
+        '[$originalName, $originalNameOffset])';
   }
 }
 
 abstract class BoundAttributeInfo extends AttributeInfo {
-  final String originalName;
-  final int originalNameOffset;
-
   Map<String, LocalVariable> localVariables =
       new HashMap<String, LocalVariable>();
 
   BoundAttributeInfo(String name, int nameOffset, String value, int valueOffset,
-      this.originalName, this.originalNameOffset)
-      : super(name, nameOffset, value, valueOffset);
+      String originalName, int originalNameOffset)
+      : super(name, nameOffset, value, valueOffset, originalName,
+            originalNameOffset);
 
   List<AngularAstNode> get children => const <AngularAstNode>[];
 
   @override
   String toString() {
-    return '(' + super.toString() + ', [$originalName, $originalNameOffset])';
+    return '(' + super.toString() + ', [$children])';
   }
 }
 
@@ -162,7 +165,18 @@ class TextAttribute extends AttributeInfo {
 
   TextAttribute(String name, int nameOffset, String value, int valueOffset,
       this.mustaches)
-      : super(name, nameOffset, value, valueOffset);
+      : super(name, nameOffset, value, valueOffset, name, nameOffset);
+
+  TextAttribute.synthetic(
+      String name,
+      int nameOffset,
+      String value,
+      int valueOffset,
+      String originalName,
+      int originalNameOffset,
+      this.mustaches)
+      : super(name, nameOffset, value, valueOffset, originalName,
+            originalNameOffset);
 
   void accept(AngularAstVisitor visitor) => visitor.visitTextAttr(this);
 }

--- a/analyzer_plugin/lib/src/converter.dart
+++ b/analyzer_plugin/lib/src/converter.dart
@@ -460,16 +460,22 @@ class EmbeddedDartParser {
           errorReporter.reportErrorForToken(
               AngularWarningCode.UNEXPECTED_HASH_IN_TEMPLATE, token);
         }
+        int originalVarOffset = token.offset;
+        String originalName = token.lexeme;
         token = token.next;
         // get the local variable name
+        String localVarName = "";
+        int localVarOffset = token.offset;
         if (!_tokenMatchesIdentifier(token)) {
           errorReporter.reportErrorForToken(
               AngularWarningCode.EXPECTED_IDENTIFIER, token);
-          break;
+        } else {
+          localVarOffset = token.offset;
+          localVarName = token.lexeme;
+          originalName +=
+              ' ' * (token.offset - originalVarOffset) + localVarName;
+          token = token.next;
         }
-        int localVarOffset = token.offset;
-        String localVarName = token.lexeme;
-        token = token.next;
         // get an optional internal variable
         int internalVarOffset = null;
         String internalVarName = null;
@@ -487,11 +493,13 @@ class EmbeddedDartParser {
         }
         // declare the local variable
         // Note the care that the varname's offset is preserved in place.
-        attributes.add(new TextAttribute(
+        attributes.add(new TextAttribute.synthetic(
             'let-$localVarName',
             localVarOffset - 'let-'.length,
             internalVarName,
-            internalVarOffset, []));
+            internalVarOffset,
+            originalName,
+            originalVarOffset, []));
         continue;
       }
       // key

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2429,6 +2429,7 @@ class TestPanel {}
 """);
     _resolveSingleTemplate(dartSource);
     _assertElement('deferred-content>').selector.at("deferred-content]')");
+    errorListener.assertNoErrors();
   }
 
   void test_textInterpolation() {

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -8,10 +8,13 @@ import 'package:analysis_server/src/provisional/completion/dart/completion_dart.
 import 'package:analysis_server/src/services/completion/dart/optype.dart';
 import 'package:analysis_server/src/services/completion/dart/type_member_contributor.dart';
 import 'package:analysis_server/src/services/completion/dart/inherited_reference_contributor.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/task/dart.dart';
 import 'package:analyzer/task/model.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/tasks.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
@@ -50,6 +53,7 @@ class DartSnippetExtractor extends AngularAstVisitor {
   // don't recurse, findTarget already did that
   @override
   visitElementInfo(ElementInfo element) {}
+
   @override
   visitTextAttr(TextAttribute attr) {}
 
@@ -78,6 +82,32 @@ class DartSnippetExtractor extends AngularAstVisitor {
       dartSnippet = mustache.expression;
     }
   }
+
+  @override
+  visitTemplateAttr(TemplateAttribute attr) {
+    // if we visit this, we're in a template but after one of its attributes.
+    TextAttribute textAttributeToTreatAsInput;
+    for (AttributeInfo subAttribute in attr.virtualAttributes) {
+      if (subAttribute is TextAttribute &&
+          subAttribute.valueOffset == null &&
+          subAttribute.offset < offset) {
+        textAttributeToTreatAsInput = subAttribute;
+      }
+    }
+
+    if (textAttributeToTreatAsInput != null) {
+      AnalysisErrorListener analysisErrorListener =
+          new IgnoringAnalysisErrorListener();
+      EmbeddedDartParser dartParser =
+          new EmbeddedDartParser(null, analysisErrorListener, null, null);
+      dartSnippet = dartParser.parseDartExpression(offset, '', false);
+    }
+  }
+}
+
+class IgnoringAnalysisErrorListener implements AnalysisErrorListener {
+  @override
+  void onError(AnalysisError error) {}
 }
 
 class LocalVariablesExtractor extends AngularAstVisitor {

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -86,16 +86,16 @@ class DartSnippetExtractor extends AngularAstVisitor {
   @override
   visitTemplateAttr(TemplateAttribute attr) {
     // if we visit this, we're in a template but after one of its attributes.
-    TextAttribute textAttributeToTreatAsInput;
+    AttributeInfo attributeToAppendTo;
     for (AttributeInfo subAttribute in attr.virtualAttributes) {
-      if (subAttribute is TextAttribute &&
-          subAttribute.valueOffset == null &&
-          subAttribute.offset < offset) {
-        textAttributeToTreatAsInput = subAttribute;
+      if (subAttribute.valueOffset == null && subAttribute.offset < offset) {
+        attributeToAppendTo = subAttribute;
       }
     }
 
-    if (textAttributeToTreatAsInput != null) {
+    if (attributeToAppendTo != null &&
+        attributeToAppendTo is TextAttribute &&
+        !attributeToAppendTo.name.startsWith("let")) {
       AnalysisErrorListener analysisErrorListener =
           new IgnoringAnalysisErrorListener();
       EmbeddedDartParser dartParser =

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -242,6 +242,116 @@ class MyComp {
     assertSuggestGetter('hashCode', 'int');
   }
 
+  test_noCompleteMemberInNgForRightAfterLet() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let^ item of [text]"></div>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested('text');
+  }
+
+  test_noCompleteMemberInNgForInLet() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('<div *ngFor="l^et item of [text]"></div>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested('text');
+  }
+
+  test_noCompleteMemberInNgForAfterLettedName() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let item^ of [text]"></div>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested('text');
+  }
+
+  test_noCompleteMemberInNgForInLettedName() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let i^tem of [text]"></div>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested('text');
+  }
+
+  test_noCompleteMemberInNgFor_forLettedName() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let ^"></div>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested('text');
+  }
+
   test_completeNgForItem() async {
     Source dartSource = newSource(
         '/completionTest.dart',


### PR DESCRIPTION
Previously I had made ngFor="let x of " try to parse a statement after
"of". Unfortunately, this is not actually a valid parsing requirement
(though it does indicate an issue, that's for a linter to raise, or for
us to raise in tandem with special ngFor detection, because in a general
sense it could be valid).

Also noticed that "*structuralDirective="let x; attr; attr;" would be
reported wrong while messing with the idea of treating *deferred as
*deferred=";" to suppress the error. Left that fix in.

Once we don't report "of" itself as a syntactic error (it isn't as said
above), then we no longer have a partial expression for
DartSnippetExtractor to pick up. So instead, inside DartSnippetExtractor
we look for TextAttributes that could be intended to become
ExpressionBoundAttributes, and create an expression to pass to the dart
completer when that happens.

In the process of doing that, found some issues with findTarget in the
presence of stars. Firstly, name, value, and originalName were getting
all messed up, which I fixed. Secondly, the name length isn't actually
based on the length of the name, as in the case of ngForOf which is
seven characters but only appears as "of" in the template with a length
of two. Therefore I made sure that findTarget goes off of originalName,
and that originalName is correct in the virtual attributes.

Now with text attributes having a separate name/original name, all
attributes do (templates for the possible star, inputs and outputs for
the brackets, and text for the sugar in a star). Therefore move the
orgiinalName back into AttributeInfo from the previous base class
BoundAttributeInfo. But keep that around because of the children
property it has.

Autocompleting dart inside ngFor definitely got a bit funky, but I
think it is doable for now.