### PR TITLE
Update test_reflective_loader, fix analyzer warnings&errors

### DIFF
--- a/analyzer_plugin/lib/src/angular_driver.dart
+++ b/analyzer_plugin/lib/src/angular_driver.dart
@@ -25,7 +25,6 @@ import 'package:angular_analyzer_plugin/src/summary/idl.dart';
 import 'package:angular_analyzer_plugin/src/summary/format.dart';
 import 'package:angular_analyzer_plugin/src/standard_components.dart';
 import 'package:analyzer/src/generated/engine.dart';
-import 'package:tuple/tuple.dart';
 import 'package:analyzer/src/dart/analysis/file_state.dart';
 import 'package:crypto/crypto.dart';
 

--- a/analyzer_plugin/lib/starter.dart
+++ b/analyzer_plugin/lib/starter.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:analyzer/error/error.dart';
 import 'package:analysis_server/src/analysis_server.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/angular_driver.dart';
@@ -64,6 +67,6 @@ class Starter {
       }
     }
 
-    send(null, null, null);
+    sendFn(null, null, null);
   }
 }

--- a/analyzer_plugin/test/angular_driver_test.dart
+++ b/analyzer_plugin/test/angular_driver_test.dart
@@ -22,14 +22,15 @@ import 'package:unittest/unittest.dart';
 import 'abstract_angular.dart';
 
 main() {
-  groupSep = ' | ';
-  defineReflectiveTests(AngularParseHtmlTest);
-  defineReflectiveTests(BuildStandardHtmlComponentsTest);
-  defineReflectiveTests(BuildUnitDirectivesTest);
-  defineReflectiveTests(BuildUnitViewsTest);
-  defineReflectiveTests(ResolveDartTemplatesTest);
-  defineReflectiveTests(ResolveHtmlTemplatesTest);
-  defineReflectiveTests(ResolveHtmlTemplateTest);
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AngularParseHtmlTest);
+    defineReflectiveTests(BuildStandardHtmlComponentsTest);
+    defineReflectiveTests(BuildUnitDirectivesTest);
+    defineReflectiveTests(BuildUnitViewsTest);
+    defineReflectiveTests(ResolveDartTemplatesTest);
+    defineReflectiveTests(ResolveHtmlTemplatesTest);
+    defineReflectiveTests(ResolveHtmlTemplateTest);
+  });
 }
 
 @reflectiveTest
