### PR TITLE
Resolve issue #171 track tags matching complex selectors

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -886,10 +886,10 @@ class DirectiveResolver extends AngularAstVisitor {
     bool tagIsStandard = _isStandardTagName(element.localName);
 
     for (AbstractDirective directive in allDirectives) {
-      Selector selector = directive.selector;
-      if (selector.match(elementView, template)) {
+      SelectorMatch match = directive.selector.match(elementView, template);
+      if (match != SelectorMatch.NoMatch) {
         element.boundDirectives.add(new DirectiveBinding(directive));
-        if (selector is ElementNameSelector) {
+        if (match == SelectorMatch.TagMatch) {
           tagIsResolved = true;
         }
       }
@@ -913,7 +913,8 @@ class DirectiveResolver extends AngularAstVisitor {
     // TODO: report error if no directives matched here?
     ElementView elementView = new ElementViewImpl(attr.virtualAttributes, null);
     for (AbstractDirective directive in allDirectives) {
-      if (directive.selector.match(elementView, template)) {
+      if (directive.selector.match(elementView, template) !=
+          SelectorMatch.NoMatch) {
         attr.boundDirectives.add(new DirectiveBinding(directive));
       }
     }

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2493,6 +2493,78 @@ class TestPanel {
     ]);
   }
 
+  void test_resolvedTag_complexSelector() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [MyTag])
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+@Component(selector: 'my-tag[my-prop]', template: '')
+class MyTag {
+}
+''');
+    String code = r"""
+<my-tag my-prop></my-tag>
+    """;
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  void test_unResolvedTag_evenThoughMatchedComplexSelector() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [MyTag])
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+@Component(selector: 'my-tag.not-this-class,[my-prop]', template: '')
+class MyTag {
+}
+''');
+    String code = r"""
+<my-tag my-prop></my-tag>
+    """;
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    _assertElement("my-prop")
+        .selector
+        .inFileName("test_panel.dart")
+        .at("my-prop");
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.UNRESOLVED_TAG, code, "my-tag");
+  }
+
+  void test_resolvedTag_evenThoughAlsoMatchesNonTagMatch() {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [MyTag])
+class TestPanel {
+  void handleClick(MouseEvent e) {
+  }
+}
+@Component(selector: '[red-herring],my-tag,[unrelated]', template: '')
+class MyTag {
+}
+''');
+    String code = r"""
+<my-tag red-herring unrelated></my-tag>
+    """;
+    _addHtmlSource(code);
+    _resolveSingleTemplate(dartSource);
+    _assertElement("my-tag")
+        .selector
+        .inFileName("test_panel.dart")
+        .at("my-tag");
+    errorListener.assertNoErrors();
+  }
+
   void _addDartSource(String code) {
     dartCode = '''
 import '/angular2/angular2.dart';

