### PR TITLE
@ContentChild and @ContentChildren validation.

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -227,8 +227,25 @@ class DirectiveBinding {
   final AbstractDirective boundDirective;
   final List<InputBinding> inputBindings = [];
   final List<OutputBinding> outputBindings = [];
+  final Map<ContentChild, ContentChildBinding> contentChildBindings = {};
+  final Map<ContentChild, ContentChildBinding> contentChildrenBindings = {};
 
   DirectiveBinding(this.boundDirective);
+}
+
+/**
+ * Allows us to track ranges for navigating ContentChild(ren), and detect when
+ * multiple ContentChilds are matched which is an error.
+
+ * Naming here is important: "bound content child" != "content child binding." 
+ */
+class ContentChildBinding {
+  final AbstractDirective directive;
+  final ContentChild boundContentChild;
+  final Set<ElementInfo> boundElements = new HashSet<ElementInfo>();
+  // TODO: track bound attributes in #foo?
+
+  ContentChildBinding(this.directive, this.boundContentChild);
 }
 
 /**
@@ -312,6 +329,8 @@ class ElementInfo extends NodeInfo implements HasDirectives {
       boundDirectives.map((bd) => bd.boundDirective);
   int childNodesMaxEnd;
   bool tagMatchedAsTransclusion = false;
+  bool tagMatchedAsDirective = false;
+  bool tagMatchedAsImmediateContentChild = false;
 
   ElementInfo(
       this.localName,

--- a/analyzer_plugin/lib/src/directive_extraction.dart
+++ b/analyzer_plugin/lib/src/directive_extraction.dart
@@ -400,9 +400,14 @@ class DirectiveExtractor extends AnnotationProcessorMixin {
           continue;
         }
 
-        final annotationArgs = annotation.arguments.arguments;
+        final annotationArgs = annotation?.arguments?.arguments;
+        if (annotationArgs == null) {
+          // This happens for invalid dart code. Ignore
+          continue;
+        }
+
         if (annotationArgs.length == 0) {
-          // no need to report an error, dart does that already
+          // No need to report an error, dart does that already.
           continue;
         }
 

--- a/analyzer_plugin/lib/src/directive_extraction.dart
+++ b/analyzer_plugin/lib/src/directive_extraction.dart
@@ -427,10 +427,14 @@ class DirectiveExtractor extends AnnotationProcessorMixin {
         } else if (member is ast.MethodDeclaration) {
           name = member.name.toString();
 
-          var parameters = member.parameters.parameters;
-          if (parameters.length > 0 && parameters[0].type != null) {
-            setterTypeOffset = parameters[0].type.offset;
-            setterTypeLength = parameters[0].type.length;
+          var parameters = member.parameters?.parameters;
+          if (parameters != null && parameters.length > 0) {
+            var parameter = parameters[0];
+            if (parameter is ast.SimpleFormalParameter &&
+                parameter.type != null) {
+              setterTypeOffset = parameter.type.offset;
+              setterTypeLength = parameter.type.length;
+            }
           }
         }
         targetList.add(new ContentChildField(name,

--- a/analyzer_plugin/lib/src/directive_linking.dart
+++ b/analyzer_plugin/lib/src/directive_linking.dart
@@ -2,15 +2,17 @@ import 'dart:async';
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/src/generated/engine.dart';
 import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:angular_analyzer_plugin/src/directive_extraction.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
+import 'package:angular_analyzer_plugin/src/standard_components.dart';
 import 'package:analyzer/src/dart/resolver/scope.dart';
 import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:analyzer/src/generated/constant.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:front_end/src/scanner/token.dart';
 import 'summary/idl.dart';
 
@@ -93,6 +95,10 @@ class DirectiveLinker {
                 outputSum.propNameOffset, outputSum.propName.length),
             bindingSynthesizer.getEventType(getter, getter.name)));
       }
+      final contentChildFields =
+          deserializeContentChildFields(dirSum.contentChildFields);
+      final contentChildrenFields =
+          deserializeContentChildFields(dirSum.contentChildrenFields);
       if (dirSum.isComponent) {
         final ngContents = deserializeNgContents(dirSum.ngContents, source);
         final component = new Component(classElem,
@@ -101,7 +107,9 @@ class DirectiveLinker {
             inputs: inputs,
             outputs: outputs,
             ngContents: ngContents,
-            elementTags: elementTags);
+            elementTags: elementTags,
+            contentChildFields: contentChildFields,
+            contentChildrenFields: contentChildrenFields);
         directives.add(component);
         final subDirectives = <DirectiveReference>[];
         for (final useSum in dirSum.subdirectives) {
@@ -128,7 +136,9 @@ class DirectiveLinker {
             selector: selector,
             inputs: inputs,
             outputs: outputs,
-            elementTags: elementTags);
+            elementTags: elementTags,
+            contentChildFields: contentChildFields,
+            contentChildrenFields: contentChildrenFields);
         directives.add(directive);
       }
     }
@@ -152,13 +162,24 @@ class DirectiveLinker {
           ngContentSum.selectorStr.length);
     }).toList();
   }
+
+  List<ContentChildField> deserializeContentChildFields(
+      List<SummarizedContentChildField> fieldSums) {
+    return fieldSums.map((fieldSum) {
+      return new ContentChildField(fieldSum.fieldName,
+          nameRange: new SourceRange(fieldSum.nameOffset, fieldSum.nameLength),
+          typeRange: new SourceRange(fieldSum.typeOffset, fieldSum.typeLength));
+    }).toList();
+  }
 }
 
-class ChildDirectiveLinker {
+class ChildDirectiveLinker implements DirectiveMatcher {
   final FileDirectiveProvider _fileDirectiveProvider;
   final ErrorReporter _errorReporter;
+  final StandardAngular _standardAngular;
 
-  ChildDirectiveLinker(this._fileDirectiveProvider, this._errorReporter);
+  ChildDirectiveLinker(
+      this._fileDirectiveProvider, this._standardAngular, this._errorReporter);
 
   Future linkDirectives(
     List<AbstractDirective> directivesToLink,
@@ -170,13 +191,18 @@ class ChildDirectiveLinker {
         for (final reference in directive.view.directiveReferences) {
           final referent = lookupByName(reference, directivesToLink);
           if (referent != null) {
-            directive.view.directives.add(await withNgContent(referent));
+            directive.view.directives
+                .add(await withNgContentAndChildren(referent));
           } else {
             await lookupFromLibrary(
                 reference, scope, directive.view.directives);
           }
         }
       }
+
+      await new ContentChildLinker(
+              directive, this, _standardAngular, _errorReporter)
+          .linkContentChildren();
     }
   }
 
@@ -208,7 +234,7 @@ class ChildDirectiveLinker {
         final directive = await matchDirective(type);
 
         if (directive != null) {
-          directives.add(await withNgContent(directive));
+          directives.add(await withNgContentAndChildren(directive));
         } else {
           _errorReporter.reportErrorForOffset(
               AngularWarningCode.TYPE_IS_NOT_A_DIRECTIVE,
@@ -270,7 +296,7 @@ class ChildDirectiveLinker {
       if (typeValue is InterfaceType && typeValue.element is ClassElement) {
         final directive = await matchDirective(typeValue.element);
         if (directive != null) {
-          directives.add(await withNgContent(directive));
+          directives.add(await withNgContentAndChildren(directive));
         } else {
           _errorReporter.reportErrorForOffset(
               AngularWarningCode.TYPE_IS_NOT_A_DIRECTIVE,
@@ -288,12 +314,166 @@ class ChildDirectiveLinker {
     }
   }
 
-  Future<AbstractDirective> withNgContent(AbstractDirective directive) async {
+  Future<AbstractDirective> withNgContentAndChildren(
+      AbstractDirective directive) async {
     if (directive is Component && directive?.view?.templateUriSource != null) {
       final source = directive.view.templateUriSource;
       directive.ngContents.addAll(
           await _fileDirectiveProvider.getHtmlNgContent(source.fullName));
     }
+
+    // ignore errors from linking subcomponents content childs
+    final errorIgnorer = new ErrorReporter(new IgnoringErrorListener(),
+        directive.classElement.unit.element.source);
+    await new ContentChildLinker(
+            directive, this, _standardAngular, errorIgnorer)
+        .linkContentChildren();
     return directive;
   }
 }
+
+abstract class DirectiveMatcher {
+  Future<AbstractDirective> matchDirective(ClassElement clazz);
+}
+
+class ContentChildLinker {
+  final AnalysisContext _context;
+  final ErrorReporter _errorReporter;
+  final AbstractDirective _directive;
+  final DirectiveMatcher _directiveMatcher;
+  final StandardAngular _standardAngular;
+
+  ContentChildLinker(AbstractDirective directive, this._directiveMatcher,
+      this._standardAngular, this._errorReporter)
+      : _context = directive.classElement.unit.element.context,
+        _directive = directive;
+
+  Future linkContentChildren() async {
+    final unit = _directive.classElement.unit.element;
+    final bindingSynthesizer = new BindingTypeSynthesizer(
+        _directive.classElement,
+        unit.context.typeProvider,
+        unit.context,
+        _errorReporter);
+
+    for (final childField in _directive.contentChildFields) {
+      await recordContentChildOrChildren(childField, unit.library,
+          bindingSynthesizer, transformSetterTypeSingular,
+          annotationName: "ContentChild",
+          destinationArray: _directive.contentChilds);
+    }
+    for (final childrenField in _directive.contentChildrenFields) {
+      await recordContentChildOrChildren(childrenField, unit.library,
+          bindingSynthesizer, transformSetterTypeMultiple,
+          annotationName: "ContentChildren",
+          destinationArray: _directive.contentChildren);
+    }
+  }
+
+  Future recordContentChildOrChildren(
+      ContentChildField field,
+      LibraryElement library,
+      BindingTypeSynthesizer bindingSynthesizer,
+      TransformSetterTypeFn transformSetterTypeFn,
+      {List<ContentChild> destinationArray,
+      String annotationName}) async {
+    final member =
+        _directive.classElement.lookUpSetter(field.fieldName, library);
+    if (member == null) {
+      return;
+    }
+
+    final metadata = new List.from(member.metadata)
+      ..addAll(member.variable.metadata);
+    final annotation = metadata.singleWhere((annotation) =>
+        annotation.element?.enclosingElement?.name == annotationName);
+
+    // constantValue.getField() doesn't do inheritance. Do that ourself.
+    final value = annotation
+        .computeConstantValue() // ContentChild
+        .getField("(super)") // extends Query
+        ?.getField("(super)") // extends DependencyMetadata
+        ?.getField("selector"); // which has field selector
+    if (value?.toStringValue() != null) {
+      final setterType = transformSetterTypeFn(
+          bindingSynthesizer.getSetterType(member), field, annotationName);
+      destinationArray.add(new ContentChild(field,
+          new LetBoundQueriedChildType(value.toStringValue(), setterType)));
+    } else if (value?.toTypeValue() != null) {
+      final type = value.toTypeValue();
+      final referencedDirective =
+          await _directiveMatcher.matchDirective(type.element);
+      if (referencedDirective != null) {
+        destinationArray.add(new ContentChild(
+            field, new DirectiveQueriedChildType(referencedDirective)));
+      } else if (type.element.name == "ElementRef") {
+        destinationArray
+            .add(new ContentChild(field, new ElementRefQueriedChildType()));
+      } else if (type.element.name == "TemplateRef") {
+        destinationArray
+            .add(new ContentChild(field, new TemplateRefQueriedChildType()));
+      } else {
+        _errorReporter.reportErrorForOffset(
+            AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE,
+            field.nameRange.offset,
+            field.nameRange.length,
+            [field.fieldName, annotationName]);
+        return;
+      }
+
+      final setterType = transformSetterTypeFn(
+          bindingSynthesizer.getSetterType(member), field, annotationName);
+      checkQueriedTypeAssignableTo(setterType, type, field, annotationName);
+    } else {
+      _errorReporter.reportErrorForOffset(
+          AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE,
+          field.nameRange.offset,
+          field.nameRange.length,
+          [field.fieldName, annotationName]);
+    }
+  }
+
+  void checkQueriedTypeAssignableTo(DartType setterType, DartType annotatedType,
+      ContentChildField field, String annotationName) {
+    if (setterType != null && !setterType.isSupertypeOf(annotatedType)) {
+      _errorReporter.reportErrorForOffset(
+          AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+          field.typeRange.offset,
+          field.typeRange.length,
+          [field.fieldName, annotationName, annotatedType, setterType]);
+    }
+  }
+
+  DartType transformSetterTypeSingular(DartType setterType,
+          ContentChildField field, String annotationName) =>
+      setterType;
+
+  DartType transformSetterTypeMultiple(
+      DartType setterType, ContentChildField field, String annotationName) {
+    // construct QueryList<Bottom>, which is a supertype of all QueryList<T>
+    // NOTE: In most languages, you'd need QueryList<Object>, but not dart.
+    var queryListBottom = _standardAngular.queryList.type
+        .instantiate([_context.typeProvider.bottomType]);
+
+    var isQueryList = setterType.isSupertypeOf(queryListBottom);
+
+    if (!isQueryList) {
+      _errorReporter.reportErrorForOffset(
+          AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
+          field.typeRange.offset,
+          field.typeRange.length,
+          [field.fieldName, annotationName, setterType]);
+
+      return _context.typeProvider.dynamicType;
+    }
+
+    var iterableType = _context.typeProvider.iterableType;
+
+    // get T for setterTypes that extend Iterable<T>
+    return _context.typeSystem
+        .mostSpecificTypeArgument(setterType, iterableType);
+  }
+}
+
+typedef DartType TransformSetterTypeFn(
+    DartType setterType, ContentChildField field, String annotationName);

--- a/analyzer_plugin/lib/src/directive_linking.dart
+++ b/analyzer_plugin/lib/src/directive_linking.dart
@@ -323,8 +323,8 @@ class ChildDirectiveLinker implements DirectiveMatcher {
     }
 
     // ignore errors from linking subcomponents content childs
-    final errorIgnorer = new ErrorReporter(new IgnoringErrorListener(),
-        directive.classElement.unit.element.source);
+    final errorIgnorer = new ErrorReporter(
+        new IgnoringErrorListener(), directive.classElement.source);
     await new ContentChildLinker(
             directive, this, _standardAngular, errorIgnorer)
         .linkContentChildren();
@@ -345,11 +345,12 @@ class ContentChildLinker {
 
   ContentChildLinker(AbstractDirective directive, this._directiveMatcher,
       this._standardAngular, this._errorReporter)
-      : _context = directive.classElement.unit.element.context,
+      : _context =
+            directive.classElement.enclosingElement.enclosingElement.context,
         _directive = directive;
 
   Future linkContentChildren() async {
-    final unit = _directive.classElement.unit.element;
+    final unit = _directive.classElement.enclosingElement.enclosingElement;
     final bindingSynthesizer = new BindingTypeSynthesizer(
         _directive.classElement,
         unit.context.typeProvider,

--- a/analyzer_plugin/lib/src/directive_linking.dart
+++ b/analyzer_plugin/lib/src/directive_linking.dart
@@ -404,8 +404,15 @@ class ContentChildLinker {
 
     final metadata = new List.from(member.metadata)
       ..addAll(member.variable.metadata);
-    final annotation = metadata.singleWhere((annotation) =>
+    final annotations = metadata.where((annotation) =>
         annotation.element?.enclosingElement?.name == annotationName);
+
+    // This can happen for invalid dart
+    if (annotations.length != 1) {
+      return;
+    }
+
+    final annotation = annotations.first;
 
     // constantValue.getField() doesn't do inheritance. Do that ourself.
     final value = getSelectorWithInheritance(annotation.computeConstantValue());

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -15,6 +15,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
+import 'package:angular_analyzer_plugin/src/standard_components.dart';
 import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
 
@@ -87,6 +88,7 @@ class TemplateResolver {
   final Map<String, OutputElement> standardHtmlEvents;
   final Map<String, InputElement> standardHtmlAttributes;
   final AnalysisErrorListener errorListener;
+  final StandardAngular standardAngular;
 
   Template template;
   View view;
@@ -105,8 +107,13 @@ class TemplateResolver {
   Map<String, LocalVariable> localVariables =
       new HashMap<String, LocalVariable>();
 
-  TemplateResolver(this.typeProvider, this.standardHtmlComponents,
-      this.standardHtmlEvents, this.standardHtmlAttributes, this.errorListener);
+  TemplateResolver(
+      this.typeProvider,
+      this.standardHtmlComponents,
+      this.standardHtmlEvents,
+      this.standardHtmlAttributes,
+      this.standardAngular,
+      this.errorListener);
 
   void resolve(Template template) {
     this.template = template;
@@ -120,8 +127,16 @@ class TemplateResolver {
       ..addAll(standardHtmlComponents)
       ..addAll(view.directives);
     DirectiveResolver directiveResolver = new DirectiveResolver(
-        allDirectives, templateSource, template, errorListener);
+        allDirectives,
+        templateSource,
+        template,
+        standardAngular,
+        errorReporter,
+        errorListener);
     root.accept(directiveResolver);
+    ComponentContentResolver contentResolver =
+        new ComponentContentResolver(templateSource, template, errorListener);
+    root.accept(contentResolver);
 
     _resolveScope(root);
   }
@@ -703,47 +718,168 @@ class DirectiveResolver extends AngularAstVisitor {
   final Source templateSource;
   final Template template;
   final AnalysisErrorListener errorListener;
+  final ErrorReporter _errorReporter;
+  final StandardAngular _standardAngular;
+  final List<DirectiveBinding> outerBindings = [];
+  final List<ElementInfo> outerElements = [];
 
   DirectiveResolver(this.allDirectives, this.templateSource, this.template,
-      this.errorListener);
+      this._standardAngular, this._errorReporter, this.errorListener);
 
   @override
   void visitElementInfo(ElementInfo element) {
+    outerElements.add(element);
     if (element.templateAttribute != null) {
       visitTemplateAttr(element.templateAttribute);
     }
 
     ElementView elementView = new ElementViewImpl(element.attributes, element);
-    bool tagIsResolved = element.tagMatchedAsTransclusion;
-    bool tagIsStandard = _isStandardTagName(element.localName);
-    Component component;
 
+    int containingDirectivesCount = outerBindings.length;
     for (AbstractDirective directive in allDirectives) {
       SelectorMatch match = directive.selector.match(elementView, template);
       if (match != SelectorMatch.NoMatch) {
-        element.boundDirectives.add(new DirectiveBinding(directive));
+        var binding = new DirectiveBinding(directive);
+        element.boundDirectives.add(binding);
         if (match == SelectorMatch.TagMatch) {
-          tagIsResolved = true;
+          element.tagMatchedAsDirective = true;
         }
 
-        if (directive is Component) {
-          component = directive;
-          // TODO better html tag detection, see #248
-          tagIsStandard = component.isHtml;
+        if (!(directive is Component && directive.isHtml)) {
+          outerBindings.add(binding);
         }
       }
-    }
-    if (!tagIsStandard && !tagIsResolved) {
-      _reportErrorForRange(element.openingNameSpan,
-          AngularWarningCode.UNRESOLVED_TAG, [element.localName]);
     }
 
     if (!element.isOrHasTemplateAttribute) {
       _checkNoStructuralDirectives(element.attributes);
     }
 
+    recordContentChildren(element);
+
+    for (NodeInfo child in element.childNodes) {
+      child.accept(this);
+    }
+
+    outerBindings.removeRange(containingDirectivesCount, outerBindings.length);
+    outerElements.removeLast();
+  }
+
+  @override
+  void visitTemplateAttr(TemplateAttribute attr) {
+    // TODO: report error if no directives matched here?
+    ElementView elementView = new ElementViewImpl(attr.virtualAttributes, null);
+    for (AbstractDirective directive in allDirectives) {
+      if (directive.selector.match(elementView, template) !=
+          SelectorMatch.NoMatch) {
+        attr.boundDirectives.add(new DirectiveBinding(directive));
+      }
+    }
+  }
+
+  _checkNoStructuralDirectives(List<AttributeInfo> attributes) {
+    for (AttributeInfo attribute in attributes) {
+      if (attribute.name == 'ngFor' || attribute.name == 'ngIf') {
+        _reportErrorForRange(
+            new SourceRange(attribute.nameOffset, attribute.name.length),
+            AngularWarningCode.STRUCTURAL_DIRECTIVES_REQUIRE_TEMPLATE,
+            [attribute.name]);
+      }
+    }
+  }
+
+  recordContentChildren(ElementInfo element) {
+    for (final binding in outerBindings) {
+      for (var contentChild in binding.boundDirective.contentChilds) {
+        // an already matched ContentChild shouldn't look inside that match
+        if (binding.contentChildBindings[contentChild]?.boundElements
+                ?.any((element) => outerElements.contains(element)) ==
+            true) {
+          continue;
+        }
+
+        if (contentChild.query
+            .match(element, _standardAngular, _errorReporter)) {
+          binding.contentChildBindings.putIfAbsent(
+              contentChild,
+              () => new ContentChildBinding(
+                  binding.boundDirective, contentChild));
+
+          if (!binding
+              .contentChildBindings[contentChild].boundElements.isEmpty) {
+            _errorReporter.reportErrorForOffset(
+                AngularWarningCode.SINGULAR_CHILD_QUERY_MATCHED_MULTIPLE_TIMES,
+                element.offset,
+                element.length, [
+              binding.boundDirective.classElement.name,
+              contentChild.field.fieldName
+            ]);
+          }
+          binding.contentChildBindings[contentChild].boundElements.add(element);
+
+          if (element.parent.boundDirectives.contains(binding)) {
+            element.tagMatchedAsImmediateContentChild = true;
+          }
+        }
+      }
+
+      for (var contentChildren in binding.boundDirective.contentChildren) {
+        if (contentChildren.query
+            .match(element, _standardAngular, _errorReporter)) {
+          binding.contentChildrenBindings.putIfAbsent(
+              contentChildren,
+              () => new ContentChildBinding(
+                  binding.boundDirective, contentChildren));
+          binding.contentChildrenBindings[contentChildren].boundElements
+              .add(element);
+
+          if (element.parent.boundDirectives.contains(binding)) {
+            element.tagMatchedAsImmediateContentChild = true;
+          }
+        }
+      }
+    }
+  }
+
+  void _reportErrorForRange(SourceRange range, ErrorCode errorCode,
+      [List<Object> arguments]) {
+    errorListener.onError(new AnalysisError(
+        templateSource, range.offset, range.length, errorCode, arguments));
+  }
+}
+
+class ComponentContentResolver extends AngularAstVisitor {
+  final Source templateSource;
+  final Template template;
+  final AnalysisErrorListener errorListener;
+
+  ComponentContentResolver(
+      this.templateSource, this.template, this.errorListener);
+
+  @override
+  void visitElementInfo(ElementInfo element) {
+    // TODO should we visitTemplateAttr(element.templateAttribute) ??
+    bool tagIsStandard = _isStandardTagName(element.localName);
+    Component component;
+
+    for (AbstractDirective directive in element.directives) {
+      if (directive is Component) {
+        component = directive;
+        // TODO better html tag detection, see #248
+        tagIsStandard = component.isHtml;
+      }
+    }
+
+    if (!tagIsStandard &&
+        !element.tagMatchedAsTransclusion &&
+        !element.tagMatchedAsDirective) {
+      _reportErrorForRange(element.openingNameSpan,
+          AngularWarningCode.UNRESOLVED_TAG, [element.localName]);
+    }
+
     if (!tagIsStandard) {
-      _checkTranscludedContent(component, element.childNodes, tagIsStandard);
+      checkTransclusionsContentChildren(
+          component, element.childNodes, tagIsStandard);
     }
 
     for (NodeInfo child in element.childNodes) {
@@ -751,7 +887,7 @@ class DirectiveResolver extends AngularAstVisitor {
     }
   }
 
-  void _checkTranscludedContent(
+  void checkTransclusionsContentChildren(
       Component component, List<NodeInfo> children, bool tagIsStandard) {
     if (component?.ngContents == null) {
       return;
@@ -776,35 +912,14 @@ class DirectiveResolver extends AngularAstVisitor {
           }
         }
 
+        matched = matched || child.tagMatchedAsImmediateContentChild;
+
         if (!matched) {
           _reportErrorForRange(new SourceRange(child.offset, child.length),
               AngularWarningCode.CONTENT_NOT_TRANSCLUDED);
         } else if (matchedTag) {
           child.tagMatchedAsTransclusion = true;
         }
-      }
-    }
-  }
-
-  @override
-  void visitTemplateAttr(TemplateAttribute attr) {
-    // TODO: report error if no directives matched here?
-    ElementView elementView = new ElementViewImpl(attr.virtualAttributes, null);
-    for (AbstractDirective directive in allDirectives) {
-      if (directive.selector.match(elementView, template) !=
-          SelectorMatch.NoMatch) {
-        attr.boundDirectives.add(new DirectiveBinding(directive));
-      }
-    }
-  }
-
-  _checkNoStructuralDirectives(List<AttributeInfo> attributes) {
-    for (AttributeInfo attribute in attributes) {
-      if (attribute.name == 'ngFor' || attribute.name == 'ngIf') {
-        _reportErrorForRange(
-            new SourceRange(attribute.nameOffset, attribute.name.length),
-            AngularWarningCode.STRUCTURAL_DIRECTIVES_REQUIRE_TEMPLATE,
-            [attribute.name]);
       }
     }
   }

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -745,7 +745,9 @@ class DirectiveResolver extends AngularAstVisitor {
           element.tagMatchedAsDirective = true;
         }
 
-        if (!(directive is Component && directive.isHtml)) {
+        // optimization: only add the bindings that care about content child
+        if (directive.contentChilds.isNotEmpty ||
+            directive.contentChildren.isNotEmpty) {
           outerBindings.add(binding);
         }
       }

--- a/analyzer_plugin/lib/src/standard_components.dart
+++ b/analyzer_plugin/lib/src/standard_components.dart
@@ -14,6 +14,14 @@ class StandardHtml {
   StandardHtml(this.components, this.events, this.attributes);
 }
 
+class StandardAngular {
+  final ClassElement templateRef;
+  final ClassElement elementRef;
+  final ClassElement queryList;
+
+  StandardAngular({this.templateRef, this.elementRef, this.queryList});
+}
+
 class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   final Map<String, Component> components;
   final Map<String, OutputElement> events;

--- a/analyzer_plugin/lib/src/summary/format.dart
+++ b/analyzer_plugin/lib/src/summary/format.dart
@@ -750,6 +750,8 @@ class SummarizedDirectiveBuilder extends Object
   List<SummarizedBindableBuilder> _inputs;
   List<SummarizedBindableBuilder> _outputs;
   List<SummarizedDirectiveUseBuilder> _subdirectives;
+  List<SummarizedContentChildFieldBuilder> _contentChildFields;
+  List<SummarizedContentChildFieldBuilder> _contentChildrenFields;
 
   @override
   bool get isComponent => _isComponent ??= false;
@@ -865,6 +867,23 @@ class SummarizedDirectiveBuilder extends Object
     this._subdirectives = value;
   }
 
+  @override
+  List<SummarizedContentChildFieldBuilder> get contentChildFields =>
+      _contentChildFields ??= <SummarizedContentChildFieldBuilder>[];
+
+  void set contentChildFields(List<SummarizedContentChildFieldBuilder> value) {
+    this._contentChildFields = value;
+  }
+
+  @override
+  List<SummarizedContentChildFieldBuilder> get contentChildrenFields =>
+      _contentChildrenFields ??= <SummarizedContentChildFieldBuilder>[];
+
+  void set contentChildrenFields(
+      List<SummarizedContentChildFieldBuilder> value) {
+    this._contentChildrenFields = value;
+  }
+
   SummarizedDirectiveBuilder(
       {bool isComponent,
       String selectorStr,
@@ -880,7 +899,9 @@ class SummarizedDirectiveBuilder extends Object
       List<SummarizedNgContentBuilder> ngContents,
       List<SummarizedBindableBuilder> inputs,
       List<SummarizedBindableBuilder> outputs,
-      List<SummarizedDirectiveUseBuilder> subdirectives})
+      List<SummarizedDirectiveUseBuilder> subdirectives,
+      List<SummarizedContentChildFieldBuilder> contentChildFields,
+      List<SummarizedContentChildFieldBuilder> contentChildrenFields})
       : _isComponent = isComponent,
         _selectorStr = selectorStr,
         _selectorOffset = selectorOffset,
@@ -895,7 +916,9 @@ class SummarizedDirectiveBuilder extends Object
         _ngContents = ngContents,
         _inputs = inputs,
         _outputs = outputs,
-        _subdirectives = subdirectives;
+        _subdirectives = subdirectives,
+        _contentChildFields = contentChildFields,
+        _contentChildrenFields = contentChildrenFields;
 
   /**
    * Flush [informative] data recursively.
@@ -905,6 +928,8 @@ class SummarizedDirectiveBuilder extends Object
     _inputs?.forEach((b) => b.flushInformative());
     _outputs?.forEach((b) => b.flushInformative());
     _subdirectives?.forEach((b) => b.flushInformative());
+    _contentChildFields?.forEach((b) => b.flushInformative());
+    _contentChildrenFields?.forEach((b) => b.flushInformative());
   }
 
   /**
@@ -954,6 +979,22 @@ class SummarizedDirectiveBuilder extends Object
         x?.collectApiSignature(signature);
       }
     }
+    if (this._contentChildFields == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._contentChildFields.length);
+      for (var x in this._contentChildFields) {
+        x?.collectApiSignature(signature);
+      }
+    }
+    if (this._contentChildrenFields == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._contentChildrenFields.length);
+      for (var x in this._contentChildrenFields) {
+        x?.collectApiSignature(signature);
+      }
+    }
   }
 
   fb.Offset finish(fb.Builder fbBuilder) {
@@ -966,6 +1007,8 @@ class SummarizedDirectiveBuilder extends Object
     fb.Offset offset_inputs;
     fb.Offset offset_outputs;
     fb.Offset offset_subdirectives;
+    fb.Offset offset_contentChildFields;
+    fb.Offset offset_contentChildrenFields;
     if (_selectorStr != null) {
       offset_selectorStr = fbBuilder.writeString(_selectorStr);
     }
@@ -996,6 +1039,14 @@ class SummarizedDirectiveBuilder extends Object
     if (!(_subdirectives == null || _subdirectives.isEmpty)) {
       offset_subdirectives = fbBuilder
           .writeList(_subdirectives.map((b) => b.finish(fbBuilder)).toList());
+    }
+    if (!(_contentChildFields == null || _contentChildFields.isEmpty)) {
+      offset_contentChildFields = fbBuilder.writeList(
+          _contentChildFields.map((b) => b.finish(fbBuilder)).toList());
+    }
+    if (!(_contentChildrenFields == null || _contentChildrenFields.isEmpty)) {
+      offset_contentChildrenFields = fbBuilder.writeList(
+          _contentChildrenFields.map((b) => b.finish(fbBuilder)).toList());
     }
     fbBuilder.startTable();
     if (_isComponent == true) {
@@ -1043,6 +1094,12 @@ class SummarizedDirectiveBuilder extends Object
     if (offset_subdirectives != null) {
       fbBuilder.addOffset(14, offset_subdirectives);
     }
+    if (offset_contentChildFields != null) {
+      fbBuilder.addOffset(15, offset_contentChildFields);
+    }
+    if (offset_contentChildrenFields != null) {
+      fbBuilder.addOffset(16, offset_contentChildrenFields);
+    }
     return fbBuilder.endTable();
   }
 }
@@ -1079,6 +1136,8 @@ class _SummarizedDirectiveImpl extends Object
   List<idl.SummarizedBindable> _inputs;
   List<idl.SummarizedBindable> _outputs;
   List<idl.SummarizedDirectiveUse> _subdirectives;
+  List<idl.SummarizedContentChildField> _contentChildFields;
+  List<idl.SummarizedContentChildField> _contentChildrenFields;
 
   @override
   bool get isComponent {
@@ -1181,6 +1240,26 @@ class _SummarizedDirectiveImpl extends Object
         .vTableGet(_bc, _bcOffset, 14, const <idl.SummarizedDirectiveUse>[]);
     return _subdirectives;
   }
+
+  @override
+  List<idl.SummarizedContentChildField> get contentChildFields {
+    _contentChildFields ??=
+        const fb.ListReader<idl.SummarizedContentChildField>(
+                const _SummarizedContentChildFieldReader())
+            .vTableGet(
+                _bc, _bcOffset, 15, const <idl.SummarizedContentChildField>[]);
+    return _contentChildFields;
+  }
+
+  @override
+  List<idl.SummarizedContentChildField> get contentChildrenFields {
+    _contentChildrenFields ??=
+        const fb.ListReader<idl.SummarizedContentChildField>(
+                const _SummarizedContentChildFieldReader())
+            .vTableGet(
+                _bc, _bcOffset, 16, const <idl.SummarizedContentChildField>[]);
+    return _contentChildrenFields;
+  }
 }
 
 abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
@@ -1211,6 +1290,12 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
     if (subdirectives.isNotEmpty)
       _result["subdirectives"] =
           subdirectives.map((_value) => _value.toJson()).toList();
+    if (contentChildFields.isNotEmpty)
+      _result["contentChildFields"] =
+          contentChildFields.map((_value) => _value.toJson()).toList();
+    if (contentChildrenFields.isNotEmpty)
+      _result["contentChildrenFields"] =
+          contentChildrenFields.map((_value) => _value.toJson()).toList();
     return _result;
   }
 
@@ -1231,6 +1316,8 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
         "inputs": inputs,
         "outputs": outputs,
         "subdirectives": subdirectives,
+        "contentChildFields": contentChildFields,
+        "contentChildrenFields": contentChildrenFields,
       };
 
   @override
@@ -2001,6 +2088,188 @@ abstract class _SummarizedNgContentMixin implements idl.SummarizedNgContent {
         "length": length,
         "selectorStr": selectorStr,
         "selectorOffset": selectorOffset,
+      };
+
+  @override
+  String toString() => convert.JSON.encode(toJson());
+}
+
+class SummarizedContentChildFieldBuilder extends Object
+    with _SummarizedContentChildFieldMixin
+    implements idl.SummarizedContentChildField {
+  String _fieldName;
+  int _nameOffset;
+  int _nameLength;
+  int _typeOffset;
+  int _typeLength;
+
+  @override
+  String get fieldName => _fieldName ??= '';
+
+  void set fieldName(String value) {
+    this._fieldName = value;
+  }
+
+  @override
+  int get nameOffset => _nameOffset ??= 0;
+
+  void set nameOffset(int value) {
+    assert(value == null || value >= 0);
+    this._nameOffset = value;
+  }
+
+  @override
+  int get nameLength => _nameLength ??= 0;
+
+  void set nameLength(int value) {
+    assert(value == null || value >= 0);
+    this._nameLength = value;
+  }
+
+  @override
+  int get typeOffset => _typeOffset ??= 0;
+
+  void set typeOffset(int value) {
+    assert(value == null || value >= 0);
+    this._typeOffset = value;
+  }
+
+  @override
+  int get typeLength => _typeLength ??= 0;
+
+  void set typeLength(int value) {
+    assert(value == null || value >= 0);
+    this._typeLength = value;
+  }
+
+  SummarizedContentChildFieldBuilder(
+      {String fieldName,
+      int nameOffset,
+      int nameLength,
+      int typeOffset,
+      int typeLength})
+      : _fieldName = fieldName,
+        _nameOffset = nameOffset,
+        _nameLength = nameLength,
+        _typeOffset = typeOffset,
+        _typeLength = typeLength;
+
+  /**
+   * Flush [informative] data recursively.
+   */
+  void flushInformative() {}
+
+  /**
+   * Accumulate non-[informative] data into [signature].
+   */
+  void collectApiSignature(api_sig.ApiSignature signature) {
+    signature.addString(this._fieldName ?? '');
+    signature.addInt(this._nameOffset ?? 0);
+    signature.addInt(this._nameLength ?? 0);
+    signature.addInt(this._typeOffset ?? 0);
+    signature.addInt(this._typeLength ?? 0);
+  }
+
+  fb.Offset finish(fb.Builder fbBuilder) {
+    fb.Offset offset_fieldName;
+    if (_fieldName != null) {
+      offset_fieldName = fbBuilder.writeString(_fieldName);
+    }
+    fbBuilder.startTable();
+    if (offset_fieldName != null) {
+      fbBuilder.addOffset(0, offset_fieldName);
+    }
+    if (_nameOffset != null && _nameOffset != 0) {
+      fbBuilder.addUint32(1, _nameOffset);
+    }
+    if (_nameLength != null && _nameLength != 0) {
+      fbBuilder.addUint32(2, _nameLength);
+    }
+    if (_typeOffset != null && _typeOffset != 0) {
+      fbBuilder.addUint32(3, _typeOffset);
+    }
+    if (_typeLength != null && _typeLength != 0) {
+      fbBuilder.addUint32(4, _typeLength);
+    }
+    return fbBuilder.endTable();
+  }
+}
+
+class _SummarizedContentChildFieldReader
+    extends fb.TableReader<_SummarizedContentChildFieldImpl> {
+  const _SummarizedContentChildFieldReader();
+
+  @override
+  _SummarizedContentChildFieldImpl createObject(
+          fb.BufferContext bc, int offset) =>
+      new _SummarizedContentChildFieldImpl(bc, offset);
+}
+
+class _SummarizedContentChildFieldImpl extends Object
+    with _SummarizedContentChildFieldMixin
+    implements idl.SummarizedContentChildField {
+  final fb.BufferContext _bc;
+  final int _bcOffset;
+
+  _SummarizedContentChildFieldImpl(this._bc, this._bcOffset);
+
+  String _fieldName;
+  int _nameOffset;
+  int _nameLength;
+  int _typeOffset;
+  int _typeLength;
+
+  @override
+  String get fieldName {
+    _fieldName ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 0, '');
+    return _fieldName;
+  }
+
+  @override
+  int get nameOffset {
+    _nameOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 1, 0);
+    return _nameOffset;
+  }
+
+  @override
+  int get nameLength {
+    _nameLength ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 2, 0);
+    return _nameLength;
+  }
+
+  @override
+  int get typeOffset {
+    _typeOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 3, 0);
+    return _typeOffset;
+  }
+
+  @override
+  int get typeLength {
+    _typeLength ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 4, 0);
+    return _typeLength;
+  }
+}
+
+abstract class _SummarizedContentChildFieldMixin
+    implements idl.SummarizedContentChildField {
+  @override
+  Map<String, Object> toJson() {
+    Map<String, Object> _result = <String, Object>{};
+    if (fieldName != '') _result["fieldName"] = fieldName;
+    if (nameOffset != 0) _result["nameOffset"] = nameOffset;
+    if (nameLength != 0) _result["nameLength"] = nameLength;
+    if (typeOffset != 0) _result["typeOffset"] = typeOffset;
+    if (typeLength != 0) _result["typeLength"] = typeLength;
+    return _result;
+  }
+
+  @override
+  Map<String, Object> toMap() => {
+        "fieldName": fieldName,
+        "nameOffset": nameOffset,
+        "nameLength": nameLength,
+        "typeOffset": typeOffset,
+        "typeLength": typeLength,
       };
 
   @override

--- a/analyzer_plugin/lib/src/summary/format.fbs
+++ b/analyzer_plugin/lib/src/summary/format.fbs
@@ -66,6 +66,10 @@ table SummarizedDirective {
   outputs:[SummarizedBindable] (id: 13);
 
   subdirectives:[SummarizedDirectiveUse] (id: 14);
+
+  contentChildFields:[SummarizedContentChildField] (id: 15);
+
+  contentChildrenFields:[SummarizedContentChildField] (id: 16);
 }
 
 table SummarizedAnalysisError {
@@ -114,6 +118,18 @@ table SummarizedNgContent {
   selectorStr:string (id: 2);
 
   selectorOffset:uint (id: 3);
+}
+
+table SummarizedContentChildField {
+  fieldName:string (id: 0);
+
+  nameOffset:uint (id: 1);
+
+  nameLength:uint (id: 2);
+
+  typeOffset:uint (id: 3);
+
+  typeLength:uint (id: 4);
 }
 
 root_type PackageBundle;

--- a/analyzer_plugin/lib/src/summary/idl.dart
+++ b/analyzer_plugin/lib/src/summary/idl.dart
@@ -93,6 +93,10 @@ abstract class SummarizedDirective extends base.SummaryClass {
   List<SummarizedBindable> get outputs;
   @Id(14)
   List<SummarizedDirectiveUse> get subdirectives;
+  @Id(15)
+  List<SummarizedContentChildField> get contentChildFields;
+  @Id(16)
+  List<SummarizedContentChildField> get contentChildrenFields;
 }
 
 abstract class SummarizedAnalysisError extends base.SummaryClass {
@@ -146,4 +150,17 @@ abstract class SummarizedNgContent extends base.SummaryClass {
   String get selectorStr;
   @Id(3)
   int get selectorOffset;
+}
+
+abstract class SummarizedContentChildField extends base.SummaryClass {
+  @Id(0)
+  String get fieldName;
+  @Id(1)
+  int get nameOffset;
+  @Id(2)
+  int get nameLength;
+  @Id(3)
+  int get typeOffset;
+  @Id(4)
+  int get typeLength;
 }

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -44,7 +44,11 @@ const List<AngularWarningCode> _angularWarningCodeValues = const [
   AngularWarningCode.OUTPUT_STATEMENT_REQUIRES_EXPRESSION_STATEMENT,
   AngularWarningCode.DISALLOWED_EXPRESSION,
   AngularWarningCode.ATTRIBUTE_PARAMETER_MUST_BE_STRING,
-  AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID
+  AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID,
+  AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+  AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE,
+  AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
+  AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE
 ];
 
 /**
@@ -402,6 +406,60 @@ class AngularWarningCode extends ErrorCode {
           "Input {0} is not a string input, but is not bound with [bracket] "
           "syntax. This binds the String attribute value directly, resulting "
           "in a type error.");
+  /**
+   * An error code indicating that a @ContentChild or @ContentChildren field
+   * either mismatched types in the definition, or where it was used (ie
+   * `@ContentChild(TemplateRef) ElementRef foo`, or `@ContentChild('foo')
+   * TemplateRef foo` with `<div #foo>`).
+   */
+  static const AngularWarningCode INVALID_TYPE_FOR_CHILD_QUERY =
+      const AngularWarningCode(
+          'INVALID_TYPE_FOR_CHILD_QUERY',
+          "The field {0} marked with @{1} referencing type {2} expects a member"
+          " referencing type {2}, but got a {3}");
+
+  /**
+   * An error code indicating that a @ContentChild or @ContentChildren field
+   * didn't have an expected value
+   */
+  static const AngularWarningCode UNKNOWN_CHILD_QUERY_TYPE =
+      const AngularWarningCode(
+          'UNKNOWN_CHILD_QUERY_TYPE',
+          "The field {0} marked with @{1} must reference a directive, a string"
+          " let-binding name, TemplateRef, or ElementRef");
+
+  /**
+   * An error code indicating that @ContentChildren or @ViewChildren was used
+   * but the property wasn't a `QueryList`.
+   */
+  static const AngularWarningCode CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST =
+      const AngularWarningCode(
+          'CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST',
+          "The field {0} marked with @{1} expects a member of type QueryList,"
+          " but got {2}");
+
+  /**
+   * An error code indicating that @ContentChild or @ViewChild with a string
+   * let-binding query was matched in a way that's not assignable to the
+   * annotated property.
+   */
+  static const AngularWarningCode MATCHED_LET_BINDING_HAS_WRONG_TYPE =
+      const AngularWarningCode(
+          'MATCHED_LET_BINDING_HAS_WRONG_TYPE',
+          "Marking this with #{0} here expects the element to be of type {1},"
+          " (but is of type {2}) because an enclosing element marks {0} as a"
+          " content child field of type {1}.");
+
+  /**
+   * An error code indicating that @ContentChild or @ViewChild was matched
+   * multiple times.
+   */
+  static const AngularWarningCode SINGULAR_CHILD_QUERY_MATCHED_MULTIPLE_TIMES =
+      const AngularWarningCode(
+          'SINGULAR_CHILD_QUERY_MATCHED_MULTIPLE_TIMES',
+          "A containing {0} expects a single child matching {1}, but this is"
+          " not the first match. Use (Content or View)Children to allow"
+          " multiple matches.");
 
   /**
    * Initialize a newly created error code to have the given [name].

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -259,12 +259,12 @@ class ContentChildren extends Query {
 }
 
 class Query extends DependencyMetadata {
-  const DependencyMetadata(dynamic selector) : super(selector);
+  final dynamic /* Type | String */ selector;
+  const DependencyMetadata(this.selector) : super();
 }
 
 class DependencyMetadata {
-  final dynamic /* Type | String */ selector;
-  const DependencyMetadata(this.selector);
+  const DependencyMetadata();
 }
 
 class TemplateRef {}

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -121,7 +121,9 @@ class AbstractAngularTest {
     resourceProvider = new MemoryResourceProvider();
 
     sdk = new MockSdk(resourceProvider: resourceProvider);
-    final packageMap = new Map<String, List<Folder>>();
+    final packageMap = <String, List<Folder>>{
+      "angular2": [resourceProvider.getFolder("/angular2")]
+    };
     PackageMapUriResolver packageResolver =
         new PackageMapUriResolver(resourceProvider, packageMap);
     SourceFactory sf = new SourceFactory([
@@ -245,6 +247,29 @@ class Attribute {
   final String attributeName;
   const Attribute(this.attributeName);
 }
+
+class ContentChild extends Query {
+  const ContentChild(dynamic /* Type | String */ selector,
+              {dynamic read: null}) : super(selector);
+}
+
+class ContentChildren extends Query {
+  const ContentChildren(dynamic /* Type | String */ selector,
+              {dynamic read: null}) : super(selector);
+}
+
+class Query extends DependencyMetadata {
+  const DependencyMetadata(dynamic selector) : super(selector);
+}
+
+class DependencyMetadata {
+  final dynamic /* Type | String */ selector;
+  const DependencyMetadata(this.selector);
+}
+
+class TemplateRef {}
+class ElementRef {}
+class QueryList<T> implements Iterable<T> {}
 ''');
     newSource(
         '/angular2/src/core/async.dart',

--- a/analyzer_plugin/test/angular_driver_test.dart
+++ b/analyzer_plugin/test/angular_driver_test.dart
@@ -265,7 +265,7 @@ class BuildUnitDirectivesTest extends AbstractAngularTest {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'comp-a', template:'')
 class ComponentA {
@@ -313,7 +313,7 @@ class ComponentB {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: 'dir-a')
 class DirectiveA {
@@ -361,7 +361,7 @@ class DirectiveB {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: 'dir-a1, dir-a2, dir-a3')
 class DirectiveA {
@@ -418,7 +418,7 @@ class DirectiveB {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: 'dir-a.myClass[myAttr]')
 class DirectiveA {
@@ -466,7 +466,7 @@ class DirectiveB {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: 'dir-a1.myClass[myAttr], dir-a2.otherClass')
 class DirectiveA {
@@ -518,7 +518,7 @@ class DirectiveB {
 
   Future test_exportAs_Component() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', exportAs: 'export-name', template:'')
 class ComponentA {
@@ -552,7 +552,7 @@ class ComponentB {
 
   Future test_exportAs_Directive() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: '[aaa]', exportAs: 'export-name')
 class DirectiveA {
@@ -588,7 +588,7 @@ class DirectiveB {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', exportAs: 42, template:'')
 class ComponentA {
@@ -607,7 +607,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', exportAs: 'a' + 'b', template:'')
 class ComponentA {
@@ -623,7 +623,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(template:'')
 class ComponentA {
@@ -637,7 +637,7 @@ class ComponentA {
 
   Future test_hasError_CannotParseSelector() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(selector: 'a+bad selector', template: '')
 class ComponentA {
 }
@@ -653,7 +653,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 55, template: '')
 class ComponentA {
@@ -671,7 +671,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'a' + '[b]', template: '')
 class ComponentA {
@@ -686,7 +686,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', inputs: const ['noSetter: no-setter'], template: '')
 class ComponentA {
@@ -706,7 +706,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', inputs: const ['noSetter'], template: '')
 class ComponentA {
@@ -722,7 +722,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', inputs: const ['noSetter'], template: '')
 class ComponentA {
@@ -740,7 +740,7 @@ class ComponentA {
 
   Future test_inputs() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
@@ -825,7 +825,7 @@ class MyComponent {
 
   Future test_inputs_deprecatedProperties() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
@@ -865,7 +865,7 @@ class MyComponent {
 
   Future test_outputs() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
@@ -955,7 +955,7 @@ class MyComponent {
 
   Future test_outputs_streamIsOk() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'dart:async';
 
 @Component(
@@ -980,7 +980,7 @@ class MyComponent {
 
   Future test_outputs_extendStreamIsOk() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'dart:async';
 
 abstract class MyStream<T> implements Stream<T> { }
@@ -1007,7 +1007,7 @@ class MyComponent {
 
   Future test_outputs_extendStreamSpecializedIsOk() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'dart:async';
 
 class MyStream extends Stream<int> { }
@@ -1034,7 +1034,7 @@ class MyComponent {
 
   Future test_outputs_extendStreamUntypedIsOk() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'dart:async';
 
 class MyStream extends Stream { }
@@ -1061,7 +1061,7 @@ class MyComponent {
 
   Future test_outputs_notEventEmitterTypeError() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
@@ -1079,7 +1079,7 @@ class MyComponent {
 
   Future test_outputs_extendStreamNotStreamHasDynamicEventType() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
@@ -1104,7 +1104,7 @@ class MyComponent {
 
   Future test_parameterizedInputsOutputs() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'my-component',
@@ -1185,7 +1185,7 @@ class MyComponent<T, A extends String, B extends A> {
 
   Future test_parameterizedInheritedInputsOutputs() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 class Generic<T> {
   T input;
@@ -1224,7 +1224,7 @@ class MyComponent extends Generic {
 
   Future test_parameterizedInheritedInputsOutputsSpecified() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 class Generic<T> {
   T input;
@@ -1263,7 +1263,7 @@ class MyComponent extends Generic<String> {
 
   Future test_finalPropertyInputError() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '<p></p>')
 class MyComponent {
@@ -1281,7 +1281,7 @@ class MyComponent {
 
   Future test_finalPropertyInputStringError() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '<p></p>', inputs: const ['immutable'])
 class MyComponent {
@@ -1308,7 +1308,7 @@ class B {}
 
   Future test_inputOnGetterIsError() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '')
 class MyComponent {
@@ -1326,7 +1326,7 @@ class MyComponent {
 
   Future test_outputOnSetterIsError() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '')
 class MyComponent {
@@ -1340,6 +1340,138 @@ class MyComponent {
         AngularWarningCode.OUTPUT_ANNOTATION_PLACEMENT_INVALID,
         code,
         "@Output()");
+  }
+
+  Future test_hasContentChildDirective() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp)
+  ContentChildComp contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getDirectives(source);
+    Component component = directives.first;
+    final childFields = component.contentChildFields;
+    expect(childFields, hasLength(1));
+    final child = childFields.first;
+    expect(child.fieldName, equals("contentChild"));
+    expect(child.nameRange.offset, equals(code.indexOf("ContentChildComp)")));
+    expect(child.nameRange.length, equals("ContentChildComp".length));
+    expect(child.typeRange.offset, equals(code.indexOf("ContentChildComp ")));
+    expect(child.typeRange.length, equals("ContentChildComp".length));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenDirective() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  QueryList<ContentChildComp> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getDirectives(source);
+    Component component = directives.first;
+    final childrenFields = component.contentChildrenFields;
+    expect(childrenFields, hasLength(1));
+    final children = childrenFields.first;
+    expect(children.fieldName, equals("contentChildren"));
+    expect(
+        children.nameRange.offset, equals(code.indexOf("ContentChildComp)")));
+    expect(children.nameRange.length, equals("ContentChildComp".length));
+    expect(children.typeRange.offset,
+        equals(code.indexOf("QueryList<ContentChildComp>")));
+    expect(children.typeRange.length,
+        equals("QueryList<ContentChildComp>".length));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildChildrenNoRangeNotRecorded() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren()
+  QueryList<ContentChildComp> contentChildren;
+  @ContentChild()
+  ContentChildComp contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getDirectives(source);
+    Component component = directives.first;
+    final childrenFields = component.contentChildrenFields;
+    expect(childrenFields, hasLength(0));
+    final childFields = component.contentChildFields;
+    expect(childFields, hasLength(0));
+    // validate
+    errorListener.assertErrorsWithCodes([
+      CompileTimeErrorCode.NOT_ENOUGH_REQUIRED_ARGUMENTS,
+      CompileTimeErrorCode.NOT_ENOUGH_REQUIRED_ARGUMENTS
+    ]);
+  }
+
+  Future test_hasContentChildChildrenSetter() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp) // 1
+  void set contentChild(ContentChildComp contentChild) => null;
+  @ContentChildren(ContentChildComp) // 2
+  void set contentChildren(QueryList<ContentChildComp> contentChildren) => null;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getDirectives(source);
+    Component component = directives.first;
+
+    final childFields = component.contentChildFields;
+    expect(childFields, hasLength(1));
+    final child = childFields.first;
+    expect(child.fieldName, equals("contentChild"));
+    expect(
+        child.nameRange.offset, equals(code.indexOf("ContentChildComp) // 1")));
+    expect(child.nameRange.length, equals("ContentChildComp".length));
+    expect(child.typeRange.offset, equals(code.indexOf("ContentChildComp ")));
+    expect(child.typeRange.length, equals("ContentChildComp".length));
+
+    final childrenFields = component.contentChildrenFields;
+    expect(childrenFields, hasLength(1));
+    final children = childrenFields.first;
+    expect(children.fieldName, equals("contentChildren"));
+    expect(children.nameRange.offset,
+        equals(code.indexOf("ContentChildComp) // 2")));
+    expect(children.nameRange.length, equals("ContentChildComp".length));
+    expect(children.typeRange.offset,
+        equals(code.indexOf("QueryList<ContentChildComp>")));
+    expect(children.typeRange.length,
+        equals("QueryList<ContentChildComp>".length));
+
+    errorListener.assertNoErrors();
   }
 }
 
@@ -1356,7 +1488,9 @@ class BuildUnitViewsTest extends AbstractAngularTest {
     directives = result.directives;
 
     final linker = new ChildDirectiveLinker(
-        angularDriver, new ErrorReporter(errorListener, source));
+        angularDriver,
+        await angularDriver.getStandardAngular(),
+        new ErrorReporter(errorListener, source));
     await linker.linkDirectives(directives, dartResult.unit.element.library);
     views = directives
         .map((d) => d is Component ? d.view : null)
@@ -1368,7 +1502,7 @@ class BuildUnitViewsTest extends AbstractAngularTest {
 
   Future test_buildViewsDoesntGetDependentDirectives() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'other_file.dart';
 
 @Component(selector: 'my-component', template: 'My template',
@@ -1376,7 +1510,7 @@ import 'other_file.dart';
 class MyComponent {}
 ''';
     String otherCode = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(selector: 'other-component', template: 'My template',
     directives: const [NgFor])
 class OtherComponent {}
@@ -1403,7 +1537,7 @@ class OtherComponent {}
 
   Future test_directives() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: '[aaa]')
 class DirectiveA {}
@@ -1439,7 +1573,7 @@ class MyComponent {}
 
   Future test_prefixedDirectives() async {
     String otherCode = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: '[aaa]')
 class DirectiveA {}
@@ -1454,7 +1588,7 @@ const DIR_AB = const [DirectiveA, DirectiveB];
 ''';
 
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'other.dart' as other;
 
 @Component(selector: 'my-component', template: 'My template',
@@ -1481,7 +1615,7 @@ class MyComponent {}
 
   Future test_directives_hasError_notListVariable() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 const NOT_DIRECTIVE_LIST = 42;
 
@@ -1499,7 +1633,7 @@ class MyComponent {}
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @View(template: 'AAA')
 class ComponentA {
@@ -1514,7 +1648,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', template: 55)
 class ComponentA {
@@ -1531,7 +1665,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', template: 'abc' + 'bcd')
 class ComponentA {
@@ -1545,7 +1679,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 const String tooComplex = 'bcd';
 
@@ -1562,7 +1696,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', template: 'AAA', directives: const [42])
 class ComponentA {
@@ -1577,7 +1711,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', template: 'AAA', templateUrl: 'a.html')
 class ComponentA {
@@ -1593,7 +1727,7 @@ class ComponentA {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa')
 class ComponentA {
@@ -1606,7 +1740,7 @@ class ComponentA {
 
   Future test_hasError_missingHtmlFile() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', templateUrl: 'missing-template.html')
 class MyComponent {}
@@ -1621,7 +1755,7 @@ class MyComponent {}
 
   Future test_templateExternal() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', templateUrl: 'my-template.html')
 class MyComponent {}
@@ -1646,7 +1780,7 @@ class MyComponent {}
 
   Future test_templateExternalUsingViewAnnotation() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component')
 @View(templateUrl: 'my-template.html')
@@ -1672,7 +1806,7 @@ class MyComponent {}
 
   Future test_templateInline() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: 'my-directive')
 class MyDirective {}
@@ -1708,7 +1842,7 @@ class MyComponent {}
 
   Future test_templateInlineUsingViewAnnotation() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Directive(selector: 'my-directive')
 class MyDirective {}
@@ -1742,6 +1876,745 @@ class MyComponent {}
       }
     }
   }
+
+  Future test_hasContentChildComponent() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp)
+  ContentChildComp contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType child = childs.first.query;
+
+    expect(child.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenDirective() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  QueryList<ContentChildComp> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+
+    expect(children.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildChildrenSetter() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp) // 1
+  void set contentChild(ContentChildComp contentChild) => null;
+  @ContentChildren(ContentChildComp) // 2
+  void set contentChildren(QueryList<ContentChildComp> contentChildren) => null;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+
+    expect(children.directive, equals(directives[1]));
+
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType child = childs.first.query;
+
+    expect(child.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildLetBound() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild('foo')
+  ContentChildComp contentChildDirective;
+  @ContentChild('fooTpl')
+  TemplateRef contentChildTpl;
+  @ContentChild('fooElem')
+  ElementRef contentChildElem;
+  @ContentChild('fooDynamic')
+  dynamic contentChildDynamic;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(4));
+
+    final LetBoundQueriedChildType childDirective = childs
+        .singleWhere((c) => c.field.fieldName == "contentChildDirective")
+        .query;
+    expect(childDirective, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childDirective.letBoundName, equals("foo"));
+    expect(childDirective.containerType.toString(), equals("ContentChildComp"));
+
+    final LetBoundQueriedChildType childTemplate =
+        childs.singleWhere((c) => c.field.fieldName == "contentChildTpl").query;
+    expect(childTemplate, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childTemplate.letBoundName, equals("fooTpl"));
+    expect(childTemplate.containerType.toString(), equals("TemplateRef"));
+
+    final LetBoundQueriedChildType childElement = childs
+        .singleWhere((c) => c.field.fieldName == "contentChildElem")
+        .query;
+    expect(childElement, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childElement.letBoundName, equals("fooElem"));
+    expect(childElement.containerType.toString(), equals("ElementRef"));
+
+    final LetBoundQueriedChildType childDynamic = childs
+        .singleWhere((c) => c.field.fieldName == "contentChildDynamic")
+        .query;
+    expect(childDynamic, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childDynamic.letBoundName, equals("fooDynamic"));
+    expect(childDynamic.containerType.toString(), equals("dynamic"));
+
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenLetBound() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren('foo')
+  QueryList<ContentChildComp> contentChildDirective;
+  @ContentChildren('fooTpl')
+  QueryList<TemplateRef> contentChildTpl;
+  @ContentChildren('fooElem')
+  QueryList<ElementRef> contentChildElem;
+  @ContentChildren('fooDynamic')
+  QueryList contentChildDynamic;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(4));
+
+    final LetBoundQueriedChildType childrenDirective = childrens
+        .singleWhere((c) => c.field.fieldName == "contentChildDirective")
+        .query;
+    expect(childrenDirective, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childrenDirective.letBoundName, equals("foo"));
+    expect(
+        childrenDirective.containerType.toString(), equals("ContentChildComp"));
+
+    final LetBoundQueriedChildType childrenTemplate = childrens
+        .singleWhere((c) => c.field.fieldName == "contentChildTpl")
+        .query;
+    expect(childrenTemplate, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childrenTemplate.letBoundName, equals("fooTpl"));
+    expect(childrenTemplate.containerType.toString(), equals("TemplateRef"));
+
+    final LetBoundQueriedChildType childrenElement = childrens
+        .singleWhere((c) => c.field.fieldName == "contentChildElem")
+        .query;
+    expect(childrenElement, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childrenElement.letBoundName, equals("fooElem"));
+    expect(childrenElement.containerType.toString(), equals("ElementRef"));
+
+    final LetBoundQueriedChildType childrenDynamic = childrens
+        .singleWhere((c) => c.field.fieldName == "contentChildDynamic")
+        .query;
+    expect(childrenDynamic, new isInstanceOf<LetBoundQueriedChildType>());
+    expect(childrenDynamic.letBoundName, equals("fooDynamic"));
+    expect(childrenDynamic.containerType.toString(), equals("dynamic"));
+
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildElementRef() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ElementRef)
+  ElementRef contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<ElementRefQueriedChildType>());
+
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenElementRef() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ElementRef)
+  QueryList<ElementRef> contentChildren;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<ElementRefQueriedChildType>());
+
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenTemplateRef() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(TemplateRef)
+  QueryList<TemplateRef> contentChildren;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<TemplateRefQueriedChildType>());
+
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildTemplateRef() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(TemplateRef)
+  TemplateRef contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<TemplateRefQueriedChildType>());
+
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildDirective_notRecognizedType() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(String)
+  ElementRef contentChild;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(0));
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE, code, 'String');
+  }
+
+  Future test_hasContentChildDirective_htmlNotAllowed() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+import 'dart:html';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(AnchorElement)
+  AnchorElement contentChild;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(0));
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE, code, 'AnchorElement');
+  }
+
+  Future test_hasContentChildDirective_notTypeOrString() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(const [])
+  ElementRef contentChild;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(0));
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE, code, 'const []');
+  }
+
+  Future test_hasContentChildDirective_notAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp)
+  String contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType child = childs.first.query;
+    expect(child.directive, equals(directives[1]));
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY, code, 'String');
+  }
+
+  Future test_hasContentChildDirective_dynamicOk() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp)
+  dynamic contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType child = childs.first.query;
+
+    expect(child.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildDirective_subTypeNotAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ContentChildComp)
+  ContentChildCompSub contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+
+class ContentChildCompSub extends ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childs = component.contentChilds;
+    expect(childs, hasLength(1));
+    expect(childs.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType child = childs.first.query;
+    expect(child.directive, equals(directives[1]));
+
+    // validate
+    assertErrorInCodeAtPosition(AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+        code, 'ContentChildCompSub');
+  }
+
+  Future test_hasContentChildrenDirective_notQueryList() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  String contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+    expect(children.directive, equals(directives[1]));
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
+        code,
+        'String');
+  }
+
+  Future test_hasContentChildrenDirective_dynamicOk() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  dynamic contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+
+    expect(children.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenDirective_notAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  QueryList<String> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+
+    // validate
+    assertErrorInCodeAtPosition(AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+        code, 'QueryList<String>');
+  }
+
+  Future test_hasContentChildrenDirective_dynamicListOk() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  QueryList contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+
+    expect(children.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenDirective_iterableOk() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  Iterable<ContentChildComp> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+
+    expect(children.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenDirective_iterableNotAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  Iterable<String> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+
+    // validate
+    assertErrorInCodeAtPosition(AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+        code, 'Iterable<String>');
+  }
+
+  Future test_hasContentChildrenDirective_dynamicIterableOk() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  Iterable contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+
+    expect(children.directive, equals(directives[1]));
+    // validate
+    errorListener.assertNoErrors();
+  }
+
+  Future test_hasContentChildrenDirective_subtypingQueryListNotOk() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ContentChildComp)
+  // this is not allowed. Angular makes a QueryList, regardless of your subtype
+  CannotSubtypeQueryList contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+
+abstract class CannotSubtypeQueryList extends QueryList {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+    Component component = directives.first;
+    final childrens = component.contentChildren;
+    expect(childrens, hasLength(1));
+    expect(
+        childrens.first.query, new isInstanceOf<DirectiveQueriedChildType>());
+    final DirectiveQueriedChildType children = childrens.first.query;
+    expect(children.directive, equals(directives[1]));
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
+        code,
+        'CannotSubtypeQueryList');
+  }
+
+  Future test_hasContentChildTemplateRef_notAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(TemplateRef)
+  String contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY, code, 'String');
+  }
+
+  Future test_hasContentChildrenTemplateRef_notAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(TemplateRef)
+  QueryList<String> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+
+    // validate
+    assertErrorInCodeAtPosition(AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+        code, 'QueryList<String>');
+  }
+
+  Future test_hasContentChildElementRef_notAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChild(ElementRef)
+  String contentChild;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+
+    // validate
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY, code, 'String');
+  }
+
+  Future test_hasContentChildrenElementRef_notAssignable() async {
+    final code = r'''
+import 'package:angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '')
+class ComponentA {
+  @ContentChildren(ElementRef)
+  QueryList<String> contentChildren;
+}
+
+@Component(selector: 'foo', template: '')
+class ContentChildComp {}
+''';
+    Source source = newSource('/test.dart', code);
+    await getViews(source);
+
+    // validate
+    assertErrorInCodeAtPosition(AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
+        code, 'QueryList<String>');
+  }
 }
 
 @reflectiveTest
@@ -1767,7 +2640,7 @@ class ResolveDartTemplatesTest extends AbstractAngularTest {
     var source = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'aaa', template: 'AAA', directives: const [int])
 class ComponentA {
@@ -1780,7 +2653,7 @@ class ComponentA {
 
   Future test_componentReference() async {
     var code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa', template: '<div>AAA</div>')
 class ComponentA {
@@ -1844,7 +2717,7 @@ class ComponentC {
 
   Future test_hasError_expression_ArgumentTypeNotAssignable() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel',
     template: r"<div> {{text.length + text}} </div>")
@@ -1860,7 +2733,7 @@ class TextPanel {
 
   Future test_hasError_expression_UndefinedIdentifier() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', inputs: const ['text'],
     template: r"<div>some text</div>")
@@ -1885,7 +2758,7 @@ class UserPanel {
   Future
       test_hasError_expression_UndefinedIdentifier_OutsideFirstHtmlTag() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '<h1></h1>{{noSuchName}}')
 class MyComponent {
@@ -1900,7 +2773,7 @@ class MyComponent {
 
   Future test_hasError_UnresolvedTag() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa',
     template: "<unresolved-tag attr='value'></unresolved-tag>")
@@ -1915,7 +2788,7 @@ class ComponentA {
 
   Future test_suppressError_UnresolvedTag() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa',
     template: """
@@ -1931,7 +2804,7 @@ class ComponentA {
 
   Future test_suppressError_NotCaseSensitive() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa',
     template: """
@@ -1947,7 +2820,7 @@ class ComponentA {
 
   Future test_suppressError_UnresolvedTagAndInput() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa',
     template: """
@@ -1964,7 +2837,7 @@ class ComponentA {
 
   Future test_htmlParsing_hasError() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel',
     template: r"<div> <h2> Expected closing H2 </h3> </div>")
@@ -1980,7 +2853,7 @@ class TextPanel {
   Future test_input_OK_event() async {
     String code = r'''
 import 'dart:html';
-import '/angular2/angular2.dart';
+    import 'package:angular2/angular2.dart';
 
 @Component(selector: 'UserPanel', template: r"""
 <div>
@@ -2029,7 +2902,7 @@ class TodoList {
 
   Future test_input_OK_reference_expression() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', inputs: const ['text'],
     template: r"<div>some text</div>")
@@ -2090,7 +2963,7 @@ class User {
 
   Future test_input_OK_reference_text() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
     selector: 'comp-a',
@@ -2137,7 +3010,7 @@ class ComponentB {
 
   Future test_noRootElement() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel',
     template: r'Often used without an element in tests.')
@@ -2153,7 +3026,7 @@ class TextPanel {
 
   Future test_noTemplateContents() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel',
     template: '')
@@ -2169,7 +3042,7 @@ class TextPanel {
 
   Future test_textExpression_hasError_UnterminatedMustache() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', template: r"<div> {{text </div>")
 class TextPanel {
@@ -2185,7 +3058,7 @@ class TextPanel {
 
   Future test_textExpression_hasError_UnopenedMustache() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', template: r"<div> text}} </div>")
 class TextPanel {
@@ -2199,7 +3072,7 @@ class TextPanel {
 
   Future test_textExpression_hasError_DoubleOpenedMustache() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', template: r"<div> {{text {{ error}} </div>")
 class TextPanel {
@@ -2216,7 +3089,7 @@ class TextPanel {
 
   Future test_textExpression_hasError_MultipleUnclosedMustaches() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', template: r"<div> {{open {{error {{text}} close}} close}} </div>")
 class TextPanel {
@@ -2236,7 +3109,7 @@ class TextPanel {
 
   Future test_textExpression_OK() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', inputs: const ['text'],
     template: r"<div> <h2> {{text}}  </h2> and {{text.length}} </div>")
@@ -2282,7 +3155,7 @@ class TextPanel {
 
   Future test_resolveGetChildDirectivesNgContentSelectors() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'child_file.dart';
 
 @Component(selector: 'my-component', template: 'My template',
@@ -2290,7 +3163,7 @@ import 'child_file.dart';
 class MyComponent {}
 ''';
     String childCode = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(selector: 'child-component',
     template: 'My template <ng-content></ng-content>',
     directives: const [])
@@ -2318,7 +3191,7 @@ class ChildComponent {}
 
   Future test_attributes() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '')
 class MyComponent {
@@ -2342,7 +3215,7 @@ class MyComponent {
 
   Future test_attributeNotString() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-component', template: '')
 class MyComponent {
@@ -2363,6 +3236,24 @@ class MyComponent {
     }
     assertErrorInCodeAtPosition(
         AngularWarningCode.ATTRIBUTE_PARAMETER_MUST_BE_STRING, code, 'foo');
+  }
+
+  Future test_constantExpressionTemplateVarDoesntCrash() async {
+    Source source = newSource(
+        '/test.dart',
+        r'''
+import 'package:angular2/angular2.dart';
+
+const String tplText = "we don't analyze this";
+
+@Component(selector: 'aaa', template: tplText)
+class ComponentA {
+}
+''');
+    await getDirectives(source);
+    expect(templates, hasLength(0));
+    errorListener.assertErrorsWithCodes(
+        <ErrorCode>[AngularWarningCode.STRING_VALUE_EXPECTED]);
   }
 
   static Template _getDartTemplateByClassName(
@@ -2392,7 +3283,7 @@ class ResolveHtmlTemplatesTest extends AbstractAngularTest {
 
   Future test_multipleViewsWithTemplate() async {
     String dartCodeOne = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panelA', templateUrl: 'text_panel.html')
 class TextPanelA {
@@ -2463,7 +3354,7 @@ class ResolveHtmlTemplateTest extends AbstractAngularTest {
     var dartSource = newSource(
         '/test.dart',
         r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa', templateUrl: 'test.html')
 class ComponentA {
@@ -2481,7 +3372,7 @@ class ComponentA {
 
   Future test_errorFromWeirdInclude_includesFromPath() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'my-aaa', templateUrl: "test.html")
 class ComponentA {
@@ -2500,7 +3391,7 @@ class ComponentA {
 
   Future test_hasViewWithTemplate() async {
     String dartCode = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(selector: 'text-panel', templateUrl: 'text_panel.html')
 class TextPanel {
@@ -2537,16 +3428,16 @@ class TextPanel {
 
   Future test_resolveGetChildDirectivesNgContentSelectors() async {
     String code = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 import 'child_file.dart';
 
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(selector: 'my-component', templateUrl: 'test.html',
     directives: const [ChildComponent])
 class MyComponent {}
 ''';
     String childCode = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(selector: 'child-component',
     template: 'My template <ng-content></ng-content>',
     directives: const [])

--- a/analyzer_plugin/test/fuzz_test.dart
+++ b/analyzer_plugin/test/fuzz_test.dart
@@ -3,18 +3,23 @@ import 'dart:async';
 
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:front_end/src/scanner/token.dart';
-import 'package:unittest/unittest.dart';
-import 'package:test_reflective_loader/test_reflective_loader.dart';
+//import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
+//import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import 'abstract_angular.dart';
 
+//main() {
+//  defineReflectiveSuite(() {
+//    defineReflectiveTests(FuzzTest);
+//  });
+//}
+
 main() {
-  defineReflectiveSuite(() {
-    defineReflectiveTests(FuzzTest);
-  });
+  new FuzzTest().test_fuzz_continually();
 }
 
-@reflectiveTest
+//@reflectiveTest
 class FuzzTest extends AbstractAngularTest {
   // collected with
   // `find ../deps -name '*.dart' -exec cat {} \; | shuf -n 500 | sort`
@@ -355,7 +360,7 @@ typedef A();
 ''';
 
   static const String baseDart = r'''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 
 @Component(
   selector: 'my-aaa',
@@ -376,6 +381,9 @@ class CounterComponent {
   @Input() int maxCount;
   EventEmitter<String> resetEvent;
   @Output() EventEmitter<int> incremented;
+
+  @ContentChild(CounterComponent)
+  CounterComponent recursedComponent;
 
   void reset() {}
   void increment() {}
@@ -401,7 +409,9 @@ class CounterComponent {
     [maxCount]='4'
     (reset)=''
     (click)='h1.hidden = !h1.hidden; counter.reset()'
-    (incremented)='items.add($event.toString())'></my-counter>
+    (incremented)='items.add($event.toString())'>
+    <my-counter></my-counter>
+  </my-counter>
 </div>
 ''';
 

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -3102,9 +3102,879 @@ class MyTag {
     errorListener.assertNoErrors();
   }
 
+  Future
+      test_resolveTemplate_provideContentNotMatchingSelectorsButMatchesContentChildElementRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeSome {
+  @ContentChild(ElementRef)
+  ElementRef foo;
+}
+''');
+    String code = r"""
+<transclude-some><div></div></transclude-some>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNotMatchingSelectorsButMatchesContentChildTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeNone {
+  @ContentChild(TemplateRef)
+  TemplateRef foo;
+}
+''');
+    String code = r"""
+<transclude-none><template></template></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsButMatchesContentChildTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild(TemplateRef)
+  TemplateRef foo;
+}
+''');
+    String code = r"""
+<transclude-none><template></template></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsButMatchesContentChildDirective() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [TranscludeNone, ContentChildComponent])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild(ContentChildComponent)
+  ContentChildComponent foo;
+}
+@Component(selector: 'content-child-comp', template: '')
+class ContentChildComponent {
+}
+''');
+    String code = r"""
+<transclude-none><content-child-comp></content-child-comp></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsButMatchesContentChildLetBoundElementRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild('contentChild')
+  ElementRef foo;
+  @ContentChild('contentChild')
+  dynamic fooDynamicShouldBeOk;
+  @ContentChild('contentChild')
+  Object fooObjectShouldBeOk;
+}
+''');
+    String code = r"""
+<transclude-none><div #contentChild></div></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsButMatchesContentChildLetBoundTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild('contentChild')
+  TemplateRef foo;
+  @ContentChild('contentChild')
+  dynamic fooDynamicShouldBeOk;
+  @ContentChild('contentChild')
+  Object fooObjectShouldBeOk;
+}
+''');
+    String code = r"""
+<transclude-none><template #contentChild></template></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsButMatchesContentChildLetBoundDirective() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [TranscludeNone, ContentChildDirective])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild('contentChild')
+  ContentChildDirective foo;
+  @ContentChild('contentChild')
+  dynamic fooDynamicShouldBeOk;
+  @ContentChild('contentChild')
+  Object fooObjectShouldBeOk;
+  @ContentChild('contentChild')
+  Superclass fooSuperclassShouldBeOk;
+}
+@Directive(selector: '[content-child]', exportAs: 'contentChild')
+class ContentChildDirective extends Superclass {
+}
+
+class Superclass {}
+''');
+    String code = r"""
+<transclude-none><div content-child #contentChild="contentChild"></div></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsButMatchesContentChildLetBoundComponent() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [TranscludeNone, ContentChildComponent])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild('contentChild')
+  ContentChildComponent foo;
+  @ContentChild('contentChild')
+  dynamic fooDynamicShouldBeOk;
+  @ContentChild('contentChild')
+  Object fooObjectShouldBeOk;
+  @ContentChild('contentChild')
+  Superclass fooSuperclassShouldBeOk;
+}
+@Component(selector: 'content-child-comp', template: '')
+class ContentChildComponent extends Superclass {
+}
+
+class Superclass {}
+''');
+    String code = r"""
+<transclude-none><content-child-comp #contentChild></content-child-comp></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideContentNotMatchingSelectorsOrContentChildElementRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeSome {
+  @ContentChild(ElementRef)
+  ElementRef foo;
+}
+''');
+    String code = r"""
+<transclude-some><template></template></transclude-some>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(AngularWarningCode.CONTENT_NOT_TRANSCLUDED,
+        code, "<template></template>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentNotMatchingSelectorsOrContentChildTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-some')
+@View(template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeNone {
+  @ContentChild(TemplateRef)
+  TemplateRef foo;
+}
+''');
+    String code = r"""
+<transclude-some><div></div></transclude-some>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_NOT_TRANSCLUDED, code, "<div></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsNoChildElementRefMatch() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild(ElementRef)
+  ElementRef foo;
+}
+''');
+    String code = r"""
+<transclude-none><template></template></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(AngularWarningCode.CONTENT_NOT_TRANSCLUDED,
+        code, "<template></template>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsNoContentChildTemplateRefMatch() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild(TemplateRef)
+  TemplateRef foo;
+}
+''');
+    String code = r"""
+<transclude-none><div></div></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_NOT_TRANSCLUDED, code, "<div></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentNoTransclusionsNoContentChildDirectiveMatch() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [TranscludeNone, ContentChildComponent])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+  @ContentChild(ContentChildComponent)
+  ContentChildComponent foo;
+}
+@Component(selector: 'content-child-comp', template: '')
+class ContentChildComponent {
+}
+''');
+    String code = r"""
+<transclude-none><div></div></transclude-none>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CONTENT_NOT_TRANSCLUDED, code, "<div></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentMatchingHigherComponentsIsStillNotTranscludedError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [TranscludeNone, TranscludeAllWithContentChild])
+class TestPanel {
+}
+@Component(selector: 'transclude-none')
+@View(template: '')
+class TranscludeNone {
+}
+@Component(selector: 'transclude-all-with-content-child')
+@View(template: '<ng-content></ng-content>')
+class TranscludeAllWithContentChild {
+  @ContentChild("contentChildOfHigherComponent")
+  ElementRef foo;
+}
+''');
+    String code = r"""
+<transclude-all-with-content-child>
+  <transclude-none>
+    <div #contentChildOfHigherComponent></div>
+  </transclude-none>
+</transclude-all-with-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(AngularWarningCode.CONTENT_NOT_TRANSCLUDED,
+        code, "<div #contentChildOfHigherComponent></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_templateNotElementRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  ElementRef foo;
+}
+''');
+    String code = r"""
+<has-content-child><template #contentChild></template></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<template #contentChild></template>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_componentNotElementRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeComponent])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  ElementRef foo;
+}
+@Component(selector: 'some-component', template: '')
+class SomeComponent {
+}
+''');
+    String code = r"""
+<has-content-child><some-component #contentChild></some-component></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<some-component #contentChild></some-component>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_directiveNotElementRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeDirective])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  ElementRef foo;
+}
+@Directive(selector: '[some-directive]', template: '', exportAs: "theDirective")
+class SomeDirective {
+}
+''');
+    String code = r"""
+<has-content-child><div some-directive #contentChild="theDirective"></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div some-directive #contentChild=\"theDirective\"></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_elementNotTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  TemplateRef foo;
+}
+''');
+    String code = r"""
+<has-content-child><div #contentChild></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div #contentChild></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_componentNotTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeComponent])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  TemplateRef foo;
+}
+@Component(selector: 'some-component', template: '')
+class SomeComponent {
+}
+''');
+    String code = r"""
+<has-content-child><some-component #contentChild></some-component></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<some-component #contentChild></some-component>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_directiveNotTemplateRef() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeDirective])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  TemplateRef foo;
+}
+@Directive(selector: '[some-directive]', template: '', exportAs: "theDirective")
+class SomeDirective {
+}
+''');
+    String code = r"""
+<has-content-child><div some-directive #contentChild></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div some-directive #contentChild></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_elementNotComponent() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeComponent foo;
+}
+@Component(selector: 'some-component', template: '')
+class SomeComponent {
+}
+''');
+    String code = r"""
+<has-content-child><div #contentChild></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div #contentChild></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_templateNotComponent() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeComponent foo;
+}
+@Component(selector: 'some-component', template: '')
+class SomeComponent {
+}
+''');
+    String code = r"""
+<has-content-child><template #contentChild></template></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<template #contentChild></template>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_wrongComponent() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeOtherComponent])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeComponent foo;
+}
+@Component(selector: 'some-component', template: '')
+class SomeComponent {
+}
+@Component(selector: 'some-other-component', template: '')
+class SomeOtherComponent {
+}
+''');
+    String code = r"""
+<has-content-child><some-other-component #contentChild></some-other-component></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<some-other-component #contentChild></some-other-component>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_elementNotDirective() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeDirective foo;
+}
+@Directive(selector: '[some-directive]')
+class SomeDirective {
+}
+''');
+    String code = r"""
+<has-content-child><div #contentChild></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div #contentChild></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_element_directiveNotExported() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeDirective])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeDirective foo;
+}
+@Directive(selector: '[some-directive]')
+class SomeDirective {
+}
+''');
+    String code = r"""
+<has-content-child><div some-directive #contentChild></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div some-directive #contentChild></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_templateNotDirective() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeDirective foo;
+}
+@Directive(selector: '[some-directive]')
+class SomeDirective {
+}
+''');
+    String code = r"""
+<has-content-child><template #contentChild></template></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<template #contentChild></template>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_wrongDirective() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeOtherDirective])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  SomeDirective foo;
+}
+@Directive(selector: '[some-directive]', exportAs: 'right')
+class SomeDirective {
+}
+@Directive(selector: '[some-other-directive]', exportAs: 'wrong')
+class SomeOtherDirective {
+}
+''');
+    String code = r"""
+<has-content-child><div some-other-directive #contentChild="wrong"></div></has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div some-other-directive #contentChild=\"wrong\"></div>");
+  }
+
+  Future
+      test_resolveTemplate_provideContentChildLetBound_directiveNotElementRef_deeplyNested() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChild, SomeDirective])
+class TestPanel {
+}
+@Component(selector: 'has-content-child')
+@View(template: '<ng-content></ng-content>')
+class HasContentChild {
+  @ContentChild('contentChild')
+  ElementRef foo;
+}
+@Directive(selector: '[some-directive]', template: '', exportAs: "theDirective")
+class SomeDirective {
+}
+''');
+    String code = r"""
+<has-content-child>
+  <div>
+    <span>
+      <div>
+        <div some-directive #contentChild="theDirective"></div>
+      </div>
+    </span>
+  </div>
+</has-content-child>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
+        code,
+        "<div some-directive #contentChild=\"theDirective\"></div>");
+  }
+
+  Future test_resolveTemplate_provideDuplicateContentChildError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChildElementRef])
+class TestPanel {
+}
+@Component(selector: 'has-content-child-element-ref')
+@View(template: '')
+class HasContentChildElementRef {
+  @ContentChild(ElementRef)
+  ElementRef theElement;
+}
+''');
+    String code = r"""
+<has-content-child-element-ref>
+  <div first></div>
+  <div second></div>
+</has-content-child-element-ref>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.SINGULAR_CHILD_QUERY_MATCHED_MULTIPLE_TIMES,
+        code,
+        "<div second></div>");
+  }
+
+  Future test_resolveTemplate_provideDuplicateContentChildrenOk() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChildrenElementRef])
+class TestPanel {
+}
+@Component(selector: 'has-content-children-element-ref')
+@View(template: '')
+class HasContentChildrenElementRef {
+  @ContentChildren(ElementRef)
+  QueryList<ElementRef> theElement;
+}
+''');
+    String code = r"""
+<has-content-children-element-ref>
+  <div first></div>
+  <div second></div>
+</has-content-children-element-ref>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future test_resolveTemplate_provideDuplicateContentChildNestedOk() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChildElementRef])
+class TestPanel {
+}
+@Component(selector: 'has-content-child-element-ref')
+@View(template: '')
+class HasContentChildElementRef {
+  @ContentChild(ElementRef)
+  ElementRef theElement;
+}
+''');
+    String code = r"""
+<has-content-child-element-ref>
+  <div first>
+    <div second></div>
+  </div>
+</has-content-child-element-ref>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      test_resolveTemplate_provideDuplicateContentChildSiblingsError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [HasContentChildTemplateRef])
+class TestPanel {
+}
+@Component(selector: 'has-content-child-template-ref')
+@View(template: '<ng-content></ng-content>')
+class HasContentChildTemplateRef {
+  @ContentChild(TemplateRef)
+  TemplateRef theTemplate;
+}
+''');
+    String code = r"""
+<has-content-child-template-ref>
+  <div>
+    <template first></template>
+  </div>
+  <div>
+    <template second></template>
+  </div>
+</has-content-child-template-ref>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.SINGULAR_CHILD_QUERY_MATCHED_MULTIPLE_TIMES,
+        code,
+        "<template second></template>");
+  }
+
   void _addDartSource(String code) {
     dartCode = '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 $code
 ''';
     dartSource = newSource('/test_panel.dart', dartCode);


