### PR TITLE
Solve issue #223 supply completion replacement length & offset

### DIFF
--- a/analyzer_plugin/lib/src/ignoring_error_listener.dart
+++ b/analyzer_plugin/lib/src/ignoring_error_listener.dart
@@ -1,0 +1,7 @@
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/listener.dart';
+
+class IgnoringAnalysisErrorListener implements AnalysisErrorListener {
+  @override
+  void onError(AnalysisError error) {}
+}

--- a/server_plugin/lib/plugin.dart
+++ b/server_plugin/lib/plugin.dart
@@ -4,7 +4,6 @@ import 'package:analysis_server/plugin/analysis/analysis_domain.dart';
 import 'package:analysis_server/plugin/analysis/navigation/navigation.dart';
 import 'package:analysis_server/plugin/analysis/occurrences/occurrences.dart';
 import 'package:analysis_server/src/provisional/completion/completion.dart';
-import 'package:analysis_server/src/provisional/completion/dart/completion.dart';
 import 'package:angular_analyzer_server_plugin/src/analysis.dart';
 import 'package:angular_analyzer_server_plugin/src/completion.dart';
 import 'package:plugin/plugin.dart';
@@ -35,7 +34,7 @@ class AngularServerPlugin implements Plugin {
         new AngularOccurrencesContributor());
     registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
         () => new AngularTemplateCompletionContributor());
