### PR TITLE
Resolve plain attributes -- in ranges, and strchecks for inputs.

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -232,15 +232,17 @@ class DirectiveBinding {
 }
 
 /**
- * A binding between an [ExpressionBoundAttribute] and an [InputElement].
- * This is used in the context of a [DirectiveBinding] because each instance of
- * a bound directive has different input bindings.
+ * A binding between an [AttributeInfo] and an [InputElement].  This is used in
+ * the context of a [DirectiveBinding] because each instance of a bound
+ * directive has different input bindings. Note that inputs can be bound via
+ * bracket syntax (an [ExpressionBoundAttribute]), or via plain attribute syntax
+ * (a [TextAttribute]).
  *
  * Naming here is important: "bound input" != "input binding." 
  */
 class InputBinding {
   final InputElement boundInput;
-  final ExpressionBoundAttribute attribute;
+  final AttributeInfo attribute;
 
   InputBinding(this.boundInput, this.attribute);
 }

--- a/analyzer_plugin/lib/src/angular_driver.dart
+++ b/analyzer_plugin/lib/src/angular_driver.dart
@@ -268,6 +268,8 @@ class AngularDriver
 
     final linker = new ChildDirectiveLinker(this, linkErrorReporter);
     await linker.linkDirectives(directives, unit.library);
+    final attrValidator = new AttributeAnnotationValidator(linkErrorReporter);
+    directives.forEach(attrValidator.validate);
 
     for (final directive in directives) {
       if (directive is Component) {

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1105,8 +1105,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
           SourceRange range =
               new SourceRange(attribute.nameOffset, attribute.name.length);
           template.addRange(range, input);
-          directiveBinding.inputBindings
-              .add(new InputBinding(input, attribute));
+          // TODO save this as an input binding
         }
       }
 
@@ -1121,13 +1120,20 @@ class SingleScopeResolver extends AngularScopeVisitor {
 
     InputElement standardHtmlAttribute = standardHtmlAttributes[attribute.name];
     if (standardHtmlAttribute != null) {
-      _typecheckMatchingInput(attribute, standardHtmlAttribute);
+      var inputType = standardHtmlAttribute.setterType;
+      if (!typeProvider.stringType.isAssignableTo(inputType)) {
+        errorListener.onError(new AnalysisError(
+            templateSource,
+            attribute.nameOffset,
+            attribute.name.length,
+            AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID,
+            [attribute.name]));
+      }
 
       SourceRange range =
           new SourceRange(attribute.nameOffset, attribute.name.length);
       template.addRange(range, standardHtmlAttribute);
-      attribute.parent.boundStandardInputs
-          .add(new InputBinding(standardHtmlAttribute, attribute));
+      // TODO save this as an input binding
     }
 
     // visit mustaches inside

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1081,6 +1081,59 @@ class SingleScopeResolver extends AngularScopeVisitor {
     }
   }
 
