### PR TITLE
Attach "from" path to template errors when "from" a strange file #109

### DIFF
--- a/analyzer_plugin/lib/src/from_file_prefixed_error.dart
+++ b/analyzer_plugin/lib/src/from_file_prefixed_error.dart
@@ -1,0 +1,64 @@
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/src/generated/source.dart';
+
+/**
+ * A wrapper around AnalysisError which also links back to a "from" file for
+ * context.
+ *
+ * Is a wrapper, not just an extension, so that it can have a different hashCode
+ * than the error without a "from" path, in the case that a file is included
+ * both sanely and strangely (which is common: prod and test).
+ */
+class FromFilePrefixedError implements AnalysisError {
+  final Source fromSource;
+  final String originalMessage;
+  final AnalysisError originalError;
+  String _message;
+
+  FromFilePrefixedError(this.fromSource, AnalysisError originalError)
+      : originalMessage = originalError.message,
+        originalError = originalError {
+    _message = "$originalMessage (from ${fromSource.fullName})";
+  }
+
+  @override
+  ErrorCode get errorCode => originalError.errorCode;
+
+  @override
+  int get offset => originalError.offset;
+
+  @override
+  set offset(int v) => originalError.offset = v;
+
+  @override
+  int get length => originalError.length;
+
+  @override
+  set length(int v) => originalError.length = v;
+
+  @override
+  bool get isStaticOnly => originalError.isStaticOnly;
+
+  @override
+  set isStaticOnly(bool v) => originalError.isStaticOnly = v;
+
+  @override
+  getProperty<V>(ErrorProperty<V> v) => originalError.getProperty(v);
+
+  @override
+  String get correction => originalError.correction;
+
+  @override
+  Source get source => originalError.source;
+
+  @override
+  String get message => _message;
+
+  @override
+  int get hashCode {
+    int hashCode = offset;
+    hashCode ^= (_message != null) ? _message.hashCode : 0;
+    hashCode ^= (source != null) ? source.hashCode : 0;
+    return hashCode;
+  }
+}

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -23,6 +23,7 @@ import 'package:analyzer/src/task/general.dart';
 import 'package:analyzer/task/dart.dart';
 import 'package:analyzer/task/model.dart';
 import 'package:analyzer/task/general.dart';
+import 'package:angular_analyzer_plugin/src/from_file_prefixed_error.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/resolver.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
@@ -1519,13 +1520,25 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
             document,
             extraNodes)
         .resolve();
+
+    List<AnalysisError> errorList = errorListener.errors
+        .where((e) => !template.ignoredErrors.contains(e.errorCode.name))
+        .toList();
+
+    String shorten(String filename) =>
+        filename.substring(0, filename.lastIndexOf('.'));
+
+    if (shorten(view.source.fullName) !=
+        shorten(view.templateSource.fullName)) {
+      errorList = errorList
+          .map((e) => new FromFilePrefixedError(view.source, e))
+          .toList();
+    }
     //
     // Record outputs.
     //
     outputs[HTML_TEMPLATE] = template;
-    outputs[HTML_TEMPLATE_ERRORS] = errorListener.errors
-        .where((e) => !template.ignoredErrors.contains(e.errorCode.name))
-        .toList();
+    outputs[HTML_TEMPLATE_ERRORS] = errorList;
   }
 
   /**


### PR DESCRIPTION
Main use case here is being able to tell when "unresolved tag" etc
errors come up from a test file rather than production file. Without a
"from" path in that case, you can't tell.