### PR TITLE
Go back to allowing dart2js to be used, but handle it's type of code

### DIFF
--- a/analyzer_plugin/lib/src/angular_driver.dart
+++ b/analyzer_plugin/lib/src/angular_driver.dart
@@ -169,9 +169,7 @@ class AngularDriver
     if (standardHtml == null) {
       final source = _sourceFactory.resolveUri(null, DartSdk.DART_HTML);
 
-      // The dart2js analysis doesn't work right, _force_ dartium analysis.
-      final result = await dartDriver
-          .getResult(source.fullName.replaceAll('dart2js', 'dartium'));
+      final result = await dartDriver.getResult(source.fullName);
 
       final components = <String, Component>{};
       final events = <String, OutputElement>{};

--- a/analyzer_plugin/lib/src/standard_components.dart
+++ b/analyzer_plugin/lib/src/standard_components.dart
@@ -84,6 +84,19 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
         Component component = _buildComponent(tag, tagOffset);
         components[tag] = component;
       }
+    } else if (node.methodName.name == 'JS' &&
+        argumentList != null &&
+        argumentList.arguments.length == 4) {
+      final documentArgument = argumentList.arguments[2];
+      final tagArgument = argumentList.arguments[3];
+      if (documentArgument is ast.SimpleIdentifier &&
+          documentArgument.name == 'document' &&
+          tagArgument is ast.SimpleStringLiteral) {
+        String tag = tagArgument.value;
+        int tagOffset = tagArgument.contentsOffset;
+        Component component = _buildComponent(tag, tagOffset);
+        components[tag] = component;
+      }
     }
   }
 

--- a/analyzer_plugin/test/mock_sdk.dart
+++ b/analyzer_plugin/test/mock_sdk.dart
@@ -369,9 +369,12 @@ class HtmlElement extends Element {
   set hidden(bool value) => null;
 }
 
+dynamic JS(a, b, c, d) {}
+
 class AnchorElement extends HtmlElement {
   factory AnchorElement({String href}) {
-    var e = document.createElement("a");
+    AnchorElement e = JS('returns:AnchorElement;creates:AnchorElement;new:true',
+        '#.createElement(#)', document, "a");
     if (href != null) e.href = href;
     return e;
   }


### PR DESCRIPTION
Otherwise you get "MouseEvent (from dartium.dart) is not assignable to
MouseEvent (from dart2js.dart)".

Easy enough to handle its syntax, though I am worried about other
differences between the two libraries and if we'll have other
inconsistencies.

But this at least removes the obvious problem(s).