+  /**
+   * Resolve input-bound values of [attributes] as strings, if they match. Note,
+   * this does not report an error un unmatched attributes, but it will report
+   * the range, and ensure that input bindings are string-assingable.
+   */
+  void visitTextAttr(TextAttribute attribute) {
+    for (DirectiveBinding directiveBinding
+        in attribute.parent.boundDirectives) {
+      for (InputElement input in directiveBinding.boundDirective.inputs) {
+        if (input.name == attribute.name) {
+          var inputType = input.setterType;
+
+          if (!typeProvider.stringType.isAssignableTo(inputType)) {
+            errorListener.onError(new AnalysisError(
+                templateSource,
+                attribute.nameOffset,
+                attribute.name.length,
+                AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID,
+                [input.name]));
+          }
+
+          SourceRange range =
+              new SourceRange(attribute.nameOffset, attribute.name.length);
+          template.addRange(range, input);
+          directiveBinding.inputBindings
+              .add(new InputBinding(input, attribute));
+        }
+      }
+
+      for (AngularElement elem in directiveBinding.boundDirective.attributes) {
+        if (elem.name == attribute.name) {
+          SourceRange range =
+              new SourceRange(attribute.nameOffset, attribute.name.length);
+          template.addRange(range, elem);
+        }
+      }
+    }
+
+    InputElement standardHtmlAttribute = standardHtmlAttributes[attribute.name];
+    if (standardHtmlAttribute != null) {
+      _typecheckMatchingInput(attribute, standardHtmlAttribute);
+
+      SourceRange range =
+          new SourceRange(attribute.nameOffset, attribute.name.length);
+      template.addRange(range, standardHtmlAttribute);
+      attribute.parent.boundStandardInputs
+          .add(new InputBinding(standardHtmlAttribute, attribute));
+    }
+
+    // visit mustaches inside
+    super.visitTextAttr(attribute);
+  }
+
   void _typecheckMatchingInput(
       ExpressionBoundAttribute attr, InputElement input) {
     // half-complete-code case: ensure the expression is actually there

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -1105,7 +1105,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
           SourceRange range =
               new SourceRange(attribute.nameOffset, attribute.name.length);
           template.addRange(range, input);
-          // TODO save this as an input binding
+          directiveBinding.inputBindings
+              .add(new InputBinding(input, attribute));
         }
       }
 
@@ -1133,7 +1134,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
       SourceRange range =
           new SourceRange(attribute.nameOffset, attribute.name.length);
       template.addRange(range, standardHtmlAttribute);