### PR DESCRIPTION
Validates:
- ElementRef
- TemplateRef
- Components
- Directives
- String-based let bindings (and checks property match)
- all others as errors
- property has QueryList assignability for ContentChildren
- ContentChild is only matched once

Changes:
- elements matching ContentChild of parent are counted as transcluded,
error wise
- DirectiveResolver is split into two phases, so that transclusions can
be checked _after_ inner content is directive resolved (for the sake of
ContentChild)
- added "StandardAngular" where we get certain special ClassElements
before running any other analysis, so that we can check if some random
type x is a supertype of angular's ElementRef.
- added ContentChildBindings so we can track the results of this
process to affect autocompletion suggestions, navigation, refactoring

Important edge cases:
- proper generic type checking for Iterable<T> as QueryList<T>
- using isSupertypeOf instead of isAssignableTo, because downcasting is
_known_ to be wrong (otherwise in dart downcasting is assumed
deliberate)
- don't supress transclusion errors for element A within B just because
some parent of B understands A as a contentChild -- has nothing to do
with A not belonging to B.
- don't report duplicate ContentChild errors when the duplicate is
inside a prior match (in fact, don't even report assignability errors!)
- directive matches require using exportAs with the #x="y" syntax.
- getting the "constant value" fields with inheritance requires using
`.getField("(super)")` the correct amount of times. This looks VERY
fragile to me.
- Native elements get Components, but they become ElementRefs not
TableElements. Ensure people don't use @ContentChild(TableElement).

Tests:
- changed to use 'package:angular2' instead of '/angular2/' because
that is required to build StandardAngular. However, not all tests are
changed, because its still ok to use '/angular2' too.
- added ElementRef and TemplateRef and QueryList classes.

Todos:
- ViewChild/ViewChildren
- track matched #attrs instead of just Elements
- revisit the highlighted ranges, can we make them more specific?
- instantiate classes to bounds