@@ -2487,7 +2488,7 @@ class ComponentA {
 }
 ''';
     Source dartSource = newSource('/weird.dart', code);
-    Soruce htmlSource =
+    Source htmlSource =
         newSource('/test.html', "<unresolved-tag></unresolved-tag>");
     await getDirectives(htmlSource, dartSource);
     final errors = errorListener.errors;

--- a/analyzer_plugin/test/angular_driver_test.dart
+++ b/analyzer_plugin/test/angular_driver_test.dart
@@ -262,7 +262,7 @@ class BuildUnitDirectivesTest extends AbstractAngularTest {
   }
 
   Future test_Component() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -310,7 +310,7 @@ class ComponentB {
   }
 
   Future test_Directive() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -358,7 +358,7 @@ class DirectiveB {
   }
 
   Future test_Directive_elementTags_OrSelector() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -415,7 +415,7 @@ class DirectiveB {
   }
 
   Future test_Directive_elementTags_AndSelector() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -463,7 +463,7 @@ class DirectiveB {
   }
 
   Future test_Directive_elementTags_CompoundSelector() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -528,7 +528,7 @@ class ComponentA {
 class ComponentB {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     expect(directives, hasLength(2));
     {
@@ -562,7 +562,7 @@ class DirectiveA {
 class DirectiveB {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     expect(directives, hasLength(2));
     {
@@ -585,7 +585,7 @@ class DirectiveB {
   }
 
   Future test_exportAs_hasError_notStringValue() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -604,7 +604,7 @@ class ComponentA {
   }
 
   Future test_exportAs_constantStringExpressionOk() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -620,7 +620,7 @@ class ComponentA {
   }
 
   Future test_hasError_ArgumentSelectorMissing() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -642,7 +642,7 @@ import '/angular2/angular2.dart';
 class ComponentA {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // validate
     assertErrorInCodeAtPosition(
@@ -650,7 +650,7 @@ class ComponentA {
   }
 
   Future test_hasError_selector_notStringValue() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -668,7 +668,7 @@ class ComponentA {
   }
 
   Future test_selector_constantExpressionOk() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -683,7 +683,7 @@ class ComponentA {
   }
 
   Future test_hasError_UndefinedSetter_fullSyntax() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -703,7 +703,7 @@ class ComponentA {
   }
 
   Future test_hasError_UndefinedSetter_shortSyntax() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -719,7 +719,7 @@ class ComponentA {
   }
 
   Future test_hasError_UndefinedSetter_shortSyntax_noInputMade() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -757,7 +757,7 @@ class MyComponent {
   set someSetter(String x) { }
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<InputElement> inputs = component.inputs;
@@ -836,7 +836,7 @@ class MyComponent {
   String trailingText;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<InputElement> inputs = component.inputs;
@@ -882,7 +882,7 @@ class MyComponent {
   EventEmitter get someGetter => null;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<OutputElement> compOutputs = component.outputs;
@@ -966,7 +966,7 @@ class MyComponent {
   Stream<int> myOutput;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<OutputElement> compOutputs = component.outputs;
@@ -993,7 +993,7 @@ class MyComponent {
   MyStream<int> myOutput;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<OutputElement> compOutputs = component.outputs;
@@ -1020,7 +1020,7 @@ class MyComponent {
   MyStream myOutput;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<OutputElement> compOutputs = component.outputs;
@@ -1047,7 +1047,7 @@ class MyComponent {
   MyStream myOutput;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<OutputElement> compOutputs = component.outputs;
@@ -1071,7 +1071,7 @@ class MyComponent {
   int badOutput;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     assertErrorInCodeAtPosition(
         AngularWarningCode.OUTPUT_MUST_BE_EVENTEMITTER, code, "badOutput");
@@ -1089,7 +1089,7 @@ class MyComponent {
   int badOutput;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // validate
     Component component = directives.single;
@@ -1121,7 +1121,7 @@ class MyComponent<T, A extends String, B extends A> {
 }
 
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // validate
     Component component = directives.single;
@@ -1200,7 +1200,7 @@ class Generic<T> {
 class MyComponent extends Generic {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<InputElement> compInputs = component.inputs;
@@ -1239,7 +1239,7 @@ class Generic<T> {
 class MyComponent extends Generic<String> {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<InputElement> compInputs = component.inputs;
@@ -1270,7 +1270,7 @@ class MyComponent {
   @Input() final int immutable = 1;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // validate
     assertErrorInCodeAtPosition(
@@ -1288,7 +1288,7 @@ class MyComponent {
   final int immutable = 1;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // validate. Can't easily assert position though because its all 'immutable'
     errorListener
@@ -1296,7 +1296,7 @@ class MyComponent {
   }
 
   Future test_noDirectives() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 class A {}
@@ -1316,7 +1316,7 @@ class MyComponent {
   String get someGetter => null;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     assertErrorInCodeAtPosition(
         AngularWarningCode.INPUT_ANNOTATION_PLACEMENT_INVALID,
@@ -1334,7 +1334,7 @@ class MyComponent {
   set someSetter(x) { }
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     assertErrorInCodeAtPosition(
         AngularWarningCode.OUTPUT_ANNOTATION_PLACEMENT_INVALID,
@@ -1381,7 +1381,7 @@ import '/angular2/angular2.dart';
     directives: const [NgFor])
 class OtherComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     newSource('/other_file.dart', otherCode);
     await getViews(source);
     {
@@ -1420,7 +1420,7 @@ const DIR_AB = const [DirectiveA, DirectiveB];
     directives: const [DIR_AB, DirectiveC])
 class MyComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getViews(source);
     {
       View view = getViewByClassName(views, 'MyComponent');
@@ -1461,7 +1461,7 @@ import 'other.dart' as other;
     directives: const [other.DIR_AB, other.DirectiveC])
 class MyComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     newSource('/other.dart', otherCode);
     await getViews(source);
     {
@@ -1489,14 +1489,14 @@ const NOT_DIRECTIVE_LIST = 42;
    directives: const [NOT_DIRECTIVE_LIST])
 class MyComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getViews(source);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.TYPE_IS_NOT_A_DIRECTIVE]);
   }
 
   Future test_hasError_ComponentAnnotationMissing() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1511,7 +1511,7 @@ class ComponentA {
   }
 
   Future test_hasError_StringValueExpected() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1528,7 +1528,7 @@ class ComponentA {
   }
 
   Future test_constantExpressionTemplateOk() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1542,7 +1542,7 @@ class ComponentA {
   }
 
   Future test_constantExpressionTemplateComplexIsOnlyError() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1559,7 +1559,7 @@ class ComponentA {
   }
 
   Future test_hasError_TypeLiteralExpected() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1574,7 +1574,7 @@ class ComponentA {
   }
 
   Future test_hasError_TemplateAndTemplateUrlDefined() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1590,7 +1590,7 @@ class ComponentA {
   }
 
   Future test_hasError_NeitherTemplateNorTemplateUrlDefined() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1611,7 +1611,7 @@ import '/angular2/angular2.dart';
 @Component(selector: 'my-component', templateUrl: 'missing-template.html')
 class MyComponent {}
 ''';