-      // TODO save this as an input binding
+      attribute.parent.boundStandardInputs
+          .add(new InputBinding(standardHtmlAttribute, attribute));
     }
 
     // visit mustaches inside

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -43,7 +43,8 @@ const List<AngularWarningCode> _angularWarningCodeValues = const [
   AngularWarningCode.NG_CONTENT_MUST_BE_EMPTY,
   AngularWarningCode.OUTPUT_STATEMENT_REQUIRES_EXPRESSION_STATEMENT,
   AngularWarningCode.DISALLOWED_EXPRESSION,
-  AngularWarningCode.ATTRIBUTE_PARAMETER_MUST_BE_STRING
+  AngularWarningCode.ATTRIBUTE_PARAMETER_MUST_BE_STRING,
+  AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID
 ];
 
 /**
@@ -390,6 +391,17 @@ class AngularWarningCode extends ErrorCode {
   static const AngularWarningCode ATTRIBUTE_PARAMETER_MUST_BE_STRING =
       const AngularWarningCode('ATTRIBUTE_PARAMETER_MUST_BE_STRING',
           "Parameters marked with @Attribute must be of type String");
+
+  /**
+   * An error code indicating that an input binding was used in string form, ie,
+   * `x="y"` rather than `[x]="y"`, where input x is not a string input.
+   */
+  static const AngularWarningCode STRING_STYLE_INPUT_BINDING_INVALID =
+      const AngularWarningCode(
+          'STRING_STYLE_INPUT_BINDING_INVALID',
+          "Input {0} is not a string input, but is not bound with [bracket] "
+          "syntax. This binds the String attribute value directly, resulting "
+          "in a type error.");
 
   /**
    * Initialize a newly created error code to have the given [name].

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -194,6 +194,26 @@ class SomeComponent {
     _assertElement('hidden').input.inCoreHtml;
   }
 
+  Future test_expression_inputBinding_asString() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+}
+@Component(selector: 'title-comp', template: '')
+class TitleComponent {
+  @Input() String title;
+}
+''');
+    var code = r"""
+<title-comp title='anything can go here'></title-comp>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+    _assertElement('title=').input.inFileName('/test_panel.dart').at('title;');
+  }
+
   Future test_expression_inputBinding_typeError() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel',
@@ -213,6 +233,28 @@ class TitleComponent {
     await _resolveSingleTemplate(dartSource);
     assertErrorInCodeAtPosition(
         AngularWarningCode.INPUT_BINDING_TYPE_ERROR, code, "text");
+  }
+
+  Future test_expression_inputBinding_asString_typeError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [TitleComponent], templateUrl: 'test_panel.html')
+class TestPanel {
+}
+@Component(selector: 'title-comp', template: '')
+class TitleComponent {
+  @Input() int titleInput;
+}
+''');
+    var code = r"""
+<title-comp titleInput='string binding'></title-comp>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID,
+        code,
+        "titleInput");
   }
 
   Future test_expression_inputBinding_noValue() async {
@@ -1792,6 +1834,7 @@ class TestPanel {}
 <name-panel aaa='1' [bbb]='2' bind-ccc='3'></name-panel>
 """);
     await _resolveSingleTemplate(dartSource);
+    _assertElement("aaa=").input.at("aaa', ");
     _assertElement("bbb]=").input.at("bbb', ");
     _assertElement("ccc=").input.at("ccc']");
   }
@@ -1891,6 +1934,29 @@ class TestPanel {}
     _assertElement("exportedValue'>").angular.at("exportedValue')");
     _assertElement("value.aaa").local.at("value=");
     _assertElement("aaa}}").dart.getter.at('aaa; // 1');
+  }
+
+  Future test_attributeReference() async {
+    _addDartSource(r'''
+@Component(
+    selector: 'name-panel',
+    template: r"<div>AAA</div>")
+class NamePanel {
+  NamePanel(@Attribute("name-panel-attr") String namePanelAttr);
+}
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NamePanel])
+class TestPanel {}
+''');
+    _addHtmlSource(r"""
+<name-panel name-panel-attr="foo"></name-panel>
+""");
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+    _assertElement("name-panel-attr=")
+        .angular
+        .inFileName('/test_panel.dart')
+        .at("namePanelAttr");
   }
 
   Future test_erroroneousTemplate_starHash_noCrash() async {
@@ -2991,6 +3057,7 @@ $code
     final finder = (AbstractDirective d) =>
         d is Component && d.view.templateUriSource != null;
     fillErrorListener(result.errors);
+    errorListener.assertNoErrors();
     final directive = result.directives.singleWhere(finder);
     final htmlPath = (directive as Component).view.templateUriSource.fullName;
     final result2 =

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -206,12 +206,13 @@ class TitleComponent {
 }
 ''');
     var code = r"""
-<title-comp title='anything can go here'></title-comp>
+<title-comp title='anything can go here' id="some id"></title-comp>
 """;
     _addHtmlSource(code);
     await _resolveSingleTemplate(dartSource);
     errorListener.assertNoErrors();
     _assertElement('title=').input.inFileName('/test_panel.dart').at('title;');
+    _assertElement('id=').input.inCoreHtml;
   }
 
   Future test_expression_inputBinding_typeError() async {
@@ -255,6 +256,22 @@ class TitleComponent {
         AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID,
         code,
         "titleInput");
+  }
+
+  Future test_expression_inputBinding_global_asString_typeError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    directives: const [], templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    var code = r"""
+<div hidden="string binding"></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID, code, "hidden");
   }
 
   Future test_expression_inputBinding_noValue() async {
@@ -1831,12 +1848,13 @@ class NamePanel {
 class TestPanel {}
 ''');
     _addHtmlSource(r"""
-<name-panel aaa='1' [bbb]='2' bind-ccc='3'></name-panel>
+<name-panel aaa='1' [bbb]='2' bind-ccc='3' id="someid"></name-panel>
 """);
     await _resolveSingleTemplate(dartSource);
     _assertElement("aaa=").input.at("aaa', ");
     _assertElement("bbb]=").input.at("bbb', ");
     _assertElement("ccc=").input.at("ccc']");
+    _assertElement("id=").input.inCoreHtml;
   }
 
   Future test_outputReference() async {


### PR DESCRIPTION
Record resolved ranges for `x="y"` where `x` is an input or a constructor
`@Attribute`. If its an input, check that strings are assignable to it.
If not, give it its own error that hopefully explains the semi magical
situation.