### PR TITLE
Track, validate, and autocomplete transclusions.

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -267,11 +267,12 @@ class OutputBinding {
 class TextInfo extends NodeInfo {
   final List<Mustache> mustaches;
   List<AngularAstNode> get children => new List<AngularAstNode>.from(mustaches);
+  final ElementInfo parent;
 
   final String text;
   final int offset;
 
-  TextInfo(this.offset, this.text, this.mustaches);
+  TextInfo(this.offset, this.text, this.parent, this.mustaches);
 
   int get length => text.length;
 
@@ -292,12 +293,15 @@ class ElementInfo extends NodeInfo implements HasDirectives {
   final bool isTemplate;
   final List<AttributeInfo> attributes;
   final TemplateAttribute templateAttribute;
+  final ElementInfo parent;
+
   List<DirectiveBinding> boundDirectives = <DirectiveBinding>[];
   List<OutputBinding> boundStandardOutputs = <OutputBinding>[];
   List<InputBinding> boundStandardInputs = <InputBinding>[];
   List<AbstractDirective> get directives =>
       boundDirectives.map((bd) => bd.boundDirective);
   int childNodesMaxEnd;
+  bool tagMatchedAsTransclusion = false;
 
   ElementInfo(
       this.localName,
@@ -307,7 +311,8 @@ class ElementInfo extends NodeInfo implements HasDirectives {
       this.closingNameSpan,
       this.isTemplate,
       this.attributes,
-      this.templateAttribute) {
+      this.templateAttribute,
+      this.parent) {
     if (!isSynthetic) {
       childNodesMaxEnd = offset + length;
     }

--- a/analyzer_plugin/lib/plugin.dart
+++ b/analyzer_plugin/lib/plugin.dart
@@ -30,7 +30,7 @@ class AngularAnalyzerPlugin implements Plugin {
     {
       String id = DART_ERRORS_FOR_UNIT_EXTENSION_POINT_ID;
       registerExtension(id, DIRECTIVES_ERRORS);
-      registerExtension(id, VIEWS_ERRORS);
+      registerExtension(id, VIEWS_ERRORS2);
       registerExtension(id, DART_TEMPLATES_ERRORS);
     }
     // errors for HTML sources
@@ -45,7 +45,9 @@ class AngularAnalyzerPlugin implements Plugin {
         ..addTaskDescriptor(BuildStandardHtmlComponentsTask.DESCRIPTOR)
         ..addTaskDescriptor(BuildUnitDirectivesTask.DESCRIPTOR)
         ..addTaskDescriptor(BuildUnitViewsTask.DESCRIPTOR)
+        ..addTaskDescriptor(BuildUnitViewsTask2.DESCRIPTOR)
         ..addTaskDescriptor(ComputeDirectivesInLibraryTask.DESCRIPTOR)
+        ..addTaskDescriptor(GetAstsForTemplatesInUnitTask.DESCRIPTOR)
         ..addTaskDescriptor(ResolveDartTemplatesTask.DESCRIPTOR)
         ..addTaskDescriptor(ResolveHtmlTemplatesTask.DESCRIPTOR)
         ..addTaskDescriptor(ResolveHtmlTemplateTask.DESCRIPTOR);

--- a/analyzer_plugin/lib/src/angular_work_manager.dart
+++ b/analyzer_plugin/lib/src/angular_work_manager.dart
@@ -28,7 +28,7 @@ class AngularWorkManager implements WorkManager {
 
   /**
    * The list of Dart sources for which we want to compute
-   * [VIEWS_WITH_HTML_TEMPLATES] to be able to resolve [priorityHtmlSources].
+   * [VIEWS_WITH_HTML_TEMPLATES2] to be able to resolve [priorityHtmlSources].
    */
   final List<Source> priorityDartSourcesForViews = <Source>[];
 
@@ -42,7 +42,7 @@ class AngularWorkManager implements WorkManager {
    */
   AngularWorkManager(this.context) {
     context.onResultInvalidated.listen((InvalidatedResult result) {
-      if (result.descriptor == VIEWS_WITH_HTML_TEMPLATES) {
+      if (result.descriptor == VIEWS_WITH_HTML_TEMPLATES2) {
         List<View> views = result.value;
         for (View view in views) {
           _updateTemplateViews(view, false);
@@ -104,15 +104,15 @@ class AngularWorkManager implements WorkManager {
       }
       return new TargetedResult(source, SOURCE_KIND);
     }
-    // Request VIEWS_WITH_HTML_TEMPLATES computing.
+    // Request VIEWS_WITH_HTML_TEMPLATES2 computing.
     while (priorityDartSourcesForViews.isNotEmpty) {
       Source source = priorityDartSourcesForViews.last;
       LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-      if (!_needsComputing(target, VIEWS_WITH_HTML_TEMPLATES)) {
+      if (!_needsComputing(target, VIEWS_WITH_HTML_TEMPLATES2)) {
         priorityDartSourcesForViews.removeLast();
         continue;
       }
-      return new TargetedResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      return new TargetedResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     // Request HTML_TEMPLATES computing.
     while (priorityHtmlSources.isNotEmpty) {
@@ -156,7 +156,7 @@ class AngularWorkManager implements WorkManager {
     }
     // Update views containing templates.
     {
-      List<View> newViews = outputs[VIEWS_WITH_HTML_TEMPLATES];
+      List<View> newViews = outputs[VIEWS_WITH_HTML_TEMPLATES2];
       if (newViews != null) {
         for (View newView in newViews) {
           _updateTemplateViews(newView, true);

--- a/analyzer_plugin/lib/src/converter.dart
+++ b/analyzer_plugin/lib/src/converter.dart
@@ -16,6 +16,15 @@ import 'package:html/dom.dart' as html;
 import 'package:html/parser.dart' as html;
 import 'package:source_span/source_span.dart';
 
+html.Element firstElement(html.Node node) {
+  for (html.Element child in node.children) {
+    if (child is html.Element) {
+      return child;
+    }
+  }
+  return null;
+}
+
 class HtmlTreeConverter {
   final EmbeddedDartParser dartParser;
   final Source templateSource;
@@ -23,7 +32,7 @@ class HtmlTreeConverter {
 
   HtmlTreeConverter(this.dartParser, this.templateSource, this.errorListener);
 
-  NodeInfo convert(html.Node node) {
+  NodeInfo convert(html.Node node, {ElementInfo parent}) {
     if (node is html.Element) {
       String localName = node.localName;
       List<AttributeInfo> attributes = _convertAttributes(node);
@@ -44,7 +53,8 @@ class HtmlTreeConverter {
           closingNameSpan,
           isTemplate,
           attributes,
-          findTemplateAttribute(attributes));
+          findTemplateAttribute(attributes),
+          parent);
 
       for (AttributeInfo attribute in attributes) {
         attribute.parent = element;
@@ -57,7 +67,8 @@ class HtmlTreeConverter {
     if (node is html.Text) {
       int offset = node.sourceSpan.start.offset;
       String text = node.text;
-      return new TextInfo(offset, text, dartParser.findMustaches(text, offset));
+      return new TextInfo(
+          offset, text, parent, dartParser.findMustaches(text, offset));
     }
     return null;
   }
@@ -205,16 +216,16 @@ class HtmlTreeConverter {
         bound);
   }
 
-  List<NodeInfo> _convertChildren(html.Element node, ElementInfo root) {
+  List<NodeInfo> _convertChildren(html.Element node, ElementInfo parent) {
     List<NodeInfo> children = <NodeInfo>[];
     for (html.Node child in node.nodes) {
-      NodeInfo childNode = convert(child);
+      NodeInfo childNode = convert(child, parent: parent);
       if (childNode != null) {
         children.add(childNode);
         if (childNode is ElementInfo) {
-          root.childNodesMaxEnd = childNode.childNodesMaxEnd;
+          parent.childNodesMaxEnd = childNode.childNodesMaxEnd;
         } else {
-          root.childNodesMaxEnd = childNode.offset + childNode.length;
+          parent.childNodesMaxEnd = childNode.offset + childNode.length;
         }
       }
     }

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -9,127 +9,14 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
-import 'package:analyzer/src/error/codes.dart';
 import 'package:analyzer/src/generated/error_verifier.dart';
 import 'package:analyzer/src/generated/resolver.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/src/generated/source.dart';
-import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
-import 'package:html/dom.dart' as html;
-import 'package:html/parser.dart' as html;
-import 'package:source_span/source_span.dart';
-
-html.Element _firstElement(html.Node node) {
-  for (html.Element child in node.children) {
-    if (child is html.Element) {
-      return child;
-    }
-  }
-  return null;
-}
-
-/**
- * [DartTemplateResolver]s resolve inline [View] templates.
- */
-class DartTemplateResolver {
-  final TypeProvider typeProvider;
-  final List<Component> standardHtmlComponents;
-  final Map<String, OutputElement> standardHtmlEvents;
-  final Map<String, InputElement> standardHtmlAttributes;
-  final AnalysisErrorListener errorListener;
-  final View view;
-
-  DartTemplateResolver(
-      this.typeProvider,
-      this.standardHtmlComponents,
-      this.standardHtmlEvents,
-      this.standardHtmlAttributes,
-      this.errorListener,
-      this.view);
-
-  Template resolve() {
-    String templateText = view.templateText;
-    if (templateText == null) {
-      return null;
-    }
-    // Parse HTML.
-    html.Document document;
-    List<NodeInfo> extraNodes;
-    {
-      String fragmentText =
-          ' ' * view.templateOffset + templateText.trimRight();
-      html.HtmlParser parser = new html.HtmlParser(fragmentText,
-          generateSpans: true, lowercaseAttrName: false);
-      parser.compatMode = 'quirks';
-
-      // Don't parse as a fragment, but parse as a document. That way there
-      // will be a single first element with all contents.
-      document = parser.parse();
-      extraNodes = _filterParserErrorsToExtraNodes(parser, fragmentText);
-    }
-    // Create and resolve Template.
-    Template template = new Template(view, _firstElement(document));
-    view.template = template;
-    template.ast = new TemplateResolver(typeProvider, standardHtmlComponents,
-            standardHtmlEvents, standardHtmlAttributes, errorListener)
-        .resolve(template);
-    if (extraNodes.isNotEmpty) {
-      template.extraNodes.addAll(extraNodes);
-    }
-    _setIgnoredErrors(template, document);
-    return template;
-  }
-
-  /**
-   * Report HTML errors as [AnalysisError]s except for 'eof-in-tag-name' error,
-   * which should be returned as a list of TextNodes
-   */
-  List<NodeInfo> _filterParserErrorsToExtraNodes(
-      html.HtmlParser parser, String fragmentText) {
-    List<html.ParseError> parseErrors = parser.errors;
-    List<NodeInfo> extraNodes = <NodeInfo>[];
-
-    for (html.ParseError parseError in parseErrors) {
-      // We parse this as a full document rather than as a template so
-      // that everything is in the first document element. But then we
-      // get these errors which don't apply -- suppress them.
-      if (parseError.errorCode == 'expected-doctype-but-got-start-tag' ||
-          parseError.errorCode == 'expected-doctype-but-got-chars' ||
-          parseError.errorCode == 'expected-doctype-but-got-eof') {
-        continue;
-      }
-      SourceSpan span = parseError.span;
-      if (parseError.errorCode == 'eof-in-tag-name' ||
-          parseError.errorCode == 'expected-attribute-name-but-got-eof') {
-        int localNameOffset = span.start.offset + "<".length;
-        String localName = fragmentText.substring(localNameOffset).trimRight();
-        ElementInfo extraNode = new ElementInfo(
-            localName,
-            new SourceRange(span.start.offset, span.length),
-            null,
-            new SourceRange(localNameOffset, localName.length),
-            null,
-            localName == 'template',
-            <AttributeInfo>[],
-            null);
-        extraNodes.add(extraNode);
-      }
-      _reportErrorForSpan(
-          span, HtmlErrorCode.PARSE_ERROR, [parseError.message]);
-    }
-    return extraNodes;
-  }
-
-  void _reportErrorForSpan(SourceSpan span, ErrorCode errorCode,
-      [List<Object> arguments]) {
-    errorListener.onError(new AnalysisError(
-        view.source, span.start.offset, span.length, errorCode, arguments));
-  }
-}
 
 /**
  * The implementation of [ElementView] using [AttributeInfo]s.
@@ -180,65 +67,6 @@ class ElementViewImpl implements ElementView {
   }
 }
 
-_setIgnoredErrors(Template template, html.Document document) {
-  html.Node firstNode = document.nodes[0];
-  if (firstNode is html.Comment) {
-    String text = firstNode.text.trim();
-    if (text.startsWith("@ngIgnoreErrors")) {
-      text = text.substring("@ngIgnoreErrors".length);
-      // Per spec: optional color
-      if (text.startsWith(":")) {
-        text = text.substring(1);
-      }
-      // Per spec: optional commas
-      String delim = text.indexOf(',') == -1 ? ' ' : ',';
-      template.ignoredErrors.addAll(new HashSet.from(
-          text.split(delim).map((c) => c.trim().toUpperCase())));
-    }
-  }
-}
-
-/**
- * [HtmlTemplateResolver]s resolve templates in separate Html files.
- */
-class HtmlTemplateResolver {
-  final TypeProvider typeProvider;
-  final List<Component> standardHtmlComponents;
-  final Map<String, OutputElement> standardHtmlEvents;
-  final Map<String, InputElement> standardHtmlAttributes;
-  final AnalysisErrorListener errorListener;
-  final View view;
-  final html.Document document;
-  final List<NodeInfo> extraNodes;
-
-  HtmlTemplateResolver(
-      this.typeProvider,
-      this.standardHtmlComponents,
-      this.standardHtmlEvents,
-      this.standardHtmlAttributes,
-      this.errorListener,
-      this.view,
-      this.document,
-      this.extraNodes);
-
-  HtmlTemplate resolve() {
-    HtmlTemplate template =
-        new HtmlTemplate(view, _firstElement(document), view.templateUriSource);
-
-    view.template = template;
-    template.ast = new TemplateResolver(typeProvider, standardHtmlComponents,
-            standardHtmlEvents, standardHtmlAttributes, errorListener)
-        .resolve(template);
-    _setIgnoredErrors(template, document);
-
-    if (extraNodes != null && extraNodes.isNotEmpty) {
-      template.extraNodes.addAll(extraNodes);
-    }
-
-    return template;
-  }
-}
-
 /**
  * A variable defined by a [AbstractDirective].
  */
@@ -280,17 +108,13 @@ class TemplateResolver {
   TemplateResolver(this.typeProvider, this.standardHtmlComponents,
       this.standardHtmlEvents, this.standardHtmlAttributes, this.errorListener);
 
-  ElementInfo resolve(Template template) {
+  void resolve(Template template) {
     this.template = template;
     this.view = template.view;
     this.templateSource = view.templateSource;
     this.errorReporter = new ErrorReporter(errorListener, templateSource);
-    EmbeddedDartParser parser = new EmbeddedDartParser(
-        templateSource, errorListener, typeProvider, errorReporter);
 
-    ElementInfo root =
-        new HtmlTreeConverter(parser, templateSource, errorListener)
-            .convert(template.element);
+    ElementInfo root = template.ast;
 
     var allDirectives = <AbstractDirective>[]
       ..addAll(standardHtmlComponents)
@@ -300,7 +124,6 @@ class TemplateResolver {
     root.accept(directiveResolver);
 
     _resolveScope(root);
-    return root;
   }
 
   /**
@@ -882,8 +705,9 @@ class DirectiveResolver extends AngularAstVisitor {
     }
 
     ElementView elementView = new ElementViewImpl(element.attributes, element);
-    bool tagIsResolved = false;
+    bool tagIsResolved = element.tagMatchedAsTransclusion;
     bool tagIsStandard = _isStandardTagName(element.localName);
+    Component component;
 
     for (AbstractDirective directive in allDirectives) {
       Selector selector = directive.selector;
@@ -891,6 +715,10 @@ class DirectiveResolver extends AngularAstVisitor {
         element.boundDirectives.add(new DirectiveBinding(directive));
         if (selector is ElementNameSelector) {
           tagIsResolved = true;
+        }
+
+        if (directive is Component) {
+          component = directive;
         }
       }
     }
@@ -903,8 +731,50 @@ class DirectiveResolver extends AngularAstVisitor {
       _checkNoStructuralDirectives(element.attributes);
     }
 
+    if (!tagIsStandard) {
+      _checkTranscludedContent(component, element.childNodes, tagIsStandard);
+    }
+
     for (NodeInfo child in element.childNodes) {
       child.accept(this);
+    }
+  }
+
+  void _checkTranscludedContent(
+      Component component, List<NodeInfo> children, bool tagIsStandard) {
+    Template componentTemplate = component?.view?.template;
+    if (componentTemplate == null) {
+      return;
+    }
+
+    bool acceptAll = componentTemplate.ngContents.any((s) => s.matchesAll);
+    for (NodeInfo child in children) {
+      if (child is TextInfo && !acceptAll && child.text.trim() != "") {
+        _reportErrorForRange(new SourceRange(child.offset, child.length),
+            AngularWarningCode.CONTENT_NOT_TRANSCLUDED);
+      } else if (child is ElementInfo) {
+        ElementView view = new ElementViewImpl(child.attributes, child);
+        bool matched = acceptAll;
+        bool matchedTag = false;
+        if (componentTemplate != null) {
+          for (NgContent ngContent in componentTemplate.ngContents) {
+            if (ngContent.matchesAll ||
+                ngContent.selector.match(view, template)) {
+              matched = true;
+              // TODO don't just check is ElementNameSelector
+              matchedTag =
+                  matchedTag || ngContent.selector is ElementNameSelector;
+            }
+          }
+        }
+
+        if (!matched) {
+          _reportErrorForRange(new SourceRange(child.offset, child.length),
+              AngularWarningCode.CONTENT_NOT_TRANSCLUDED);
+        } else if (matchedTag) {
+          child.tagMatchedAsTransclusion = true;
+        }
+      }
     }
   }
 
@@ -942,6 +812,75 @@ class DirectiveResolver extends AngularAstVisitor {
   static bool _isStandardTagName(String name) {
     name = name.toLowerCase();
     return !name.contains('-') || name == 'ng-content';
+  }
+}
+
+class NgContentRecorder extends AngularScopeVisitor {
+  final Template template;
+  final Source source;
+  final ErrorReporter errorReporter;
+
+  NgContentRecorder(Template template, this.errorReporter)
+      : template = template,
+        source = template.view.templateSource;
+
+  @override
+  void visitElementInfo(ElementInfo element) {
+    if (element.localName != 'ng-content') {
+      for (NodeInfo child in element.childNodes) {
+        child.accept(this);
+      }
+
+      return;
+    }
+
+    List<AttributeInfo> selectorAttrs =
+        element.attributes.where((a) => a.name == 'select');
+
+    if (element.childNodes.length > 0) {
+      errorReporter.reportErrorForOffset(
+          AngularWarningCode.NG_CONTENT_MUST_BE_EMPTY,
+          element.openingSpan.offset,
+          element.openingSpan.length);
+    }
+
+    if (selectorAttrs.length == 0) {
+      template.ngContents.add(new NgContent(element.offset, element.length));
+      return;
+    }
+
+    // We don't actually check if selectors.length > 2, because the html parser
+    // reports that.
+    try {
+      AttributeInfo selectorAttr = selectorAttrs.first;
+      if (selectorAttr.value == null) {
+        errorReporter.reportErrorForOffset(
+            AngularWarningCode.CANNOT_PARSE_SELECTOR,
+            selectorAttr.nameOffset,
+            selectorAttr.name.length);
+      } else if (selectorAttr.value == "") {
+        errorReporter.reportErrorForOffset(
+            AngularWarningCode.CANNOT_PARSE_SELECTOR,
+            selectorAttr.valueOffset - 1,
+            2);
+      } else {
+        Selector selector = new SelectorParser(
+                source, selectorAttr.valueOffset, selectorAttr.value)
+            .parse();
+        template.ngContents.add(new NgContent.withSelector(
+            element.offset,
+            element.length,
+            selector,
+            selectorAttr.valueOffset,
+            selectorAttr.value.length));
+      }
+    } on SelectorParseError catch (e) {
+      errorReporter.reportErrorForOffset(
+          AngularWarningCode.CANNOT_PARSE_SELECTOR,
+          e.offset,
+          e.length,
+          [e.message]);
+    }
   }
 }
 

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1541,6 +1541,8 @@ class GetAstsForTemplatesInUnitTask extends SourceBasedAnalysisTask
     with ParseHtmlMixin {
   static const String DIRECTIVES_IN_UNIT1_INPUT = 'DIRECTIVES_IN_UNIT1_INPUT';
   static const String HTML_DOCUMENTS_INPUT = 'HTML_DOCUMENTS_INPUT';
+  static const String HTML_DOCUMENTS_ERRORS_INPUT =
+      'HTML_DOCUMENTS_ERRORS_INPUT';
   static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
   static const String EXTRA_NODES_INPUT = 'EXTRA_NODES_INPUT';
 
@@ -1561,6 +1563,8 @@ class GetAstsForTemplatesInUnitTask extends SourceBasedAnalysisTask
         getRequiredInput(DIRECTIVES_IN_UNIT1_INPUT);
     Map<Source, html.Document> documentsMap =
         getRequiredInput(HTML_DOCUMENTS_INPUT);
+    Map<Source, List<AnalysisError>> documentsErrorsMap =
+        getRequiredInput(HTML_DOCUMENTS_ERRORS_INPUT);
     Map<Source, List<NodeInfo>> extraNodesMap =
         getRequiredInput(EXTRA_NODES_INPUT);
     List<ElementInfo> asts = <ElementInfo>[];
@@ -1583,6 +1587,7 @@ class GetAstsForTemplatesInUnitTask extends SourceBasedAnalysisTask
             return;
           }
 
+          documentsErrorsMap[source].forEach(errorListener.onError);
           _processView(
               new Template(d.view),
               documentsMap[source],
@@ -1596,7 +1601,6 @@ class GetAstsForTemplatesInUnitTask extends SourceBasedAnalysisTask
             return;
           }
 
-          errorReporter = new ErrorReporter(errorListener, source);
           parse((' ' * view.templateOffset) + view.templateText);
           parseErrors.forEach(errorListener.onError);
           parseErrors.clear();
@@ -1683,6 +1687,15 @@ class GetAstsForTemplatesInUnitTask extends SourceBasedAnalysisTask
               .toList())
           // to map<source, html document of source>
           .toMapOf(ANGULAR_HTML_DOCUMENT),
+      HTML_DOCUMENTS_ERRORS_INPUT: VIEWS_WITH_HTML_TEMPLATES1
+          .of(target)
+          // mapped to html source of the view
+          .mappedToList((views) => views
+              .map((v) => v.templateUriSource)
+              .where((v) => v != null)
+              .toList())
+          // to map<source, html document of source>
+          .toMapOf(ANGULAR_HTML_DOCUMENT_ERRORS),
       EXTRA_NODES_INPUT: VIEWS_WITH_HTML_TEMPLATES1
           .of(target)
           // mapped to html source of the view

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1,5 +1,7 @@
 library angular2.src.analysis.analyzer_plugin.src.tasks;
 
+import 'dart:collection';
+
 import 'package:analyzer/src/context/cache.dart';
 import 'package:analyzer/dart/ast/ast.dart' as ast;
 import 'package:analyzer/dart/ast/token.dart';
@@ -24,6 +26,7 @@ import 'package:analyzer/task/dart.dart';
 import 'package:analyzer/task/model.dart';
 import 'package:analyzer/task/general.dart';
 import 'package:angular_analyzer_plugin/src/from_file_prefixed_error.dart';
+import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/resolver.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
@@ -179,30 +182,78 @@ final ListResultDescriptor<View> TEMPLATE_VIEWS =
     new ListResultDescriptor<View>('ANGULAR_TEMPLATE_VIEWS', View.EMPTY_LIST);
 
 /**
- * The [View]s of a [LibrarySpecificUnit].
+ * The [View]s of a [LibrarySpecificUnit], without looking at what directives
+ * they use.
  */
-final ListResultDescriptor<View> VIEWS =
-    new ListResultDescriptor<View>('ANGULAR_VIEWS', View.EMPTY_LIST);
+final ListResultDescriptor<View> VIEWS1 =
+    new ListResultDescriptor<View>('ANGULAR_VIEWS1', View.EMPTY_LIST);
 
 /**
- * The errors produced while building [VIEWS].
+ * The [View]s of a [LibrarySpecificUnit], including what directives they use.
+ */
+final ListResultDescriptor<View> VIEWS2 =
+    new ListResultDescriptor<View>('ANGULAR_VIEWS2', View.EMPTY_LIST);
+
+/**
+ * The errors produced while building [VIEWS1]. Included in [VIEWS_ERRORS2].
  *
  * The list will be empty if there were no errors, but will not be `null`.
  *
  * The result is only available for [LibrarySpecificUnit]s.
  */
-final ListResultDescriptor<AnalysisError> VIEWS_ERRORS =
+final ListResultDescriptor<AnalysisError> VIEWS_ERRORS1 =
     new ListResultDescriptor<AnalysisError>(
-        'ANGULAR_VIEWS_ERRORS', AnalysisError.NO_ERRORS);
+        'ANGULAR_VIEWS_ERRORS1', AnalysisError.NO_ERRORS);
 
 /**
- * The [View]s with templates in separate HTML files.
+ * The errors produced while building [VIEWS2]. Includes [VIEWS_ERRORS2].
+ *
+ * The list will be empty if there were no errors, but will not be `null`.
  *
  * The result is only available for [LibrarySpecificUnit]s.
  */
-final ListResultDescriptor<View> VIEWS_WITH_HTML_TEMPLATES =
+final ListResultDescriptor<AnalysisError> VIEWS_ERRORS2 =
+    new ListResultDescriptor<AnalysisError>(
+        'ANGULAR_VIEWS_ERRORS2', AnalysisError.NO_ERRORS);
+
+/**
+ * The [View]s with templates in separate HTML files, without including what
+ * directives they use.
+ *
+ * The result is only available for [LibrarySpecificUnit]s.
+ */
+final ListResultDescriptor<View> VIEWS_WITH_HTML_TEMPLATES1 =
     new ListResultDescriptor<View>(
-        'ANGULAR_VIEWS_WITH_TEMPLATES', View.EMPTY_LIST);
+        'ANGULAR_VIEWS_WITH_TEMPLATES1', View.EMPTY_LIST);
+
+/**
+ * The [View]s with templates in separate HTML files, including what directives
+ * they use.
+ *
+ * The result is only available for [LibrarySpecificUnit]s.
+ */
+final ListResultDescriptor<View> VIEWS_WITH_HTML_TEMPLATES2 =
+    new ListResultDescriptor<View>(
+        'ANGULAR_VIEWS_WITH_TEMPLATES2', View.EMPTY_LIST);
+
+/**
+ * The asts on the [VIEWS] in a [LibrarySpecificUnit]. Usually you will depend
+ * on this and [VIEWS] and use the asts that will therefore be guaranteed to be
+ * set on the [View] objects you get.
+ */
+final ListResultDescriptor<ElementInfo> ANGULAR_ASTS =
+    new ListResultDescriptor<ElementInfo>('ANGULAR_ASTS', const []);
+
+/**
+ * The errors produced while creating [ANGULAR_ASTS]. Use a Map<Source, ...>
+ * because the ast is usually in a different file from the view, and there may
+ * be multiple views (and therefore multiple different sources) in a unit.
+ *
+ * The result is only available for [LibrarySpecificUnit]s.
+ */
+final ResultDescriptor<Map<Source, List<AnalysisError>>> ANGULAR_ASTS_ERRORS =
+    new ResultDescriptor<Map<Source, List<AnalysisError>>>(
+        'ANGULAR_ASTS_ERRORS', const <Source, List<AnalysisError>>{});
 
 /**
  * A task that scans contents of a HTML file,
@@ -212,7 +263,7 @@ final ListResultDescriptor<View> VIEWS_WITH_HTML_TEMPLATES =
  * Builds [ANGULAR_HTML_DOCUMENT],[ANGULAR_HTML_DOCUMENT_ERRORS], and
  * [ANGULAR_HTML_DOCUMENT_EXTRA_NODES].
  */
-class AngularParseHtmlTask extends SourceBasedAnalysisTask {
+class AngularParseHtmlTask extends SourceBasedAnalysisTask with ParseHtmlMixin {
   static const String CONTENT_INPUT_NAME = 'CONTENT_INPUT_NAME';
   static const String MODIFICATION_TIME_INPUT = 'MODIFICATION_TIME_INPUT';
 
@@ -252,43 +303,9 @@ class AngularParseHtmlTask extends SourceBasedAnalysisTask {
       ];
       outputs[ANGULAR_HTML_DOCUMENT_EXTRA_NODES] = null;
     } else {
-      html.HtmlParser parser = new html.HtmlParser(content,
-          generateSpans: true, lowercaseAttrName: false);
-      parser.compatMode = 'quirks';
-      html.Document document = parser.parse();
-
-      List<AnalysisError> documentErrors = <AnalysisError>[];
-      List<NodeInfo> extraNodes = <NodeInfo>[];
-      List<html.ParseError> parseErrors = parser.errors;
-
-      for (html.ParseError parseError in parseErrors) {
-        if (parseError.errorCode == 'expected-doctype-but-got-start-tag' ||
-            parseError.errorCode == 'expected-doctype-but-got-chars' ||
-            parseError.errorCode == 'expected-doctype-but-got-eof') {
-          continue;
-        }
-        SourceSpan span = parseError.span;
-        if (parseError.errorCode == 'eof-in-tag-name' ||
-            parseError.errorCode == 'expected-attribute-name-but-got-eof') {
-          int localNameOffset = span.start.offset + "<".length;
-          String localName = content.substring(localNameOffset).trimRight();
-          ElementInfo extraNode = new ElementInfo(
-              localName,
-              new SourceRange(span.start.offset, span.length),
-              null,
-              new SourceRange(localNameOffset, localName.length),
-              null,
-              localName == 'template',
-              <AttributeInfo>[],
-              null);
-          extraNodes.add(extraNode);
-        }
-        documentErrors.add(new AnalysisError(target.source, span.start.offset,
-            span.length, HtmlErrorCode.PARSE_ERROR, [parseError.errorCode]));
-      }
-
+      parse(content);
       outputs[ANGULAR_HTML_DOCUMENT] = document;
-      outputs[ANGULAR_HTML_DOCUMENT_ERRORS] = documentErrors;
+      outputs[ANGULAR_HTML_DOCUMENT_ERRORS] = parseErrors;
       outputs[ANGULAR_HTML_DOCUMENT_EXTRA_NODES] = extraNodes;
     }
   }
@@ -303,6 +320,53 @@ class AngularParseHtmlTask extends SourceBasedAnalysisTask {
   static AngularParseHtmlTask createTask(
       AnalysisContext context, AnalysisTarget target) {
     return new AngularParseHtmlTask(context, target);
+  }
+}
+
+abstract class ParseHtmlMixin implements AnalysisTask {
+  html.Document document;
+  final List<AnalysisError> parseErrors = <AnalysisError>[];
+  final List<NodeInfo> extraNodes = <NodeInfo>[];
+
+  void parse(String content) {
+    html.HtmlParser parser = new html.HtmlParser(content,
+        generateSpans: true, lowercaseAttrName: false);
+    parser.compatMode = 'quirks';
+    document = parser.parse();
+
+    List<html.ParseError> htmlErrors = parser.errors;
+
+    for (html.ParseError parseError in htmlErrors) {
+      if (parseError.errorCode == 'expected-doctype-but-got-start-tag' ||
+          parseError.errorCode == 'expected-doctype-but-got-chars' ||
+          parseError.errorCode == 'expected-doctype-but-got-eof') {
+        continue;
+      }
+
+      SourceSpan span = parseError.span;
+      // html parser lib isn't nice enough to send this error all the time
+      // see github #47 for dart-lang/html
+      if (span == null) continue;
+
+      if (parseError.errorCode == 'eof-in-tag-name' ||
+          parseError.errorCode == 'expected-attribute-name-but-got-eof') {
+        int localNameOffset = span.start.offset + "<".length;
+        String localName = content.substring(localNameOffset).trimRight();
+        ElementInfo extraNode = new ElementInfo(
+            localName,
+            new SourceRange(span.start.offset, span.length),
+            null,
+            new SourceRange(localNameOffset, localName.length),
+            null,
+            localName == 'template',
+            <AttributeInfo>[],
+            null,
+            null);
+        extraNodes.add(extraNode);
+      }
+      this.parseErrors.add(new AnalysisError(target.source, span.start.offset,
+          span.length, HtmlErrorCode.PARSE_ERROR, [parseError.errorCode]));
+    }
   }
 }
 
@@ -926,23 +990,24 @@ class BuildUnitDirectivesTask extends SourceBasedAnalysisTask
  * A task that builds [View]s of a [CompilationUnit].
  */
 class BuildUnitViewsTask extends SourceBasedAnalysisTask
-    with _AnnotationProcessorMixin {
-  static const String DIRECTIVES_INPUT = 'DIRECTIVES_INPUT';
+    with _AnnotationProcessorMixin, ParseHtmlMixin {
+  static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
   static const String UNIT_INPUT = 'UNIT_INPUT';
+  static const String DIRECTIVES_INPUT = 'DIRECTIVES_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
       'BuildUnitViewsTask',
       createTask,
       buildInputs,
-      <ResultDescriptor>[VIEWS, VIEWS_ERRORS, VIEWS_WITH_HTML_TEMPLATES]);
-
-  List<AbstractDirective> _allDirectives;
+      <ResultDescriptor>[VIEWS1, VIEWS_ERRORS1, VIEWS_WITH_HTML_TEMPLATES1]);
 
   BuildUnitViewsTask(AnalysisContext context, AnalysisTarget target)
       : super(context, target);
 
   @override
   TaskDescriptor get descriptor => DESCRIPTOR;
+
+  List<AbstractDirective> directivesDefinedInFile;
 
   @override
   void internalPerform() {
@@ -951,7 +1016,7 @@ class BuildUnitViewsTask extends SourceBasedAnalysisTask
     // Prepare inputs.
     //
     ast.CompilationUnit unit = getRequiredInput(UNIT_INPUT);
-    _allDirectives = getRequiredInput(DIRECTIVES_INPUT);
+    directivesDefinedInFile = getRequiredInput(DIRECTIVES_INPUT);
 
     //
     // Process all classes.
@@ -991,9 +1056,190 @@ class BuildUnitViewsTask extends SourceBasedAnalysisTask
     //
     // Record outputs.
     //
-    outputs[VIEWS] = views;
-    outputs[VIEWS_ERRORS] = errorListener.errors;
-    outputs[VIEWS_WITH_HTML_TEMPLATES] = viewsWithTemplates;
+    outputs[VIEWS1] = views;
+    outputs[VIEWS_ERRORS1] = errorListener.errors;
+    outputs[VIEWS_WITH_HTML_TEMPLATES1] = viewsWithTemplates;
+  }
+
+  /**
+   * Create a new [View] for the given [annotation], may return `null`
+   * if [annotation] or [classElement] don't provide enough information.
+   */
+  View _createView(ClassElement classElement, ast.Annotation annotation) {
+    // Template in a separate HTML file.
+    Source templateUriSource = null;
+    bool definesTemplate = false;
+    bool definesTemplateUrl = false;
+    SourceRange templateUrlRange = null;
+    {
+      ast.Expression templateUrlExpression =
+          _getNamedArgument(annotation, 'templateUrl');
+      definesTemplateUrl = templateUrlExpression != null;
+      String templateUrl = _getExpressionString(templateUrlExpression);
+      if (templateUrl != null) {
+        SourceFactory sourceFactory = context.sourceFactory;
+        templateUriSource =
+            sourceFactory.resolveUri(target.source, templateUrl);
+
+        if (templateUriSource == null || !templateUriSource.exists()) {
+          errorReporter.reportErrorForNode(
+              AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST,
+              templateUrlExpression);
+        }
+
+        templateUrlRange = new SourceRange(
+            templateUrlExpression.offset, templateUrlExpression.length);
+      }
+    }
+    // Try to find inline "template".
+    String templateText;
+    int templateOffset = 0;
+    {
+      ast.Expression expression = _getNamedArgument(annotation, 'template');
+      if (expression != null) {
+        templateOffset = expression.offset;
+        definesTemplate = true;
+        OffsettingConstantEvaluator constantEvaluation =
+            _calculateStringWithOffsets(expression);
+
+        // highly dynamically generated constant expressions can't be validated
+        if (constantEvaluation == null || !constantEvaluation.offsetsAreValid) {
+          templateText = '';
+        } else {
+          templateText = constantEvaluation.value;
+        }
+      }
+    }
+
+    if (definesTemplate && definesTemplateUrl) {
+      errorReporter.reportErrorForNode(
+          AngularWarningCode.TEMPLATE_URL_AND_TEMPLATE_DEFINED, annotation);
+
+      return null;
+    }
+
+    if (!definesTemplate && !definesTemplateUrl) {
+      errorReporter.reportErrorForNode(
+          AngularWarningCode.NO_TEMPLATE_URL_OR_TEMPLATE_DEFINED, annotation);
+
+      return null;
+    }
+
+    // Find the corresponding Component.
+    Component component = _findComponentAnnotationOrReportError(classElement);
+    if (component == null) {
+      return null;
+    }
+    // Create View.
+    return new View(classElement, component, <AbstractDirective>[],
+        templateText: templateText,
+        templateOffset: templateOffset,
+        templateUriSource: templateUriSource,
+        templateUrlRange: templateUrlRange,
+        annotation: annotation);
+  }
+
+  Component _findComponentAnnotationOrReportError(ClassElement classElement) {
+    for (AbstractDirective directive in directivesDefinedInFile) {
+      if (directive is Component && directive.classElement == classElement) {
+        return directive;
+      }
+    }
+    errorReporter.reportErrorForElement(
+        AngularWarningCode.COMPONENT_ANNOTATION_MISSING, classElement, []);
+    return null;
+  }
+
+  /**
+   * Return a map from the names of the inputs of this kind of task to the
+   * task input descriptors describing those inputs for a task with the
+   * given [target].
+   */
+  static Map<String, TaskInput> buildInputs(AnalysisTarget target) {
+    return <String, TaskInput>{
+      DIRECTIVES_INPUT: DIRECTIVES_IN_UNIT.of(target),
+      UNIT_INPUT: RESOLVED_UNIT.of(target),
+      TYPE_PROVIDER_INPUT: TYPE_PROVIDER.of(AnalysisContextTarget.request),
+    };
+  }
+
+  /**
+   * Create a task based on the given [target] in the given [context].
+   */
+  static BuildUnitViewsTask createTask(
+      AnalysisContext context, AnalysisTarget target) {
+    return new BuildUnitViewsTask(context, target);
+  }
+}
+
+class BuildUnitViewsTask2 extends SourceBasedAnalysisTask
+    with _AnnotationProcessorMixin {
+  static const String VIEWS1_INPUT = 'VIEWS1_INPUT';
+  static const String VIEWS_ERRORS1_INPUT = 'VIEWS_ERRORS1_INPUT';
+  static const String DIRECTIVES_INPUT = 'DIRECTIVES_INPUT';
+
+  static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
+      'BuildUnitViewsTask2',
+      createTask,
+      buildInputs,
+      <ResultDescriptor>[VIEWS2, VIEWS_ERRORS2, VIEWS_WITH_HTML_TEMPLATES2]);
+
+  @override
+  TaskDescriptor get descriptor => DESCRIPTOR;
+
+  List<AbstractDirective> _allDirectives;
+
+  BuildUnitViewsTask2(AnalysisContext context, AnalysisTarget target)
+      : super(context, target);
+
+  void internalPerform() {
+    List<View> views = getRequiredInput(VIEWS1_INPUT);
+    _allDirectives = getRequiredInput(DIRECTIVES_INPUT);
+    initAnnotationProcessor(target);
+
+    views.forEach(findDirectives);
+    outputs[VIEWS2] = views;
+
+    outputs[VIEWS_WITH_HTML_TEMPLATES2] =
+        views.where((d) => d.templateUriSource != null).toList();
+
+    outputs[VIEWS_ERRORS2] = new List<AnalysisError>.from(errorListener.errors)
+      ..addAll(getRequiredInput(VIEWS_ERRORS1_INPUT));
+  }
+
+  void findDirectives(View view) {
+    // Prepare directives and elementTags
+    ast.Expression listExpression =
+        _getNamedArgument(view.annotation, 'directives');
+    if (listExpression is ast.ListLiteral) {
+      for (ast.Expression item in listExpression.elements) {
+        if (item is ast.Identifier) {
+          Element element = item.staticElement;
+          // TypeLiteral
+          if (element is ClassElement) {
+            _addDirectiveAndElementTagOrReportError(
+                view.directives, view.elementTagsInfo, item, element);
+            continue;
+          }
+          // LIST_OF_DIRECTIVES
+          if (element is PropertyAccessorElement &&
+              element.variable.constantValue != null) {
+            DartObject value = element.variable.constantValue;
+            bool success = _addDirectivesAndElementTagsForDartObject(
+                view.directives, view.elementTagsInfo, value);
+            if (!success) {
+              errorReporter.reportErrorForNode(
+                  AngularWarningCode.TYPE_LITERAL_EXPECTED, item);
+              return null;
+            }
+            continue;
+          }
+        }
+        // unknown
+        errorReporter.reportErrorForNode(
+            AngularWarningCode.TYPE_LITERAL_EXPECTED, item);
+      }
+    }
   }
 
   /**
@@ -1067,132 +1313,6 @@ class BuildUnitViewsTask extends SourceBasedAnalysisTask
   }
 
   /**
-   * Create a new [View] for the given [annotation], may return `null`
-   * if [annotation] or [classElement] don't provide enough information.
-   */
-  View _createView(ClassElement classElement, ast.Annotation annotation) {
-    // Template in a separate HTML file.
-    Source templateUriSource = null;
-    bool definesTemplate = false;
-    bool definesTemplateUrl = false;
-    SourceRange templateUrlRange = null;
-    {
-      ast.Expression templateUrlExpression =
-          _getNamedArgument(annotation, 'templateUrl');
-      definesTemplateUrl = templateUrlExpression != null;
-      String templateUrl = _getExpressionString(templateUrlExpression);
-      if (templateUrl != null) {
-        SourceFactory sourceFactory = context.sourceFactory;
-        templateUriSource =
-            sourceFactory.resolveUri(target.source, templateUrl);
-
-        if (templateUriSource == null || !templateUriSource.exists()) {
-          errorReporter.reportErrorForNode(
-              AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST,
-              templateUrlExpression);
-        }
-
-        templateUrlRange = new SourceRange(
-            templateUrlExpression.offset, templateUrlExpression.length);
-      }
-    }
-    // Try to find inline "template".
-    String templateText;
-    int templateOffset = 0;
-    {
-      ast.Expression expression = _getNamedArgument(annotation, 'template');
-      if (expression != null) {
-        templateOffset = expression.offset;
-        definesTemplate = true;
-        OffsettingConstantEvaluator constantEvaluation =
-            _calculateStringWithOffsets(expression);
-
-        // highly dynamically generated constant expressions can't be validated
-        if (constantEvaluation == null || !constantEvaluation.offsetsAreValid) {
-          templateText = '';
-        } else {
-          templateText = constantEvaluation.value;
-        }
-      }
-    }
-
-    if (definesTemplate && definesTemplateUrl) {
-      errorReporter.reportErrorForNode(
-          AngularWarningCode.TEMPLATE_URL_AND_TEMPLATE_DEFINED, annotation);
-
-      return null;
-    }
-
-    if (!definesTemplate && !definesTemplateUrl) {
-      errorReporter.reportErrorForNode(
-          AngularWarningCode.NO_TEMPLATE_URL_OR_TEMPLATE_DEFINED, annotation);
-
-      return null;
-    }
-
-    // Find the corresponding Component.
-    Component component = _findComponentAnnotationOrReportError(classElement);
-    if (component == null) {
-      return null;
-    }
-    // Prepare directives and elementTags
-    List<AbstractDirective> directives = <AbstractDirective>[];
-    Map<String, List<AbstractDirective>> elementTagsInfo =
-        new Map<String, List<AbstractDirective>>();
-    {
-      ast.Expression listExpression =
-          _getNamedArgument(annotation, 'directives');
-      if (listExpression is ast.ListLiteral) {
-        for (ast.Expression item in listExpression.elements) {
-          if (item is ast.Identifier) {
-            Element element = item.staticElement;
-            // TypeLiteral
-            if (element is ClassElement) {
-              _addDirectiveAndElementTagOrReportError(
-                  directives, elementTagsInfo, item, element);
-              continue;
-            }
-            // LIST_OF_DIRECTIVES
-            if (element is PropertyAccessorElement &&
-                element.variable.constantValue != null) {
-              DartObject value = element.variable.constantValue;
-              bool success = _addDirectivesAndElementTagsForDartObject(
-                  directives, elementTagsInfo, value);
-              if (!success) {
-                errorReporter.reportErrorForNode(
-                    AngularWarningCode.TYPE_LITERAL_EXPECTED, item);
-                return null;
-              }
-              continue;
-            }
-          }
-          // unknown
-          errorReporter.reportErrorForNode(
-              AngularWarningCode.TYPE_LITERAL_EXPECTED, item);
-        }
-      }
-    }
-    // Create View.
-    return new View(classElement, component, directives,
-        elementTagsInfo: elementTagsInfo,
-        templateText: templateText,
-        templateOffset: templateOffset,
-        templateUriSource: templateUriSource,
-        templateUrlRange: templateUrlRange);
-  }
-
-  Component _findComponentAnnotationOrReportError(ClassElement classElement) {
-    for (AbstractDirective directive in _allDirectives) {
-      if (directive is Component && directive.classElement == classElement) {
-        return directive;
-      }
-    }
-    errorReporter.reportErrorForElement(
-        AngularWarningCode.COMPONENT_ANNOTATION_MISSING, classElement, []);
-    return null;
-  }
-
-  /**
    * Return a map from the names of the inputs of this kind of task to the
    * task input descriptors describing those inputs for a task with the
    * given [target].
@@ -1201,16 +1321,17 @@ class BuildUnitViewsTask extends SourceBasedAnalysisTask
     return <String, TaskInput>{
       DIRECTIVES_INPUT:
           DIRECTIVES_IN_LIBRARY.of((target as LibrarySpecificUnit).library),
-      UNIT_INPUT: RESOLVED_UNIT.of(target)
+      VIEWS1_INPUT: VIEWS1.of(target),
+      VIEWS_ERRORS1_INPUT: VIEWS_ERRORS1.of(target),
     };
   }
 
   /**
    * Create a task based on the given [target] in the given [context].
    */
-  static BuildUnitViewsTask createTask(
+  static BuildUnitViewsTask2 createTask(
       AnalysisContext context, AnalysisTarget target) {
-    return new BuildUnitViewsTask(context, target);
+    return new BuildUnitViewsTask2(context, target);
   }
 }
 
@@ -1320,6 +1441,7 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
   static const String HTML_EVENTS_INPUT = 'HTML_EVENTS_INPUT';
   static const String HTML_ATTRIBUTES_INPUT = 'HTML_ATTRIBUTES_INPUT';
   static const String VIEWS_INPUT = 'VIEWS_INPUT';
+  static const String ANGULAR_ASTS_ERRORS_INPUT = 'ANGULAR_ASTS_ERRORS_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
       'ResolveDartTemplatesTask',
@@ -1352,23 +1474,24 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
     List<Template> templates = <Template>[];
     List<AnalysisError> errors = <AnalysisError>[];
     for (View view in views) {
-      if (view.templateText != null) {
+      if (view.template != null && view.templateText != null) {
         errorListener = new RecordingErrorListener();
-        Template template = new DartTemplateResolver(typeProvider,
-                htmlComponents, htmlEvents, htmlAttributes, errorListener, view)
-            .resolve();
-        if (template != null) {
-          templates.add(template);
+        new TemplateResolver(typeProvider, htmlComponents, htmlEvents,
+                htmlAttributes, errorListener)
+            .resolve(view.template);
+        if (view.template != null) {
+          templates.add(view.template);
         }
-        errors.addAll(errorListener.errors
-            .where((e) => !template.ignoredErrors.contains(e.errorCode.name)));
+        errors.addAll(errorListener.errors.where(
+            (e) => !view.template.ignoredErrors.contains(e.errorCode.name)));
       }
     }
     //
     // Record outputs.
     //
     outputs[DART_TEMPLATES] = templates;
-    outputs[DART_TEMPLATES_ERRORS] = errors;
+    outputs[DART_TEMPLATES_ERRORS] = errors
+      ..addAll(inputs[ANGULAR_ASTS_ERRORS_INPUT] ?? []);
   }
 
   /**
@@ -1385,7 +1508,23 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
           STANDARD_HTML_ELEMENT_EVENTS.of(AnalysisContextTarget.request),
       HTML_ATTRIBUTES_INPUT:
           STANDARD_HTML_ELEMENT_ATTRIBUTES.of(AnalysisContextTarget.request),
-      VIEWS_INPUT: VIEWS.of(target),
+      VIEWS_INPUT: VIEWS2.of(target),
+      // Not only is it important we calculate these errors, its important that
+      // the AST conversion which creates those errors is performed
+      ANGULAR_ASTS_ERRORS_INPUT: ANGULAR_ASTS_ERRORS
+          .of(target)
+          .mappedToList((map) => map[(target as LibrarySpecificUnit).source]),
+      // only express the dependency that dependent directives have ngContentSelectors
+      'childDirectivesAsts': DIRECTIVES_IN_LIBRARY
+          .of((target as LibrarySpecificUnit).library)
+          .mappedToList((directives) => directives
+              .map((d) => new LibrarySpecificUnit(d.source, d.source))
+              // TODO we should get LIBRARY_SPECIFIC_UNITS, not make one.
+              // But for some reason this fails. Only affects files with parts.
+              //.map((d) => d.source)
+              .toList())
+          //.toListOf(LIBRARY_SPECIFIC_UNITS)
+          .toListOf(ANGULAR_ASTS),
     };
   }
 
@@ -1395,6 +1534,173 @@ class ResolveDartTemplatesTask extends SourceBasedAnalysisTask {
   static ResolveDartTemplatesTask createTask(
       AnalysisContext context, AnalysisTarget target) {
     return new ResolveDartTemplatesTask(context, target);
+  }
+}
+
+class GetAstsForTemplatesInUnitTask extends SourceBasedAnalysisTask
+    with ParseHtmlMixin {
+  static const String DIRECTIVES_IN_UNIT1_INPUT = 'DIRECTIVES_IN_UNIT1_INPUT';
+  static const String HTML_DOCUMENTS_INPUT = 'HTML_DOCUMENTS_INPUT';
+  static const String TYPE_PROVIDER_INPUT = 'TYPE_PROVIDER_INPUT';
+  static const String EXTRA_NODES_INPUT = 'EXTRA_NODES_INPUT';
+
+  static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
+      'GetAstsForTemplatesInUnitTask',
+      createTask,
+      buildInputs,
+      <ResultDescriptor>[ANGULAR_ASTS, ANGULAR_ASTS_ERRORS]);
+
+  @override
+  TaskDescriptor get descriptor => DESCRIPTOR;
+
+  GetAstsForTemplatesInUnitTask(AnalysisContext context, AnalysisTarget target)
+      : super(context, target);
+
+  void internalPerform() {
+    List<AbstractDirective> directives =
+        getRequiredInput(DIRECTIVES_IN_UNIT1_INPUT);
+    Map<Source, html.Document> documentsMap =
+        getRequiredInput(HTML_DOCUMENTS_INPUT);
+    Map<Source, List<NodeInfo>> extraNodesMap =
+        getRequiredInput(EXTRA_NODES_INPUT);
+    List<ElementInfo> asts = <ElementInfo>[];
+    Map<Source, List<AnalysisError>> errorsByFile =
+        <Source, List<AnalysisError>>{};
+    directives.forEach((d) {
+      if (d is Component) {
+        View view = d.view;
+        if (view == null || view.templateSource == null) {
+          return; // go to next forEach
+        }
+
+        RecordingErrorListener errorListener = new RecordingErrorListener();
+        ErrorReporter errorReporter =
+            new ErrorReporter(errorListener, view.templateSource);
+
+        Source source = view.templateSource;
+        if (view.templateUriSource != null) {
+          if (documentsMap[source].nodes.length == 0) {
+            return;
+          }
+
+          _processView(
+              new Template(d.view),
+              documentsMap[source],
+              errorListener,
+              errorReporter,
+              extraNodesMap[source],
+              asts,
+              errorsByFile);
+        } else {
+          if (view.templateText == null) {
+            return;
+          }
+
+          errorReporter = new ErrorReporter(errorListener, source);
+          parse((' ' * view.templateOffset) + view.templateText);
+          parseErrors.forEach(errorListener.onError);
+          parseErrors.clear();
+
+          _processView(new Template(view), document, errorListener,
+              errorReporter, extraNodes, asts, errorsByFile);
+          extraNodes.clear();
+        }
+      }
+    });
+    outputs[ANGULAR_ASTS] = asts;
+    outputs[ANGULAR_ASTS_ERRORS] = errorsByFile;
+  }
+
+  _processView(
+      Template template,
+      html.Document document,
+      RecordingErrorListener errorListener,
+      ErrorReporter errorReporter,
+      List<ElementInfo> extraNodes,
+      List<ElementInfo> asts,
+      Map<Source, List<AnalysisError>> errorsByFile) {
+    Source source = template.view.templateSource;
+    TypeProvider typeProvider = getRequiredInput(TYPE_PROVIDER_INPUT);
+    EmbeddedDartParser parser = new EmbeddedDartParser(
+        source, errorListener, typeProvider, errorReporter);
+    template.view.template = template;
+
+    template.ast = new HtmlTreeConverter(parser, source, errorListener)
+        .convert(firstElement(document));
+    _setIgnoredErrors(template, document);
+
+    if (extraNodes != null) {
+      template.extraNodes.addAll(extraNodes);
+      extraNodes.clear();
+    }
+
+    template.ast.accept(new NgContentRecorder(template, errorReporter));
+
+    asts.add(template.ast);
+
+    if (errorsByFile[source] == null) {
+      errorsByFile[source] = <AnalysisError>[];
+    }
+    errorsByFile[source].addAll(errorListener.errors);
+  }
+
+  _setIgnoredErrors(Template template, html.Document document) {
+    if (document == null || document.nodes.length == 0) {
+      return;
+    }
+    html.Node firstNode = document.nodes[0];
+    if (firstNode is html.Comment) {
+      String text = firstNode.text.trim();
+      if (text.startsWith("@ngIgnoreErrors")) {
+        text = text.substring("@ngIgnoreErrors".length);
+        // Per spec: optional color
+        if (text.startsWith(":")) {
+          text = text.substring(1);
+        }
+        // Per spec: optional commas
+        String delim = text.indexOf(',') == -1 ? ' ' : ',';
+        template.ignoredErrors.addAll(new HashSet.from(
+            text.split(delim).map((c) => c.trim().toUpperCase())));
+      }
+    }
+  }
+
+  /**
+   * Return a map from the names of the inputs of this kind of task to the
+   * task input descriptors describing those inputs for a task with the
+   * given [target].
+   */
+  static Map<String, TaskInput> buildInputs(AnalysisTarget target) {
+    return <String, TaskInput>{
+      DIRECTIVES_IN_UNIT1_INPUT: DIRECTIVES_IN_UNIT.of(target),
+      TYPE_PROVIDER_INPUT: TYPE_PROVIDER.of(AnalysisContextTarget.request),
+      HTML_DOCUMENTS_INPUT: VIEWS_WITH_HTML_TEMPLATES1
+          .of(target)
+          // mapped to html source of the view
+          .mappedToList((views) => views
+              .map((v) => v.templateUriSource)
+              .where((v) => v != null)
+              .toList())
+          // to map<source, html document of source>
+          .toMapOf(ANGULAR_HTML_DOCUMENT),
+      EXTRA_NODES_INPUT: VIEWS_WITH_HTML_TEMPLATES1
+          .of(target)
+          // mapped to html source of the view
+          .mappedToList((views) => views
+              .map((v) => v.templateUriSource)
+              .where((v) => v != null)
+              .toList())
+          // to map<source, html document of source>
+          .toMapOf(ANGULAR_HTML_DOCUMENT_EXTRA_NODES)
+    };
+  }
+
+  /**
+   * Create a task based on the given [target] in the given [context].
+   */
+  static GetAstsForTemplatesInUnitTask createTask(
+      AnalysisContext context, AnalysisTarget target) {
+    return new GetAstsForTemplatesInUnitTask(context, target);
   }
 }
 
@@ -1466,6 +1772,7 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
   static const String HTML_DOCUMENT_ERROR_INPUT = 'HTML_DOCUMENT_ERROR_INPUT';
   static const String HTML_DOCUMENT_EXTRA_NODES_INPUT =
       'HTML_DOCUMENT_EXTRA_NODES_INPUT';
+  static const String ANGULAR_ASTS_ERRORS_INPUT = 'ANGULAR_ASTS_ERRORS_INPUT';
 
   static final TaskDescriptor DESCRIPTOR = new TaskDescriptor(
       'ResolveHtmlTemplateTask',
@@ -1500,29 +1807,22 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
     Map<String, OutputElement> htmlEvents = getRequiredInput(HTML_EVENTS_INPUT);
     Map<String, InputElement> htmlAttributes =
         getRequiredInput(HTML_ATTRIBUTES_INPUT);
-    html.Document document = getRequiredInput(HTML_DOCUMENT_INPUT);
-    List<AnalysisError> documentErrors =
-        getRequiredInput(HTML_DOCUMENT_ERROR_INPUT);
-    List<NodeInfo> extraNodes =
-        getRequiredInput(HTML_DOCUMENT_EXTRA_NODES_INPUT);
     //
     // Resolve.
     //
     View view = target;
-    _addParseErrors(documentErrors);
-    Template template = new HtmlTemplateResolver(
-            typeProvider,
-            htmlComponents,
-            htmlEvents,
-            htmlAttributes,
-            errorListener,
-            view,
-            document,
-            extraNodes)
-        .resolve();
-
-    List<AnalysisError> errorList = errorListener.errors
-        .where((e) => !template.ignoredErrors.contains(e.errorCode.name))
+    if (view.template != null) {
+      new TemplateResolver(typeProvider, htmlComponents, htmlEvents,
+              htmlAttributes, errorListener)
+          .resolve(view.template);
+    }
+    //
+    // Record outputs.
+    //
+    List<AnalysisError> errorList = (<AnalysisError>[]
+          ..addAll(errorListener.errors)
+          ..addAll(inputs[ANGULAR_ASTS_ERRORS_INPUT] ?? []))
+        .where((e) => !view.template.ignoredErrors.contains(e.errorCode.name))
         .toList();
 
     String shorten(String filename) =>
@@ -1534,10 +1834,8 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
           .map((e) => new FromFilePrefixedError(view.source, e))
           .toList();
     }
-    //
-    // Record outputs.
-    //
-    outputs[HTML_TEMPLATE] = template;
+
+    outputs[HTML_TEMPLATE] = view.template;
     outputs[HTML_TEMPLATE_ERRORS] = errorList;
   }
 
@@ -1555,12 +1853,30 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
           STANDARD_HTML_ELEMENT_EVENTS.of(AnalysisContextTarget.request),
       HTML_ATTRIBUTES_INPUT:
           STANDARD_HTML_ELEMENT_ATTRIBUTES.of(AnalysisContextTarget.request),
-      HTML_DOCUMENT_INPUT:
-          ANGULAR_HTML_DOCUMENT.of((target as View).templateUriSource),
-      HTML_DOCUMENT_ERROR_INPUT:
-          ANGULAR_HTML_DOCUMENT_ERRORS.of((target as View).templateUriSource),
       HTML_DOCUMENT_EXTRA_NODES_INPUT: ANGULAR_HTML_DOCUMENT_EXTRA_NODES
           .of((target as View).templateUriSource),
+      // Not only is it important we calculate these errors, its important that
+      // the AST conversion which creates those errors is performed
+      ANGULAR_ASTS_ERRORS_INPUT: LIBRARY_SPECIFIC_UNITS
+          .of((target as View).component.source)
+          .toListOf(ANGULAR_ASTS_ERRORS)
+          .mappedToList((maps) {
+        Map<Source, List<AnalysisError>> deduped =
+            <Source, List<AnalysisError>>{};
+        maps.forEach(deduped.addAll);
+        return deduped[(target as View).templateSource];
+      }),
+      // only express the dependency that dependent directives have ngContentSelectors
+      'childDirectivesAsts': DIRECTIVES_IN_LIBRARY
+          .of((target as View).component.source)
+          .mappedToList((directives) => directives
+              .map((d) => new LibrarySpecificUnit(d.source, d.source))
+              // TODO we should get LIBRARY_SPECIFIC_UNITS, not make one.
+              // But for some reason this fails. Only affects files with parts.
+              //.map((d) => d.source)
+              .toList())
+          //.toListOf(LIBRARY_SPECIFIC_UNITS)
+          .toListOf(ANGULAR_ASTS),
     };
   }
 
@@ -1570,15 +1886,6 @@ class ResolveHtmlTemplateTask extends AnalysisTask {
   static ResolveHtmlTemplateTask createTask(
       AnalysisContext context, AnalysisTarget target) {
     return new ResolveHtmlTemplateTask(context, target);
-  }
-
-  /**
-   * Report HTML errors as [AnalysisError]
-   */
-  void _addParseErrors(List<AnalysisError> allErrors) {
-    for (AnalysisError error in allErrors) {
-      errorListener.onError(error);
-    }
   }
 }
 

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -299,6 +299,25 @@ class AngularWarningCode extends ErrorCode {
               " too complex for errors to be mapped to locations in the file");
 
   /**
+   * An error code indicating that dom inside a component won't be transcluded
+   */
+  static const AngularWarningCode CONTENT_NOT_TRANSCLUDED =
+      const AngularWarningCode(
+          'CONTENT_NOT_TRANSCLUDED',
+          "The content does not match any transclusion selectors of the" +
+              " surrounding component");
+
+  /**
+   * An error code indicating that an <ng-content> tag had content, which is not
+   * allowed.
+   */
+  static const AngularWarningCode NG_CONTENT_MUST_BE_EMPTY =
+      const AngularWarningCode(
+          'NG_CONTENT_MUST_BE_EMPTY',
+          "Nothing is allowed inside an <ng-content> tag, as it will be" +
+              " replaced");
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -112,8 +112,8 @@ class AbstractAngularTest {
   List<View> computeLibraryViews(Source dartSource) {
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
-    return outputs[VIEWS_WITH_HTML_TEMPLATES];
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+    return outputs[VIEWS_WITH_HTML_TEMPLATES2];
   }
 
   void computeResult(AnalysisTarget target, ResultDescriptor result) {

--- a/analyzer_plugin/test/angular_work_manager_test.dart
+++ b/analyzer_plugin/test/angular_work_manager_test.dart
@@ -102,13 +102,13 @@ class AngularWorkManagerTest {
     expect(
         nextResult,
         new TargetedResult(new LibrarySpecificUnit(dartSource1, dartSource1),
-            VIEWS_WITH_HTML_TEMPLATES));
+            VIEWS_WITH_HTML_TEMPLATES2));
     expect(manager.priorityDartSourcesForViews, [dartSource1]);
   }
 
   void test_getNextResult_priorityDartSourcesForViews_alreadyComputed() {
     manager.priorityDartSourcesForViews.add(dartSource1);
-    dartUnitEntry1.setValue(VIEWS_WITH_HTML_TEMPLATES, [], []);
+    dartUnitEntry1.setValue(VIEWS_WITH_HTML_TEMPLATES2, [], []);
     TargetedResult nextResult = manager.getNextResult();
     expect(nextResult, null);
     expect(manager.priorityDartSourcesForKind, isEmpty);
@@ -189,25 +189,25 @@ class AngularWorkManagerTest {
     expect(cache.getValue(templateUriSource, TEMPLATE_VIEWS), isEmpty);
     // add "view1"
     manager.resultsComputed(source1, {
-      VIEWS_WITH_HTML_TEMPLATES: [view1]
+      VIEWS_WITH_HTML_TEMPLATES2: [view1]
     });
     expect(cache.getValue(templateUriSource, TEMPLATE_VIEWS),
         unorderedEquals([view1]));
     // add "view2" from "source3"
-    entry3.setValue(VIEWS_WITH_HTML_TEMPLATES, [view2], []);
+    entry3.setValue(VIEWS_WITH_HTML_TEMPLATES2, [view2], []);
     manager.resultsComputed(source3, {
-      VIEWS_WITH_HTML_TEMPLATES: [view2]
+      VIEWS_WITH_HTML_TEMPLATES2: [view2]
     });
     expect(cache.getValue(templateUriSource, TEMPLATE_VIEWS),
         unorderedEquals([view1, view2]));
     // add "view3"
     manager.resultsComputed(source1, {
-      VIEWS_WITH_HTML_TEMPLATES: [view3]
+      VIEWS_WITH_HTML_TEMPLATES2: [view3]
     });
     expect(cache.getValue(templateUriSource, TEMPLATE_VIEWS),
         unorderedEquals([view1, view2, view3]));
     // invalidate [view2]
-    entry3.setState(VIEWS_WITH_HTML_TEMPLATES, CacheState.INVALID);
+    entry3.setState(VIEWS_WITH_HTML_TEMPLATES2, CacheState.INVALID);
     expect(cache.getValue(templateUriSource, TEMPLATE_VIEWS),
         unorderedEquals([view1, view3]));
   }

--- a/analyzer_plugin/test/fuzz_test.dart
+++ b/analyzer_plugin/test/fuzz_test.dart
@@ -6,8 +6,8 @@ import 'package:front_end/src/scanner/token.dart';
 import 'package:analyzer/task/dart.dart';
 import 'package:analyzer/task/html.dart';
 import 'package:analyzer/task/model.dart';
-import 'package:angular_analyzer_plugin/src/tasks.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
+import 'package:angular_analyzer_plugin/src/tasks.dart';
 import 'package:unittest/unittest.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -429,7 +429,7 @@ class CounterComponent {
       fuzz_addHtmlChunk,
     ];
 
-    const iters = 50000;
+    const iters = 1000000;
     for (var i = 0; i < iters; ++i) {
       var transforms = random.nextInt(20) + 1;
       print("Fuzz $i: $transforms transforms");
@@ -591,8 +591,8 @@ class CounterComponent {
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
     // compute Angular templates, ensure no exception thrown
-    checkNoCrashForComputeResult(target, VIEWS_WITH_HTML_TEMPLATES, reason);
-    List<View> views = task.outputs[VIEWS_WITH_HTML_TEMPLATES];
+    checkNoCrashForComputeResult(target, VIEWS_WITH_HTML_TEMPLATES2, reason);
+    List<View> views = task.outputs[VIEWS_WITH_HTML_TEMPLATES2];
     checkNoCrashForComputeResult(dartSource, DART_ERRORS, reason);
     if (views.length > 0 &&
         views.first.templateUriSource.fullName == '/test.html') {

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2485,6 +2485,7 @@ class TestPanel {
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);
     errorListener.assertErrorsWithCodes([
+      HtmlErrorCode.PARSE_ERROR,
       ParserErrorCode.EXPECTED_LIST_OR_MAP_LITERAL,
       ParserErrorCode.EXPECTED_TOKEN,
       ParserErrorCode.EXPECTED_TYPE_NAME,

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -3,6 +3,7 @@ library angular2.src.analysis.analyzer_plugin.src.resolver_test;
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/error/codes.dart';
 import 'package:analyzer/src/dart/error/syntactic_errors.dart';
+import 'package:analyzer/task/dart.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
@@ -2484,13 +2485,353 @@ class TestPanel {
     _addHtmlSource(code);
     _resolveSingleTemplate(dartSource);
     errorListener.assertErrorsWithCodes([
-      HtmlErrorCode.PARSE_ERROR,
       ParserErrorCode.EXPECTED_LIST_OR_MAP_LITERAL,
       ParserErrorCode.EXPECTED_TOKEN,
       ParserErrorCode.EXPECTED_TYPE_NAME,
       StaticTypeWarningCode.NON_TYPE_AS_TYPE_ARGUMENT,
       AngularWarningCode.DISALLOWED_EXPRESSION
     ]);
+  }
+
+  void test_resolveTemplateWithNgContentTracksSelectors() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    String code = r"""
+<div>
+  <ng-content select="foo"></ng-content>
+</div>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    expect(template.ngContents, hasLength(1));
+  }
+
+  void test_resolveTemplateWithNgContent_noSelectorIsNull() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    String code = r"""
+<div>
+  <ng-content></ng-content>
+</div>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    expect(template.ngContents, hasLength(1));
+    expect(template.ngContents.first.selector, isNull);
+  }
+
+  void test_resolveTemplateWithNgContent_selectorParseError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    String code = r"""
+<div>
+  <ng-content select="foo+bar"></ng-content>
+</div>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    expect(template.ngContents, hasLength(0));
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CANNOT_PARSE_SELECTOR, code, "+");
+  }
+
+  void test_resolveTemplateWithNgContent_emptySelectorError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    String code = r"""
+<div>
+  <ng-content select=""></ng-content>
+</div>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    expect(template.ngContents, hasLength(0));
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CANNOT_PARSE_SELECTOR, code, "\"\"");
+  }
+
+  void test_resolveTemplateWithNgContent_noValueError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    String code = r"""
+<div>
+  <ng-content select></ng-content>
+</div>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    expect(template.ngContents, hasLength(0));
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CANNOT_PARSE_SELECTOR, code, "select");
+  }
+
+  void test_resolveTemplateWithNgContent_hasContentsError() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    String code = r"""
+<div>
+  <ng-content>with content</ng-content>
+</div>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.NG_CONTENT_MUST_BE_EMPTY, code, "<ng-content>");
+  }
+
+  void test_resolveTemplate_provideContentWhereInvalid() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NoTransclude])
+class TestPanel {
+}
+@Component(selector: 'no-transclude')
+@View(template: '')
+class NoTransclude {
+}
+''');
+    String code = r"""
+<no-transclude>doesn't belong</no-transclude>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_NOT_TRANSCLUDED, code, "doesn't belong");
+  }
+
+  void test_resolveTemplate_provideContentNgSelectAll() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeAll])
+class TestPanel {
+}
+@Component(selector: 'transclude-all')
+@View(template: '<ng-content></ng-content>')
+class TranscludeAll {
+}
+''');
+    String code = r"""
+<transclude-all>belongs</transclude-all>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_resolveTemplate_provideContentEmptyTextAlwaysOK() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NoTransclude])
+class TestPanel {
+}
+@Component(selector: 'no-transclude')
+@View(template: '')
+class NoTransclude {
+}
+''');
+    String code = r"""
+<no-transclude>
+</no-transclude>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_resolveTemplate_provideContentNgSelectAllWithSelectors() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeAll])
+class TestPanel {
+}
+@Component(selector: 'transclude-all')
+@View(template: '<ng-content select="x"></ng-content><ng-content></ng-content>')
+class TranscludeAll {
+}
+''');
+    String code = r"""
+<transclude-all>belongs</transclude-all>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_resolveTemplate_provideContentNotMatchingSelectors() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeSome {
+}
+''');
+    String code = r"""
+<transclude-some><div></div></transclude-some>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_NOT_TRANSCLUDED, code, "<div></div>");
+  }
+
+  void test_resolveTemplate_provideTextInfosDontMatchSelectors() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeSome {
+}
+''');
+    String code = r"""
+<transclude-some>doesn't belong</transclude-some>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_NOT_TRANSCLUDED, code, "doesn't belong");
+  }
+
+  void test_resolveTemplate_provideContentMatchingSelectors() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="[transclude-me]"></ng-content>')
+class TranscludeSome {
+}
+''');
+    String code = r"""
+<transclude-some><div transclude-me></div></transclude-some>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_resolveTemplate_provideContentMatchingSelectorsKnowsTag() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeSome {
+}
+''');
+    String code = r"""
+<transclude-some><transclude-me></transclude-me></transclude-some>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_resolveTemplate_provideContentMatchingSelectorsAndAllKnowsTag() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [TranscludeAllAndKnowsTag])
+class TestPanel {
+}
+@Component(selector: 'transclude-all-and-knows-tag')
+@View(template:
+    '<ng-content select="transclude-me"></ng-content><ng-content></ng-content>')
+class TranscludeAllAndKnowsTag {
+}
+''');
+    String code = r"""
+<transclude-all-and-knows-tag>
+  <transclude-me></transclude-me>
+</transclude-all-and-knows-tag>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_resolveTemplate_provideContentMatchingSelectorsReportsUnknownTag() {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="[transclude-me]"></ng-content>')
+class TranscludeSome {
+}
+''');
+    String code = r"""
+<transclude-some><unknown-tag transclude-me></unknown-tag></transclude-some>
+    """;
+    _addHtmlSource(code);
+    computeResult(
+        new LibrarySpecificUnit(dartSource, dartSource), ANGULAR_ASTS);
+    _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.UNRESOLVED_TAG, code, "unknown-tag");
   }
 
   void _addDartSource(String code) {

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -26,6 +26,7 @@ main() {
   defineReflectiveTests(BuildStandardHtmlComponentsTaskTest);
   defineReflectiveTests(BuildUnitDirectivesTaskTest);
   defineReflectiveTests(BuildUnitViewsTaskTest);
+  defineReflectiveTests(BuildUnitViewsTask2Test);
   defineReflectiveTests(ComputeDirectivesInLibraryTaskTest);
   defineReflectiveTests(ResolveDartTemplatesTaskTest);
   defineReflectiveTests(ResolveHtmlTemplatesTaskTest);
@@ -1526,6 +1527,49 @@ class MyComponent {
 
 @reflectiveTest
 class BuildUnitViewsTaskTest extends AbstractAngularTest {
+  void test_buildViewsDoesntGetDependentDirectives() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'other_file.dart';
+
+import '/angular2/angular2.dart';
+@Component(selector: 'my-component', template: 'My template',
+    directives: const [OtherComponent])
+class MyComponent {}
+''';
+    String otherCode = r'''
+import '/angular2/angular2.dart';
+@Component(selector: 'other-component', template: 'My template',
+    directives: const [])
+class OtherComponent {}
+''';
+    Source source = newSource('/test.dart', code);
+    Source dependentSource = newSource('/other_file.dart', otherCode);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, VIEWS1);
+    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    // validate views
+    List<View> views = outputs[VIEWS1];
+    {
+      View view = getViewByClassName(views, 'MyComponent');
+      {
+        expect(view.directives, hasLength(0));
+      }
+    }
+    // no errors
+    fillErrorListener(VIEWS_ERRORS1);
+    errorListener.assertNoErrors();
+
+    List<AbstractDirective> otherFileDirectives = context.analysisCache
+        .getValue(new LibrarySpecificUnit(dependentSource, dependentSource),
+            DIRECTIVES_IN_UNIT);
+    // shouldn't be run yet
+    expect(otherFileDirectives, hasLength(0));
+  }
+}
+
+@reflectiveTest
+class BuildUnitViewsTask2Test extends AbstractAngularTest {
   void test_directives() {
     String code = r'''
 import '/angular2/angular2.dart';
@@ -1547,10 +1591,10 @@ class MyComponent {}
 ''';
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate views
-    List<View> views = outputs[VIEWS];
+    List<View> views = outputs[VIEWS2];
     {
       View view = getViewByClassName(views, 'MyComponent');
       {
@@ -1563,7 +1607,7 @@ class MyComponent {}
       }
     }
     // no errors
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertNoErrors();
   }
 
@@ -1579,10 +1623,10 @@ class MyComponent {}
 ''';
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // no errors
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.TYPE_LITERAL_EXPECTED]);
   }
@@ -1598,10 +1642,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.COMPONENT_ANNOTATION_MISSING]);
   }
@@ -1617,10 +1661,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.DIRECTIVE_TYPE_LITERAL_EXPECTED]);
   }
@@ -1636,10 +1680,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.STRING_VALUE_EXPECTED]);
   }
@@ -1655,10 +1699,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertNoErrors();
   }
 
@@ -1675,10 +1719,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.STRING_VALUE_EXPECTED]);
   }
@@ -1694,10 +1738,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.TYPE_LITERAL_EXPECTED]);
   }
@@ -1714,10 +1758,10 @@ class ComponentA {
 ''');
     newSource('/a.html', '');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.TEMPLATE_URL_AND_TEMPLATE_DEFINED]);
   }
@@ -1733,10 +1777,10 @@ class ComponentA {
 }
 ''');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.NO_TEMPLATE_URL_OR_TEMPLATE_DEFINED]);
   }
@@ -1751,10 +1795,10 @@ class MyComponent {}
     Source dartSource = newSource('/test.dart', code);
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    fillErrorListener(VIEWS_ERRORS);
+    fillErrorListener(VIEWS_ERRORS2);
     assertErrorInCodeAtPosition(
         AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST,
         code,
@@ -1772,12 +1816,12 @@ class MyComponent {}
     Source htmlSource = newSource('/my-template.html', '');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     List<AbstractDirective> directives =
         context.analysisCache.getValue(target, DIRECTIVES_IN_UNIT);
     // validate views
-    List<View> views = outputs[VIEWS];
+    List<View> views = outputs[VIEWS2];
     expect(views, hasLength(1));
     // MyComponent
     View view = getViewByClassName(views, 'MyComponent');
@@ -1792,7 +1836,7 @@ class MyComponent {}
           new SourceRange(code.indexOf(url), url.length));
     }
     // has a single view
-    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES];
+    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES2];
     expect(templateViews, unorderedEquals([view]));
   }
 
@@ -1808,12 +1852,12 @@ class MyComponent {}
     Source htmlSource = newSource('/my-template.html', '');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     List<AbstractDirective> directives =
         context.analysisCache.getValue(target, DIRECTIVES_IN_UNIT);
     // validate views
-    List<View> views = outputs[VIEWS];
+    List<View> views = outputs[VIEWS2];
     expect(views, hasLength(1));
     // MyComponent
     View view = getViewByClassName(views, 'MyComponent');
@@ -1828,7 +1872,7 @@ class MyComponent {}
           new SourceRange(code.indexOf(url), url.length));
     }
     // has a single view
-    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES];
+    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES2];
     expect(templateViews, unorderedEquals([view]));
   }
 
@@ -1848,12 +1892,12 @@ class MyComponent {}
 ''';
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     List<AbstractDirective> directives =
         context.analysisCache.getValue(target, DIRECTIVES_IN_UNIT);
     // validate views
-    List<View> views = outputs[VIEWS];
+    List<View> views = outputs[VIEWS2];
     expect(views, hasLength(2));
     {
       View view = getViewByClassName(views, 'MyComponent');
@@ -1873,7 +1917,7 @@ class MyComponent {}
       }
     }
     // no view with external templates
-    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES];
+    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES2];
     expect(templateViews, hasLength(0));
   }
 
@@ -1894,12 +1938,12 @@ class MyComponent {}
 ''';
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, VIEWS);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    computeResult(target, VIEWS2);
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     List<AbstractDirective> directives =
         context.analysisCache.getValue(target, DIRECTIVES_IN_UNIT);
     // validate views
-    List<View> views = outputs[VIEWS];
+    List<View> views = outputs[VIEWS2];
     expect(views, hasLength(2));
     {
       View view = getViewByClassName(views, 'MyComponent');
@@ -1919,7 +1963,7 @@ class MyComponent {}
       }
     }
     // no view with external templates
-    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES];
+    List<View> templateViews = outputs[VIEWS_WITH_HTML_TEMPLATES2];
     expect(templateViews, hasLength(0));
   }
 }
@@ -2166,12 +2210,12 @@ class ComponentA {
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSourceRegular, dartSourceRegular);
-      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     // compute Angular templates
     computeResult(htmlSource, HTML_TEMPLATES_ERRORS);
@@ -2249,7 +2293,7 @@ class ComponentA {
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     // compute Angular templates
     computeResult(htmlSource, HTML_TEMPLATES);
@@ -2290,11 +2334,9 @@ class TextPanel {
 }
 ''';
     Source source = newSource('/test.dart', code);
-    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, DART_TEMPLATES);
-    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    computeResult(source, DART_ERRORS);
     // has errors
-    fillErrorListener(DART_TEMPLATES_ERRORS);
+    fillErrorListener(DART_ERRORS);
     errorListener.assertErrorsWithCodes([HtmlErrorCode.PARSE_ERROR]);
   }
 
@@ -2527,14 +2569,9 @@ class TextPanel {
 }
 ''';
     Source source = newSource('/test.dart', code);
-    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, DART_TEMPLATES);
-    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
-    // validate
-    List<Template> templates = outputs[DART_TEMPLATES];
-    expect(templates, hasLength(1));
+    computeResult(source, DART_ERRORS);
     // has errors
-    fillErrorListener(DART_TEMPLATES_ERRORS);
+    fillErrorListener(DART_ERRORS);
     errorListener
         .assertErrorsWithCodes([AngularWarningCode.UNTERMINATED_MUSTACHE]);
   }
@@ -2548,14 +2585,9 @@ class TextPanel {
 }
 ''';
     Source source = newSource('/test.dart', code);
-    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, DART_TEMPLATES);
-    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
-    // validate
-    List<Template> templates = outputs[DART_TEMPLATES];
-    expect(templates, hasLength(1));
+    computeResult(source, DART_ERRORS);
     // has errors
-    fillErrorListener(DART_TEMPLATES_ERRORS);
+    fillErrorListener(DART_ERRORS);
     errorListener.assertErrorsWithCodes([AngularWarningCode.UNOPENED_MUSTACHE]);
   }
 
@@ -2569,14 +2601,9 @@ class TextPanel {
 }
 ''';
     Source source = newSource('/test.dart', code);
-    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, DART_TEMPLATES);
-    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
-    // validate
-    List<Template> templates = outputs[DART_TEMPLATES];
-    expect(templates, hasLength(1));
+    computeResult(source, DART_ERRORS);
     // has errors
-    fillErrorListener(DART_TEMPLATES_ERRORS);
+    fillErrorListener(DART_ERRORS);
     errorListener.assertErrorsWithCodes([
       AngularWarningCode.UNTERMINATED_MUSTACHE,
       StaticWarningCode.UNDEFINED_IDENTIFIER
@@ -2593,14 +2620,9 @@ class TextPanel {
 }
 ''';
     Source source = newSource('/test.dart', code);
-    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, DART_TEMPLATES);
-    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
-    // validate
-    List<Template> templates = outputs[DART_TEMPLATES];
-    expect(templates, hasLength(1));
+    computeResult(source, DART_ERRORS);
     // has errors
-    fillErrorListener(DART_TEMPLATES_ERRORS);
+    fillErrorListener(DART_ERRORS);
     errorListener.assertErrorsWithCodes([
       AngularWarningCode.UNTERMINATED_MUSTACHE,
       AngularWarningCode.UNTERMINATED_MUSTACHE,
@@ -2661,6 +2683,103 @@ class TextPanel {
     errorListener.assertNoErrors();
   }
 
+  void test_resolveGetChildDirectivesNgContentSelectors() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'child_file.dart';
+
+import '/angular2/angular2.dart';
+@Component(selector: 'my-component', template: 'My template',
+    directives: const [ChildComponent])
+class MyComponent {}
+''';
+    String childCode = r'''
+import '/angular2/angular2.dart';
+@Component(selector: 'child-component',
+    template: 'My template <ng-content></ng-content>',
+    directives: const [])
+class ChildComponent {}
+''';
+    Source source = newSource('/test.dart', code);
+    Source childSource = newSource('/child_file.dart', childCode);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // validate views
+    List<Template> templates = outputs[DART_TEMPLATES];
+    expect(templates, hasLength(1));
+    // no errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    errorListener.assertNoErrors();
+
+    List<AbstractDirective> childDirectives = context.analysisCache.getValue(
+        new LibrarySpecificUnit(childSource, childSource), DIRECTIVES_IN_UNIT);
+    expect(childDirectives, hasLength(1));
+
+    List<View> childViews = context.analysisCache
+        .getValue(new LibrarySpecificUnit(childSource, childSource), VIEWS1);
+    expect(childViews, hasLength(1));
+    View childView = childViews.first;
+    expect(childView.template, isNotNull);
+    expect(childView.template.ngContents, hasLength(1));
+  }
+
+  /**
+   * On hold. We need to make a "EXPORTED_DIRECTIVES_IN_UNIT" result/task pair
+   * and use that
+   *
+  void test_resolveDoesntGetGrandchildDirectives() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'child_file.dart';
+
+import '/angular2/angular2.dart';
+@Component(selector: 'my-component', template: 'My template',
+    directives: const [ChildComponent])
+class MyComponent {}
+''';
+    String childCode = r'''
+import '/angular2/angular2.dart';
+import 'grandchild_file.dart';
+@Component(selector: 'child-component', template: 'My template',
+    directives: const [GrandchildComponent])
+class ChildComponent {}
+''';
+    String grandchildCode = r'''
+import '/angular2/angular2.dart';
+@Component(selector: 'grandchild-component', template: 'My template',
+    directives: const [])
+class GrandchildComponent {}
+''';
+    Source source = newSource('/test.dart', code);
+    Source childSource = newSource('/child_file.dart', childCode);
+    Source grandchildSource =
+        newSource('/grandchild_file.dart', grandchildCode);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // validate views
+    List<Template> templates = outputs[DART_TEMPLATES];
+    expect(templates, hasLength(1));
+    // no errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    errorListener.assertNoErrors();
+
+    List<AbstractDirective> childDirectives = context.analysisCache.getValue(
+        new LibrarySpecificUnit(childSource, childSource), DIRECTIVES_IN_UNIT);
+    expect(childDirectives, hasLength(1));
+
+    List<View> childViews = context.analysisCache
+        .getValue(new LibrarySpecificUnit(childSource, childSource), VIEWS1);
+    expect(childViews, hasLength(0));
+
+    List<AbstractDirective> grandchildDirectives = context.analysisCache
+        .getValue(new LibrarySpecificUnit(grandchildSource, grandchildSource),
+            DIRECTIVES_IN_UNIT);
+    expect(grandchildDirectives, hasLength(0));
+  }
+  */
+
   static Template _getDartTemplateByClassName(
       List<Template> templates, String className) {
     return templates.firstWhere(
@@ -2698,7 +2817,7 @@ class TextPanelB {
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     // compute Angular templates
     computeResult(htmlSource, HTML_TEMPLATES);
@@ -2791,9 +2910,9 @@ class TextPanel {
     newSource('/text_panel.html', htmlCode);
     // compute
     computeLibraryViews(dartSource);
-    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    expect(task, new isInstanceOf<BuildUnitViewsTask2>());
     // validate
-    List<View> views = outputs[VIEWS_WITH_HTML_TEMPLATES];
+    List<View> views = outputs[VIEWS_WITH_HTML_TEMPLATES2];
     expect(views, hasLength(1));
     {
       View view = getViewByClassName(views, 'TextPanel');
@@ -2815,5 +2934,56 @@ class TextPanel {
         expect(element.nameOffset, dartCode.indexOf('text; // 1'));
       }
     }
+  }
+
+  void test_resolveGetChildDirectivesNgContentSelectors() {
+    String code = r'''
+import '/angular2/angular2.dart';
+import 'child_file.dart';
+
+import '/angular2/angular2.dart';
+@Component(selector: 'my-component', templateUrl: 'test.html',
+    directives: const [ChildComponent])
+class MyComponent {}
+''';
+    String childCode = r'''
+import '/angular2/angular2.dart';
+@Component(selector: 'child-component',
+    template: 'My template <ng-content></ng-content>',
+    directives: const [])
+class ChildComponent {}
+''';
+    Source source = newSource('/test.dart', code);
+    Source childSource = newSource('/child_file.dart', childCode);
+    newSource('/test.html', '');
+    View view;
+    {
+      LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES1);
+      expect(task, new isInstanceOf<BuildUnitViewsTask>());
+      List<View> views;
+      views = outputs[VIEWS_WITH_HTML_TEMPLATES1];
+      expect(views, hasLength(1));
+      view = views.first;
+    }
+    computeResult(view, HTML_TEMPLATE);
+    expect(task, new isInstanceOf<ResolveHtmlTemplateTask>());
+    // validate views
+    Template template = outputs[HTML_TEMPLATE];
+    expect(template, isNotNull);
+    // no errors
+    fillErrorListener(HTML_TEMPLATE_ERRORS);
+    errorListener.assertNoErrors();
+
+    List<AbstractDirective> childDirectives = context.analysisCache.getValue(
+        new LibrarySpecificUnit(childSource, childSource), DIRECTIVES_IN_UNIT);
+    expect(childDirectives, hasLength(1));
+
+    List<View> childViews = context.analysisCache
+        .getValue(new LibrarySpecificUnit(childSource, childSource), VIEWS1);
+    expect(childViews, hasLength(1));
+    View childView = childViews.first;
+    expect(childView.template, isNotNull);
+    expect(childView.template.ngContents, hasLength(1));
   }
 }

--- a/server_plugin/lib/src/analysis.dart
+++ b/server_plugin/lib/src/analysis.dart
@@ -63,7 +63,7 @@ class AngularNavigationContributor implements NavigationContributor {
         }
         // views
         {
-          List<View> views = context.getResult(target, VIEWS);
+          List<View> views = context.getResult(target, VIEWS2);
           for (View view in views) {
             _addViewRegions(collector, lineInfo, view);
           }

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -200,6 +200,8 @@ class AngularTemplateCompletionContributor extends CompletionContributor {
 }
 
 class TemplateCompleter {
+  static const int RELEVANCE_TRANSCLUSION = DART_RELEVANCE_DEFAULT + 10;
+
   Future<List<CompletionSuggestion>> computeSuggestions(
       CompletionRequest request,
       List<Template> templates,
@@ -261,6 +263,9 @@ class TemplateCompleter {
               standardHtmlEvents, target.boundStandardOutputs);
         } else {
           suggestHtmlTags(template, suggestions);
+          if (target.parent != null) {
+            suggestTransclusions(target.parent, suggestions);
+          }
         }
       } else if (target is ElementInfo &&
           target.openingSpan != null &&
@@ -270,10 +275,15 @@ class TemplateCompleter {
           request.offset ==
               (target.closingSpan.offset + target.closingSpan.length)) {
         suggestHtmlTags(template, suggestions, addOpenBracket: true);
+        suggestTransclusions(target.parent, suggestions);
       } else if (target is ElementInfo &&
           target.openingSpan != null &&
           request.offset == target.childNodesMaxEnd) {
         suggestHtmlTags(template, suggestions);
+        suggestTransclusions(target, suggestions);
+      } else if (target is ElementInfo) {
+        suggestHtmlTags(template, suggestions, addOpenBracket: true);
+        suggestTransclusions(target, suggestions);
       } else if (target is ExpressionBoundAttribute &&
           target.bound == ExpressionBoundType.input &&
           offsetContained(request.offset, target.originalNameOffset,
@@ -289,10 +299,47 @@ class TemplateCompleter {
         bool addOpenBracket =
             target.text[request.offset - target.offset - 1] != '<';
         suggestHtmlTags(template, suggestions, addOpenBracket: addOpenBracket);
+        suggestTransclusions(target.parent, suggestions);
       }
     }
 
     return suggestions;
+  }
+
+  suggestTransclusions(
+      ElementInfo container, List<CompletionSuggestion> suggestions) {
+    for (AbstractDirective directive in container.directives) {
+      if (directive is! Component) {
+        continue;
+      }
+
+      Component component = directive;
+      Template template = component?.view?.template;
+      if (template == null) {
+        continue;
+      }
+
+      for (NgContent ngContent in template.ngContents) {
+        if (ngContent.selector == null) {
+          continue;
+        }
+
+        List<HtmlTagForSelector> tags = ngContent.selector.suggestTags();
+        for (HtmlTagForSelector tag in tags) {
+          Location location = new Location(
+              template.view.templateSource.fullName,
+              ngContent.offset,
+              ngContent.length,
+              0,
+              0);
+          suggestions.add(_createHtmlTagSuggestion(
+              tag.toString(),
+              RELEVANCE_TRANSCLUSION,
+              _createHtmlTagTransclusionElement(tag.toString(),
+                  protocol.ElementKind.CLASS_TYPE_ALIAS, location)));
+        }
+      }
+    }
   }
 
   suggestHtmlTags(Template template, List<CompletionSuggestion> suggestions,
@@ -451,6 +498,14 @@ class TemplateCompleter {
     int flags = protocol.Element
         .makeFlags(isAbstract: false, isDeprecated: false, isPrivate: false);
     return new protocol.Element(kind, leftPad + elementTagName, flags,
+        location: location);
+  }
+
+  protocol.Element _createHtmlTagTransclusionElement(
+      String elementTagName, protocol.ElementKind kind, Location location) {
+    int flags = protocol.Element
+        .makeFlags(isAbstract: false, isDeprecated: false, isPrivate: false);
+    return new protocol.Element(kind, elementTagName, flags,
         location: location);
   }
 

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -203,7 +203,7 @@ class TextPanel {}
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     // compute Angular templates
     computeResult(htmlSource, HTML_TEMPLATES);
@@ -241,7 +241,7 @@ class TextPanel {
     {
       LibrarySpecificUnit target =
           new LibrarySpecificUnit(dartSource, dartSource);
-      computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+      computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
     }
     // compute Angular templates
     computeResult(htmlSource, HTML_TEMPLATES);

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -354,7 +354,7 @@ class MyComp {
     addTestSource('html file {{^}} with mustache');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -378,7 +378,7 @@ class MyComp {
     addTestSource('html file {{text.^}} with mustache');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -400,7 +400,7 @@ class MyComp {
     addTestSource('<div *ngFor="let item of text.^"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -422,7 +422,7 @@ class MyComp {
     addTestSource('<div *ngFor="let item of ^"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -446,7 +446,7 @@ class MyComp {
     addTestSource('<div *ngFor="let^ item of [text]"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -468,7 +468,7 @@ class MyComp {
     addTestSource('<div *ngFor="l^et item of [text]"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -490,7 +490,7 @@ class MyComp {
     addTestSource('<div *ngFor="let item^ of [text]"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -512,7 +512,7 @@ class MyComp {
     addTestSource('<div *ngFor="let i^tem of [text]"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -534,7 +534,7 @@ class MyComp {
     addTestSource('<div *ngFor="let ^"></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -556,7 +556,7 @@ class MyComp {
     addTestSource('<div *ngFor="let item of items">{{^}}</div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -577,7 +577,7 @@ class MyComp {
     addTestSource('<button #buttonEl>button</button> {{^}}');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -600,7 +600,7 @@ class MyComp {
         '<button #buttonEl>button</button><div *ngFor="item of items">{{hashCode.^}}</div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -623,7 +623,7 @@ class MyComp {
     addTestSource('<input /> {{^}}');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -645,7 +645,7 @@ class MyComp {
     addTestSource('<button (click)="^"></button>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -668,7 +668,7 @@ class MyComp {
     addTestSource('some text and {{^   <div>some html</div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -690,7 +690,7 @@ class MyComp {
     addTestSource('{{^}}');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -713,7 +713,7 @@ class MyComp {
     addTestSource('{{takesArg(^)}}');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -740,7 +740,7 @@ class OtherComp {
     addTestSource('<my-tag ^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -771,7 +771,7 @@ class OtherComp {
     addTestSource('<my-tag [name]="\'bob\'" ^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -801,7 +801,7 @@ class OtherComp {
     addTestSource('<my-tag [hidden]="true" ^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -832,7 +832,7 @@ class OtherComp {
     addTestSource('<my-tag [name^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -859,7 +859,7 @@ class OtherComp {
     addTestSource('<my-tag [hidden^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -886,7 +886,7 @@ class OtherComp {
     addTestSource('<my-tag (nameEvent)="" ^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -917,7 +917,7 @@ class OtherComp {
     addTestSource('<my-tag (nameEvent^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -944,7 +944,7 @@ class OtherComp {
     addTestSource('<my-tag (click)="" ^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -974,7 +974,7 @@ class OtherComp {
     addTestSource('<my-tag (click^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1003,7 +1003,7 @@ class OtherComp {
     addTestSource('<my-tag [(name)]="name" ^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1031,7 +1031,7 @@ class OtherComp {
     addTestSource('<my-tag [^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1061,7 +1061,7 @@ class OtherComp {
     addTestSource('<my-tag (^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1091,7 +1091,7 @@ class OtherComp {
     addTestSource('<my-tag [^input]="4"></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1121,7 +1121,7 @@ class OtherComp {
     addTestSource('<my-tag (^output)="4"></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1151,7 +1151,7 @@ class OtherComp {
     addTestSource('<my-tag></my-tag ^>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1181,7 +1181,7 @@ class OtherComp {
     addTestSource('<my-tag>^</my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1211,7 +1211,7 @@ class OtherComp {
     addTestSource('<my-tag^></my-tag>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1238,7 +1238,7 @@ class OtherComp {
     addTestSource('<^<div></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1264,7 +1264,7 @@ class OtherComp {
     addTestSource('<my^<div></div>');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1290,7 +1290,7 @@ class OtherComp {
     addTestSource('''<div><div><^</div></div>''');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1316,7 +1316,7 @@ class OtherComp {
     addTestSource('''<div><div> some text<^</div></div>''');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1342,7 +1342,7 @@ class OtherComp {
     addTestSource('''<div><div><my^</div></div>''');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1368,7 +1368,7 @@ class OtherComp {
     addTestSource('''<div><div></div></div><^''');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1395,7 +1395,7 @@ class OtherComp {
     <my^''');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1421,7 +1421,7 @@ class OtherComp {
     addTestSource('^');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1447,7 +1447,7 @@ class OtherComp {
     addTestSource('<div><div></div></div>^');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1473,7 +1473,7 @@ class OtherComp {
     addTestSource('<div>some text<^');
     LibrarySpecificUnit target =
         new LibrarySpecificUnit(dartSource, dartSource);
-    computeResult(target, VIEWS_WITH_HTML_TEMPLATES);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
@@ -1481,5 +1481,189 @@ class OtherComp {
     assertSuggestClassTypeAlias("my-child1");
     assertSuggestClassTypeAlias("my-child2");
     assertSuggestClassTypeAlias("my-child3");
+  }
+
+  test_completeTransclusionSuggestion() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [ContainerComponent])
+class MyComp{}
+
+@Component(template:
+    '<ng-content select="tag1,tag2[withattr],tag3.withclass"></ng-content>',
+    selector: 'container')
+class ContainerComponent{}
+      ''');
+    addTestSource('<container>^</container>');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestTransclusion("<tag1");
+    assertSuggestTransclusion("<tag2 withattr");
+    assertSuggestTransclusion("<tag3 class=\"withclass\"");
+  }
+
+  test_completeTransclusionSuggestionInWhitespace() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [ContainerComponent])
+class MyComp{}
+
+@Component(template:
+    '<ng-content select="tag1,tag2[withattr],tag3.withclass"></ng-content>',
+    selector: 'container')
+class ContainerComponent{}
+      ''');
+    addTestSource('''
+<container>
+  ^
+</container>''');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestTransclusion("<tag1");
+    assertSuggestTransclusion("<tag2 withattr");
+    assertSuggestTransclusion("<tag3 class=\"withclass\"");
+  }
+
+  test_completeTransclusionSuggestionStarted() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [ContainerComponent])
+class MyComp{}
+
+@Component(template:
+    '<ng-content select="tag1,tag2[withattr],tag3.withclass"></ng-content>',
+    selector: 'container')
+class ContainerComponent{}
+      ''');
+    addTestSource('''
+<container>
+  <^
+</container>''');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+
+    await computeSuggestions();
+    //expect(replacementOffset, completionOffset - 1);
+    //expect(replacementLength, 1);
+    assertSuggestTransclusion("<tag1");
+    assertSuggestTransclusion("<tag2 withattr");
+    assertSuggestTransclusion("<tag3 class=\"withclass\"");
+  }
+
+  test_completeTransclusionSuggestionStartedTagName() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [ContainerComponent])
+class MyComp{}
+
+@Component(template:
+    '<ng-content select="tag1,tag2[withattr],tag3.withclass"></ng-content>',
+    selector: 'container')
+class ContainerComponent{}
+      ''');
+    addTestSource('''
+<container>
+  <tag^
+</container>''');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+
+    await computeSuggestions();
+    //expect(replacementOffset, completionOffset - 4);
+    //expect(replacementLength, 4);
+    assertSuggestTransclusion("<tag1");
+    assertSuggestTransclusion("<tag2 withattr");
+    assertSuggestTransclusion("<tag3 class=\"withclass\"");
+  }
+
+  test_completeTransclusionSuggestionAfterTag() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [ContainerComponent])
+class MyComp{}
+
+@Component(template:
+    '<ng-content select="tag1,tag2[withattr],tag3.withclass"></ng-content>',
+    selector: 'container')
+class ContainerComponent{}
+      ''');
+    addTestSource('''
+<container>
+  <blah></blah>
+  ^
+</container>''');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestTransclusion("<tag1");
+    assertSuggestTransclusion("<tag2 withattr");
+    assertSuggestTransclusion("<tag3 class=\"withclass\"");
+  }
+
+  test_completeTransclusionSuggestionBeforeTag() async {
+    Source dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [ContainerComponent])
+class MyComp{}
+
+@Component(template:
+    '<ng-content select="tag1,tag2[withattr],tag3.withclass"></ng-content>',
+    selector: 'container')
+class ContainerComponent{}
+      ''');
+    addTestSource('''
+<container>
+  ^
+  <blah></blah>
+</container>''');
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
+
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestTransclusion("<tag1");
+    assertSuggestTransclusion("<tag2 withattr");
+    assertSuggestTransclusion("<tag3 class=\"withclass\"");
+  }
+
+  assertSuggestTransclusion(String name) {
+    assertSuggestClassTypeAlias(name,
+        relevance: TemplateCompleter.RELEVANCE_TRANSCLUSION);
   }
 }


### PR DESCRIPTION
In order to track transclusions, we need to look into the html
templates of child components before we can check their parents. The
trick there is that this can be cyclic.

But its not really that its cyclic, its really just that its a first
pass. We don't need to know the relationship between the views before
we get the <ng-content>s in the html file for the view. Therefore we've
split VIEWS into VIEWS1 and VIEWS2. VIEWS1 is for getting the minimum
data to build an AST to check for <ng-content> selectors. In VIEWS2 we
wire up the Views that all have ASTs and ngContent tags.

We also have ANGULAR_ASTS as a new target which takes a dart file and
builds the ASTs for each view in that dart file. It is where we parse
inline dart templates, allowing us to consolidate html parsing into a
mixin in src/tasks.dart. It does, however, produce errors for the
templates not the dart file. So that's an output which is lists of
errros mapped to sources.

Then when you resolve a dart or html template, you make sure to depend
upon ANGULAR_ASTS.of(included directives dart files).

New visitor to collect the <ng-content>s, since it requires no
resolution and can be done in a single pass.

In the future, some changes could be made so that when analyzing a
component template, only the child directive & its <ng-content>s are
needed, but the grandchilds aren't (by depending on VIEWS1).

Also create an API for Selectors to produce HTML tag suggestions since
transclusions can be very hard to figure out. Autocompleting them, even
if djanky, is good. Use a constraining/copying system.

Now in order to suggest the proper elements, we need to track the
parents of TextInfos (and ElementInfos too for less obvious reasons).
Track those in converter.dart.

Also, when validating translusions, if a tag is matched because of its
tagname, record that so that the directive resolver doesn't flag it as
unknown.

We still need to handle @ContentChild, I won't know if that comes up
internally until I try this out later.