-    Source dartSource = newSource('/test.dart', code);
+    var dartSource = newSource('/test.dart', code);
     await getViews(dartSource);
     assertErrorInCodeAtPosition(
         AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST,
@@ -1626,8 +1626,8 @@ import '/angular2/angular2.dart';
 @Component(selector: 'my-component', templateUrl: 'my-template.html')
 class MyComponent {}
 ''';
-    Source dartSource = newSource('/test.dart', code);
-    Source htmlSource = newSource('/my-template.html', '');
+    var dartSource = newSource('/test.dart', code);
+    var htmlSource = newSource('/my-template.html', '');
     await getViews(dartSource);
     expect(views, hasLength(1));
     // MyComponent
@@ -1652,8 +1652,8 @@ import '/angular2/angular2.dart';
 @View(templateUrl: 'my-template.html')
 class MyComponent {}
 ''';
-    Source dartSource = newSource('/test.dart', code);
-    Source htmlSource = newSource('/my-template.html', '');
+    var dartSource = newSource('/test.dart', code);
+    var htmlSource = newSource('/my-template.html', '');
     await getViews(dartSource);
     expect(views, hasLength(1));
     // MyComponent
@@ -1684,7 +1684,7 @@ class OtherComponent {}
     directives: const [MyDirective, OtherComponent])
 class MyComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getViews(source);
     expect(views, hasLength(2));
     {
@@ -1721,7 +1721,7 @@ class OtherComponent {}
 @View(template: 'My template', directives: const [MyDirective, OtherComponent])
 class MyComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getViews(source);
     expect(views, hasLength(2));
     {
@@ -1764,7 +1764,7 @@ class ResolveDartTemplatesTest extends AbstractAngularTest {
   }
 
   Future test_hasError_DirectiveTypeLiteralExpected() async {
-    Source source = newSource(
+    var source = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -1799,7 +1799,7 @@ class ComponentB {
 class ComponentC {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component componentA = getComponentByClassName(directives, 'ComponentA');
     Component componentB = getComponentByClassName(directives, 'ComponentB');
@@ -1852,7 +1852,7 @@ class TextPanel {
   String text;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener.assertErrorsWithCodes(
         [StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE]);
@@ -1876,7 +1876,7 @@ class TextPanel {
 class UserPanel {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener
         .assertErrorsWithCodes([StaticWarningCode.UNDEFINED_IDENTIFIER]);
@@ -1892,7 +1892,7 @@ class MyComponent {
 }
 ''';
 
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     assertErrorInCodeAtPosition(
         StaticWarningCode.UNDEFINED_IDENTIFIER, code, 'noSuchName');
@@ -1907,7 +1907,7 @@ import '/angular2/angular2.dart';
 class ComponentA {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     assertErrorInCodeAtPosition(
         AngularWarningCode.UNRESOLVED_TAG, code, 'unresolved-tag');
@@ -1924,7 +1924,7 @@ import '/angular2/angular2.dart';
 class ComponentA {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener.assertNoErrors();
   }
@@ -1940,7 +1940,7 @@ import '/angular2/angular2.dart';
 class ComponentA {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener.assertNoErrors();
   }
@@ -1957,7 +1957,7 @@ class ComponentA {
   Object value;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener.assertNoErrors();
   }
@@ -1971,7 +1971,7 @@ import '/angular2/angular2.dart';
 class TextPanel {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // has errors
     errorListener.assertErrorsWithCodes([HtmlErrorCode.PARSE_ERROR]);
@@ -1991,7 +1991,7 @@ class TodoList {
   gotClicked(MouseEvent event) {}
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     expect(templates, hasLength(1));
     {
@@ -2050,7 +2050,7 @@ class User {
   String name; // 2
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component textPanel = getComponentByClassName(directives, 'TextPanel');
     // validate
@@ -2109,7 +2109,7 @@ class ComponentA {
 class ComponentB {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component componentA = getComponentByClassName(directives, 'ComponentA');
     // validate
@@ -2144,7 +2144,7 @@ import '/angular2/angular2.dart';
 class TextPanel {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     expect(templates, hasLength(1));
     // has errors
@@ -2160,7 +2160,7 @@ import '/angular2/angular2.dart';
 class TextPanel {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     expect(templates, hasLength(1));
     // has errors
@@ -2176,7 +2176,7 @@ class TextPanel {
   String text = "text";
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // has errors
     errorListener
@@ -2191,7 +2191,7 @@ import '/angular2/angular2.dart';
 class TextPanel {
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     // has errors
     errorListener.assertErrorsWithCodes([AngularWarningCode.UNOPENED_MUSTACHE]);
@@ -2206,7 +2206,7 @@ class TextPanel {
   String text;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener.assertErrorsWithCodes([
       AngularWarningCode.UNTERMINATED_MUSTACHE,
@@ -2223,7 +2223,7 @@ class TextPanel {
   String text, open, close;
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     errorListener.assertErrorsWithCodes([
       AngularWarningCode.UNTERMINATED_MUSTACHE,
@@ -2244,7 +2244,7 @@ class TextPanel {
   String text; // 1
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     expect(templates, hasLength(1));
     {
@@ -2296,7 +2296,7 @@ import '/angular2/angular2.dart';
     directives: const [])
 class ChildComponent {}
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     newSource('/child_file.dart', childCode);
     await getDirectives(source);
     expect(templates, hasLength(1));
@@ -2325,7 +2325,7 @@ class MyComponent {
   MyComponent(@Attribute("my-attr") String foo);
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<AngularElement> attributes = component.attributes;
@@ -2349,7 +2349,7 @@ class MyComponent {
   MyComponent(@Attribute("my-attr") int foo);
 }
 ''';
-    Source source = newSource('/test.dart', code);
+    var source = newSource('/test.dart', code);
     await getDirectives(source);
     Component component = directives.single;
     List<AngularElement> attributes = component.attributes;
@@ -2413,9 +2413,9 @@ class TextPanelB {
   {{text}}
 </div>
 """;
-    Source dartSourceOne = newSource('/test1.dart', dartCodeOne);
-    Source dartSourceTwo = newSource('/test2.dart', dartCodeTwo);
-    Source htmlSource = newSource('/text_panel.html', htmlCode);
+    var dartSourceOne = newSource('/test1.dart', dartCodeOne);
+    var dartSourceTwo = newSource('/test2.dart', dartCodeTwo);
+    var htmlSource = newSource('/text_panel.html', htmlCode);
     await getDirectives(htmlSource, [dartSourceOne, dartSourceTwo]);
     expect(templates, hasLength(2));
     // validate templates
@@ -2460,7 +2460,7 @@ class ResolveHtmlTemplateTest extends AbstractAngularTest {
   }
 
   Future test_suppressError_UnresolvedTagHtmlTemplate() async {
-    Source dartSource = newSource(
+    var dartSource = newSource(
         '/test.dart',
         r'''
 import '/angular2/angular2.dart';
@@ -2469,7 +2469,7 @@ import '/angular2/angular2.dart';
 class ComponentA {
 }
 ''');
-    Source htmlSource = newSource(
+    var htmlSource = newSource(
         '/test.html',
         '''
 <!-- @ngIgnoreErrors: UNRESOLVED_TAG -->
@@ -2487,8 +2487,8 @@ import '/angular2/angular2.dart';
 class ComponentA {
 }
 ''';
-    Source dartSource = newSource('/weird.dart', code);
-    Source htmlSource =
+    var dartSource = newSource('/weird.dart', code);
+    var htmlSource =
         newSource('/test.html', "<unresolved-tag></unresolved-tag>");
     await getDirectives(htmlSource, dartSource);
     final errors = errorListener.errors;
@@ -2512,8 +2512,8 @@ class TextPanel {
   {{text}}
 </div>
 """;
-    Source dartSource = newSource('/test.dart', dartCode);
-    Source htmlSource = newSource('/text_panel.html', htmlCode);
+    var dartSource = newSource('/test.dart', dartCode);
+    var htmlSource = newSource('/text_panel.html', htmlCode);
     // compute
     await getDirectives(htmlSource, dartSource);
     expect(views, hasLength(1));
@@ -2552,9 +2552,9 @@ import '/angular2/angular2.dart';
     directives: const [])
 class ChildComponent {}
 ''';
-    Source dartSource = newSource('/test.dart', code);
+    var dartSource = newSource('/test.dart', code);
     newSource('/child_file.dart', childCode);
-    Source htmlSource = newSource('/test.html', '');
+    var htmlSource = newSource('/test.html', '');
     await getDirectives(htmlSource, dartSource);
 
     List<AbstractDirective> childDirectives = views.first.directives;

--- a/analyzer_plugin/test/file_tracker_test.dart
+++ b/analyzer_plugin/test/file_tracker_test.dart
@@ -5,8 +5,9 @@ import 'package:unittest/unittest.dart';
 import 'package:typed_mock/typed_mock.dart';
 
 main() {
-  groupSep = ' | ';
-  defineReflectiveTests(FileTrackerTest);
+  defineReflectiveSuite(() {
+    defineReflectiveTests(FileTrackerTest);
+  });
 }
 
 @reflectiveTest

--- a/analyzer_plugin/test/fuzz_test.dart
+++ b/analyzer_plugin/test/fuzz_test.dart
@@ -9,8 +9,9 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'abstract_angular.dart';
 
 main() {
-  groupSep = ' | ';
-  defineReflectiveTests(FuzzTest);
+  defineReflectiveSuite(() {
+    defineReflectiveTests(FuzzTest);
+  });
 }
 
 @reflectiveTest
@@ -589,7 +590,7 @@ class CounterComponent {
         if (directive is Component &&
             directive.view?.templateUriSource?.fullName == '/test.html') {
           try {
-            await angularDriver.resolveHtml('/test.html', '/test.dart');
+            await angularDriver.resolveHtml('/test.html');
           } catch (e, stacktrace) {
             print("ResolveHtml failed\n$reason\n$e\n$stacktrace");
           }

--- a/analyzer_plugin/test/offsetting_constant_value_visitor_test.dart
+++ b/analyzer_plugin/test/offsetting_constant_value_visitor_test.dart
@@ -9,8 +9,9 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'package:unittest/unittest.dart';
 
 main() {
-  groupSep = ' | ';
-  defineReflectiveTests(OffsettingConstantValueVisitorTest);
+  defineReflectiveSuite(() {
+    defineReflectiveTests(OffsettingConstantValueVisitorTest);
+  });
 }
 
 @reflectiveTest

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -16,8 +16,9 @@ import 'abstract_angular.dart';
 import 'element_assert.dart';
 
 main() {
-  groupSep = ' | ';
-  defineReflectiveTests(TemplateResolverTest);
+  defineReflectiveSuite(() {
+    defineReflectiveTests(TemplateResolverTest);
+  });
 }
 
 void assertPropertyElement(AngularElement element,

--- a/analyzer_plugin/test/selector_test.dart
+++ b/analyzer_plugin/test/selector_test.dart
@@ -8,17 +8,18 @@ import 'package:typed_mock/typed_mock.dart';
 import 'package:unittest/unittest.dart';
 
 main() {
-  groupSep = ' | ';
-  defineReflectiveTests(AndSelectorTest);
-  defineReflectiveTests(AttributeSelectorTest);
-  defineReflectiveTests(ClassSelectorTest);
-  defineReflectiveTests(ElementNameSelectorTest);
-  defineReflectiveTests(OrSelectorTest);
-  defineReflectiveTests(NotSelectorTest);
-  defineReflectiveTests(AttributeValueRegexSelectorTest);
-  defineReflectiveTests(SelectorParserTest);
-  defineReflectiveTests(SuggestTagsTest);
-  defineReflectiveTests(HtmlTagForSelectorTest);
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AndSelectorTest);
+    defineReflectiveTests(AttributeSelectorTest);
+    defineReflectiveTests(ClassSelectorTest);
+    defineReflectiveTests(ElementNameSelectorTest);
+    defineReflectiveTests(OrSelectorTest);
+    defineReflectiveTests(NotSelectorTest);
+    defineReflectiveTests(AttributeValueRegexSelectorTest);
+    defineReflectiveTests(SelectorParserTest);
+    defineReflectiveTests(SuggestTagsTest);
+    defineReflectiveTests(HtmlTagForSelectorTest);
+  });
 }
 
 @reflectiveTest

--- a/analyzer_plugin/test/test_all.dart
+++ b/analyzer_plugin/test/test_all.dart
@@ -1,6 +1,6 @@
 library angular2.src.analysis.analyzer_plugin.src;
 
-import 'package:unittest/unittest.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import 'resolver_test.dart' as resolver_test;
 import 'selector_test.dart' as selector_test;
@@ -12,11 +12,10 @@ import 'offsetting_constant_value_visitor_test.dart'
  * Utility for manually running all tests.
  */
 main() {
-  groupSep = ' | ';
-  group('Angular Analyzer Plugin tests', () {
+  defineReflectiveSuite(() {
     resolver_test.main();
     selector_test.main();
     angular_driver_test.main();
     offsetting_constant_value_visitor_test.main();
-  });
+  }, name: 'Angular Analyzer Plugin tests');
 }

--- a/deps/pubspec.yaml
+++ b/deps/pubspec.yaml
@@ -4,6 +4,6 @@ description: What we need that the sdk doesn't provide
 dependencies:
   tuple: '^1.0.1'
 dev_dependencies:
-  test_reflective_loader: '^0.0.3'
+  test_reflective_loader: '^0.1.0'
   typed_mock: '^0.0.4'
   unittest: '^0.11.0'

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -26,6 +26,7 @@ import 'mock_sdk.dart';
 
 main() {
   defineReflectiveSuite(() {
+    // TODO get these working again in the latest SDK
     //defineReflectiveTests(AngularNavigationContributorTest);
     //defineReflectiveTests(AngularOccurrencesContributorTest);
     defineReflectiveTests(EmptyTest);

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -25,10 +25,11 @@ import 'package:unittest/unittest.dart';
 import 'mock_sdk.dart';
 
 main() {
-  groupSep = ' | ';
-  //defineReflectiveTests(AngularNavigationContributorTest);
-  //defineReflectiveTests(AngularOccurrencesContributorTest);
-  defineReflectiveTests(EmptyTest);
+  defineReflectiveSuite(() {
+    //defineReflectiveTests(AngularNavigationContributorTest);
+    //defineReflectiveTests(AngularOccurrencesContributorTest);
+    defineReflectiveTests(EmptyTest);
+  });
 }
 
 @reflectiveTest

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -7,7 +7,6 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'completion_contributor_test_util.dart';
 
 main() {
-  groupSep = ' | ';
   //defineReflectiveTests(DartCompletionContributorTest);
   //defineReflectiveTests(HtmlCompletionContributorTest);
 }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -7,6 +7,7 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'completion_contributor_test_util.dart';
 
 main() {
+  // TODO: get these working again on the latest SDK
   //defineReflectiveTests(DartCompletionContributorTest);
   //defineReflectiveTests(HtmlCompletionContributorTest);
 }

--- a/server_plugin/test/test_all.dart
+++ b/server_plugin/test/test_all.dart
@@ -1,6 +1,6 @@
 library angular2.src.analysis.analyzer_plugin.src;
 
-import 'package:unittest/unittest.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import 'analysis_test.dart' as analysis_test;
 import 'completion_contributor_test.dart' as completion_contributor_test;
@@ -9,9 +9,8 @@ import 'completion_contributor_test.dart' as completion_contributor_test;
  * Utility for manually running all tests.
  */
 main() {
-  groupSep = ' | ';
-  group('Angular Server Plugin tests', () {
+  defineReflectiveSuite(() {
     analysis_test.main();
     completion_contributor_test.main();
-  });
+  }, name: 'Angular Server Plugin tests');
 }

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -12,7 +12,7 @@ echo
 cd ..
 
 echo Copying and transforming sdk .packages to be useful to this repo
-cat deps/sdk/.packages | grep -v '^test' | grep -v '^typed_mock' | grep -v '^unittest' | sed 's/:/:deps\/sdk\//' > .packages
+cat deps/sdk/.packages | grep -v '^typed_mock' | grep -v '^unittest' | grep -v '^test_reflective_loader' | sed 's/:/:deps\/sdk\//' > .packages
 echo done
 echo
 


### PR DESCRIPTION
Cannot use the version we were using before. And I'm not sure how these analysis errors made it through travis, but they are bad too