-    registerExtension(DART_COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
+    registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
         () => new AngularDartCompletionContributor());
   }
 }

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -129,10 +129,10 @@ class ReplacementRangeCalculator extends AngularAstVisitor {
     if (element.openingSpan == null) {
       return;
     }
-    if (offsetContained(
-        request.offset,
-        element.openingNameSpan.offset - '<'.length,
-        element.openingNameSpan.length + '<'.length)) {
+    int nameSpanEnd =
+        element.openingNameSpan.offset + element.openingNameSpan.length;
+    if (offsetContained(request.offset, element.openingSpan.offset,
+        nameSpanEnd - element.openingSpan.offset)) {
       request.replacementOffset = element.openingSpan.offset;
       request.replacementLength = element.localName.length + 1;
     }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -16,8 +16,7 @@ main() {
 }
 
 @reflectiveTest
-class DartCompletionContributorTest
-    extends AbstractDartCompletionContributorTest {
+class DartCompletionContributorTest extends AbstractCompletionContributorTest {
   @override
   setUp() {
     testFile = '/completionTest.dart';
@@ -25,7 +24,7 @@ class DartCompletionContributorTest
   }
 
   @override
-  DartCompletionContributor createContributor() {
+  CompletionContributor createContributor() {
     return new AngularDartCompletionContributor();
   }
 
@@ -130,8 +129,8 @@ class MyComp {
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
     assertSuggestGetter('text', 'String');
     assertSuggestGetter('description', 'String');
   }
@@ -148,11 +147,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_at_beginning_with_partial() async {
@@ -167,11 +166,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - '<my'.length);
+    expect(replacementLength, '<my'.length);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_at_middle() async {
@@ -186,11 +185,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_at_middle_of_text() async {
@@ -205,11 +204,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_at_middle_with_partial() async {
@@ -224,11 +223,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - '<my'.length);
+    expect(replacementLength, '<my'.length);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_at_end() async {
@@ -243,11 +242,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_at_end_with_partial() async {
@@ -262,11 +261,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - '<m'.length);
+    expect(replacementLength, '<m'.length);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeInlineHtmlSelectorTag_on_empty_document() async {
@@ -319,11 +318,11 @@ class MyChildComponent2{}
     ''');
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 }
 
@@ -383,6 +382,28 @@ class MyComp {
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
+    assertSuggestGetter('length', 'int');
+  }
+
+  test_completeDotMemberAlreadyStartedInMustache() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a')
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('html file {{text.le^}} with mustache');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset - 'le'.length);
+    expect(replacementLength, 'le'.length);
     assertSuggestGetter('length', 'int');
   }
 
@@ -725,8 +746,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - '[name'.length);
+    expect(replacementLength, '[name'.length);
     assertSuggestSetter("[name]");
   }
 
@@ -752,8 +773,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - '[hidden'.length);
+    expect(replacementLength, '[hidden'.length);
     assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
   }
 
@@ -810,8 +831,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - '(nameEvent'.length);
+    expect(replacementLength, '(nameEvent'.length);
     assertSuggestGetter("(nameEvent)", "String");
   }
 
@@ -867,8 +888,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - '(click'.length);
+    expect(replacementLength, '(click'.length);
     assertSuggestGetter("(click)", "MouseEvent",
         relevance: DART_RELEVANCE_DEFAULT - 1);
   }
@@ -924,8 +945,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
     assertSuggestSetter("[name]");
     assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertNotSuggested("(nameEvent)");
@@ -954,8 +975,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
     assertSuggestGetter("(nameEvent)", "String");
     assertSuggestGetter("(click)", "MouseEvent",
         relevance: DART_RELEVANCE_DEFAULT - 1);
@@ -984,8 +1005,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, '[input]'.length);
     assertSuggestSetter("[name]");
     assertSuggestSetter("[hidden]", relevance: DART_RELEVANCE_DEFAULT - 1);
     assertNotSuggested("(nameEvent)");
@@ -1014,8 +1035,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, '(output)'.length);
     assertSuggestGetter("(nameEvent)", "String");
     assertSuggestGetter("(click)", "MouseEvent",
         relevance: DART_RELEVANCE_DEFAULT - 1);
@@ -1104,8 +1125,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, 0);
+    expect(replacementLength, '<my-tag'.length);
     assertNotSuggested("[name]");
     assertNotSuggested("[hidden]");
     assertNotSuggested("(event)");
@@ -1131,11 +1152,11 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeHtmlSelectorTag_at_beginning_with_partial() async {
@@ -1157,11 +1178,11 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - '<my'.length);
+    expect(replacementLength, '<my'.length);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeHtmlSelectorTag_at_middle() async {
@@ -1183,11 +1204,11 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeHtmlSelectorTag_at_middle_of_text() async {
@@ -1209,11 +1230,11 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeHtmlSelectorTag_at_middle_with_partial() async {
@@ -1235,11 +1256,11 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - '<my'.length);
+    expect(replacementLength, '<my'.length);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeHtmlSelectorTag_at_end() async {
@@ -1261,11 +1282,11 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 
   test_completeHtmlSelectorTag_at_end_with_partial() async {
@@ -1288,8 +1309,8 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - '<my'.length);
+    expect(replacementLength, '<my'.length);
     assertSuggestClassTypeAlias("my-child1");
     assertSuggestClassTypeAlias("my-child2");
     assertSuggestClassTypeAlias("my-child3");
@@ -1366,10 +1387,10 @@ class OtherComp {
     computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
 
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
-    assertSuggestClassTypeAlias("my-child1");
-    assertSuggestClassTypeAlias("my-child2");
-    assertSuggestClassTypeAlias("my-child3");
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestClassTypeAlias("<my-child1");
+    assertSuggestClassTypeAlias("<my-child2");
+    assertSuggestClassTypeAlias("<my-child3");
   }
 }

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -65,9 +65,8 @@ abstract class AbstractDartCompletionContributorTest
     });
     request = await performAnalysis(times, requestCompleter);
 
-    var range = new ReplacementRange.compute(request.offset, request.target);
-    replacementOffset = range.offset;
-    replacementLength = range.length;
+    replacementOffset = (request as CompletionRequestImpl).replacementOffset;
+    replacementLength = (request as CompletionRequestImpl).replacementLength;
     Completer<List<CompletionSuggestion>> suggestionCompleter =
         new Completer<List<CompletionSuggestion>>();
 
@@ -115,8 +114,6 @@ abstract class AbstractCompletionContributorTest
     requestCompleter.complete(request);
     request = await performAnalysis<CompletionRequest>(times, requestCompleter);
 
-    replacementOffset = request.offset;
-    replacementLength = 0;
     Completer<List<CompletionSuggestion>> suggestionCompleter =
         new Completer<List<CompletionSuggestion>>();
 
@@ -130,6 +127,8 @@ abstract class AbstractCompletionContributorTest
     // Perform analysis until the suggestions have been computed
     // or the max analysis cycles ([times]) has been reached
     suggestions = await performAnalysis(times, suggestionCompleter);
+    replacementOffset = request.replacementOffset;
+    replacementLength = request.replacementLength;
     expect(suggestions, isNotNull, reason: 'expected suggestions');
   }
 }


### PR DESCRIPTION
Added the ideal replacement length & offset assertions in the tests and
went from there.

Create a new visitor to detect what should be replaced in a target, but
also let the dart completion infrastructure override that when
'extractor.dartSnippet' is not null.

Always suggest `<` in tags since we can tell intelliJ to replace those.

Also found an issue where autocompleting `blah="^"` resulted in a
`replacementLength` of 4, forgotten I had treated that as `blah="null"`
in the converter to suppress the "expected identifier" warning since we
had a later warning for the tag being empty already and didn't want to
report two.

So no longer magically insert a null which messes up completion
lengths, but do still suppress that warning using a new class
IgnoringAnalysisErrorListener. Note that I had created a class with the
same name in a different branch to solve #220, when these get merged
those two classes should use the implementation in this branch where
its in its own file.

Not currently working for "<x^<y" because the html parser treats that
as one tag. And not working for "<x" at EOF because that's treated as a
text node. These should be solved by modifying the html parser ideally.