--- a/analyzer_plugin/test/selector_test.dart
+++ b/analyzer_plugin/test/selector_test.dart
@@ -30,32 +30,67 @@ class AndSelectorTest extends _SelectorTest {
   void setUp() {
     super.setUp();
     selector = new AndSelector(<Selector>[selector1, selector2, selector3]);
-    when(selector1.match(anyObject, anyObject)).thenReturn(true);
-    when(selector2.match(anyObject, anyObject)).thenReturn(true);
-    when(selector3.match(anyObject, anyObject)).thenReturn(true);
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
+    when(selector3.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
   }
 
   void test_match() {
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     verify(selector1.match(anyObject, anyObject)).times(2);
     verify(selector1.match(anyObject, anyObject)).times(2);
     verify(selector1.match(anyObject, anyObject)).times(2);
   }
 
   void test_match_false1() {
-    when(selector1.match(anyObject, anyObject)).thenReturn(false);
-    expect(selector.match(element, template), isFalse);
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     verify(selector1.match(anyObject, anyObject)).times(1);
     verify(selector2.match(anyObject, anyObject)).times(0);
     verify(selector3.match(anyObject, anyObject)).times(0);
   }
 
   void test_match_false2() {
-    when(selector2.match(anyObject, anyObject)).thenReturn(false);
-    expect(selector.match(element, template), isFalse);
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     verify(selector1.match(anyObject, anyObject)).times(1);
     verify(selector2.match(anyObject, anyObject)).times(1);
     verify(selector3.match(anyObject, anyObject)).times(0);
+  }
+
+  void test_match_falseTagMatch() {
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
+    verify(selector1.match(anyObject, anyObject)).times(1);
+    verify(selector2.match(anyObject, anyObject)).times(1);
+    verify(selector3.match(anyObject, anyObject)).times(0);
+  }
+
+  void test_match_TagMatch1() {
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
+    verify(selector1.match(anyObject, anyObject)).times(2);
+    verify(selector2.match(anyObject, anyObject)).times(2);
+    verify(selector3.match(anyObject, anyObject)).times(2);
+  }
+
+  void test_match_TagMatch2() {
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
+    verify(selector1.match(anyObject, anyObject)).times(2);
+    verify(selector2.match(anyObject, anyObject)).times(2);
+    verify(selector3.match(anyObject, anyObject)).times(2);
   }
 
   void test_toString() {
@@ -72,7 +107,7 @@ class AttributeSelectorTest extends _SelectorTest {
     AttributeSelector selector =
         new AttributeSelector(nameElement, null, false);
     when(element.attributes).thenReturn({'not-kind': 'no-matter'});
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_match_notValue() {
@@ -81,7 +116,7 @@ class AttributeSelectorTest extends _SelectorTest {
     when(element.attributes).thenReturn({'kind': 'strange'});
     when(element.attributeNameSpans)
         .thenReturn({'kind': _newStringSpan(100, "kind")});
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_match_noValue() {
@@ -91,7 +126,8 @@ class AttributeSelectorTest extends _SelectorTest {
     when(element.attributeNameSpans)
         .thenReturn({'kind': _newStringSpan(100, "kind")});
     // verify
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     _assertRange(resolvedRanges[0], 100, 4, selector.nameElement);
   }
 
@@ -101,7 +137,8 @@ class AttributeSelectorTest extends _SelectorTest {
     when(element.attributeNameSpans)
         .thenReturn({'kindatrue': _newStringSpan(100, "kindatrue")});
     // verify
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     _assertRange(resolvedRanges[0], 100, 9, selector.nameElement);
   }
 
@@ -111,7 +148,7 @@ class AttributeSelectorTest extends _SelectorTest {
     when(element.attributeNameSpans)
         .thenReturn({'indatrue': _newStringSpan(100, "indatrue")});
     // verify
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_toString_hasValue() {
@@ -140,12 +177,12 @@ class ClassSelectorTest extends _SelectorTest {
 
   void test_match_false_noClass() {
     when(element.attributes).thenReturn({'not-class': 'no-matter'});
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_match_false_noSuchClass() {
     when(element.attributes).thenReturn({'class': 'not-nice'});
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_match_true_first() {
@@ -153,7 +190,8 @@ class ClassSelectorTest extends _SelectorTest {
     when(element.attributes).thenReturn({'class': classValue});
     when(element.attributeValueSpans)
         .thenReturn({'class': _newStringSpan(100, classValue)});
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     expect(resolvedRanges, hasLength(1));
     _assertRange(resolvedRanges[0], 100, 4, selector.nameElement);
   }
@@ -163,7 +201,8 @@ class ClassSelectorTest extends _SelectorTest {
     when(element.attributes).thenReturn({'class': classValue});
     when(element.attributeValueSpans)
         .thenReturn({'class': _newStringSpan(100, classValue)});
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     expect(resolvedRanges, hasLength(1));
     _assertRange(resolvedRanges[0], 111, 4, selector.nameElement);
   }
@@ -173,7 +212,8 @@ class ClassSelectorTest extends _SelectorTest {
     when(element.attributes).thenReturn({'class': classValue});
     when(element.attributeValueSpans)
         .thenReturn({'class': _newStringSpan(100, classValue)});
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     expect(resolvedRanges, hasLength(1));
     _assertRange(resolvedRanges[0], 105, 4, selector.nameElement);
   }
@@ -197,14 +237,14 @@ class ElementNameSelectorTest extends _SelectorTest {
     when(element.localName).thenReturn('panel');
     when(element.openingNameSpan).thenReturn(_newStringSpan(100, 'panel'));
     when(element.closingNameSpan).thenReturn(_newStringSpan(200, 'panel'));
-    expect(selector.match(element, template), isTrue);
+    expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
     _assertRange(resolvedRanges[0], 100, 5, selector.nameElement);
     _assertRange(resolvedRanges[1], 200, 5, selector.nameElement);
   }
 
   void test_match_not() {
     when(element.localName).thenReturn('not-panel');
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_toString() {
@@ -218,24 +258,26 @@ class AttributeValueRegexSelectorTest extends _SelectorTest {
 
   void test_noMatch() {
     when(element.attributes).thenReturn({'kind': 'bcd'});
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_noMatch_any() {
     when(element.attributes)
         .thenReturn({'kind': 'bcd', 'plop': 'cde', 'klark': 'efg'});
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 
   void test_match() {
     when(element.attributes).thenReturn({'kind': '0abcd'});
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
   }
 
   void test_match_justOne() {
     when(element.attributes)
         .thenReturn({'kind': 'bcd', 'plop': 'zabcz', 'klark': 'efg'});
-    expect(selector.match(element, template), isTrue);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
   }
 }
 
@@ -251,13 +293,22 @@ class NotSelectorTest extends _SelectorTest {
   }
 
   void test_notFalse() {
-    when(condition.match(anyObject, anyObject)).thenReturn(false);
-    expect(selector.match(element, template), isTrue);
+    when(condition.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
   }
 
-  void test_notTrue() {
-    when(condition.match(anyObject, anyObject)).thenReturn(true);
-    expect(selector.match(element, template), isFalse);
+  void test_notTagMatch() {
+    when(condition.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
+  }
+
+  void test_notNonTagMatch() {
+    when(condition.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
   }
 }
 
@@ -272,29 +323,65 @@ class OrSelectorTest extends _SelectorTest {
   void setUp() {
     super.setUp();
     selector = new OrSelector(<Selector>[selector1, selector2, selector3]);
-    when(selector1.match(anyObject, anyObject)).thenReturn(false);
-    when(selector2.match(anyObject, anyObject)).thenReturn(false);
-    when(selector3.match(anyObject, anyObject)).thenReturn(false);
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
+    when(selector3.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NoMatch);
   }
 
-  void test_match1() {
-    when(selector1.match(anyObject, anyObject)).thenReturn(true);
-    expect(selector.match(element, template), isTrue);
+  void test_matchFirstIsTagMatch() {
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
     verify(selector1.match(anyObject, anyObject)).times(1);
     verify(selector2.match(anyObject, anyObject)).times(0);
     verify(selector3.match(anyObject, anyObject)).times(0);
   }
 
-  void test_match2() {
-    when(selector2.match(anyObject, anyObject)).thenReturn(true);
-    expect(selector.match(element, template), isTrue);
+  void test_matchFirstIsNonTagMatch() {
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
+    verify(selector1.match(anyObject, anyObject)).times(1);
+    verify(selector2.match(anyObject, anyObject)).times(1);
+    verify(selector3.match(anyObject, anyObject)).times(1);
+  }
+
+  void test_match2TagMatch() {
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
+    verify(selector1.match(anyObject, anyObject)).times(1);
+    verify(selector2.match(anyObject, anyObject)).times(1);
+    verify(selector3.match(anyObject, anyObject)).times(0);
+  }
+
+  void test_match2NonTagMatch() {
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
+    expect(
+        selector.match(element, template), equals(SelectorMatch.NonTagMatch));
+    verify(selector1.match(anyObject, anyObject)).times(1);
+    verify(selector2.match(anyObject, anyObject)).times(1);
+    verify(selector3.match(anyObject, anyObject)).times(1);
+  }
+
+  void test_match2TagAndNonTagMatch() {
+    when(selector1.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.NonTagMatch);
+    when(selector2.match(anyObject, anyObject))
+        .thenReturn(SelectorMatch.TagMatch);
+    expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
     verify(selector1.match(anyObject, anyObject)).times(1);
     verify(selector2.match(anyObject, anyObject)).times(1);
     verify(selector3.match(anyObject, anyObject)).times(0);
   }
 
   void test_match_false() {
-    expect(selector.match(element, template), isFalse);
+    expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     verify(selector1.match(anyObject, anyObject)).times(1);
     verify(selector2.match(anyObject, anyObject)).times(1);
     verify(selector3.match(anyObject, anyObject)).times(1);


### PR DESCRIPTION
Handle cases like `x[y],[z]`, which doesn't actually match the tag
for `<x z` even though it matches the tag...or maybe I should say,
it matches the element but not because of the tag name.

Do this by returning not true/false, but an enumeration from
selector.match, where the possible values are no match, tag match, or
non tag match.

In the case of or selectors, don't stop on the first non tag match, in
case that a later tag match will occur. In the case of and selectors,
return tag match if any item in the match is a tag match.