### PR TITLE
Autocompletion fix

### DIFF
--- a/analyzer_plugin/lib/src/angular_driver.dart
+++ b/analyzer_plugin/lib/src/angular_driver.dart
@@ -328,10 +328,11 @@ class AngularDriver
     return result;
   }
 
-  Future<Template> getTemplateForFile(String filePath) async {
+  Future<List<Template>> getTemplateForFile(String filePath) async {
+    var templates = <Template>[];
     var isDartFile = filePath.endsWith('.dart');
     if (!isDartFile && !filePath.endsWith('.html')) {
-      return null;
+      return templates;
     }
     var directiveResults = isDartFile
         ? await resolveDart(
@@ -351,11 +352,11 @@ class AngularDriver
             ? view.source.toString() == filePath
             : view.templateUriSource?.fullName == filePath;
         if (match) {
-          return view.template;
+          templates.add(view.template);
         }
       }
     }
-    return null;
+    return templates;
   }
 
   Future<DirectivesResult> resolveHtmlFrom(

--- a/analyzer_plugin/lib/src/angular_driver.dart
+++ b/analyzer_plugin/lib/src/angular_driver.dart
@@ -310,14 +310,16 @@ class AngularDriver
     }
 
     final summary = new LinkedHtmlSummaryBuilder()
-      ..errors = summarizeErrors(
-          result.errors.where((error) => error is! FromFilePrefixedError))
+      ..errors = summarizeErrors(result.errors
+          .where((error) => error is! FromFilePrefixedError)
+          .toList())
       ..errorsFromPath = result.errors
           .where((error) => error is FromFilePrefixedError)
           .map((error) => new SummarizedAnalysisErrorFromPathBuilder()
             ..path = (error as FromFilePrefixedError).fromSourcePath
             ..originalError =
-                summarizeError((error as FromFilePrefixedError).originalError));
+                summarizeError((error as FromFilePrefixedError).originalError))
+          .toList();
     final List<int> newBytes = summary.toBuffer();
     byteStore.put(key, newBytes);
 
@@ -399,7 +401,7 @@ class AngularDriver
           setIgnoredErrors(template, document);
           final resolver = new TemplateResolver(
               context.typeProvider,
-              standardHtml.components.values,
+              standardHtml.components.values.toList(),
               standardHtml.events,
               standardHtml.attributes,
               tplErrorListener);

--- a/analyzer_plugin/lib/src/angular_driver.dart
+++ b/analyzer_plugin/lib/src/angular_driver.dart
@@ -328,7 +328,7 @@ class AngularDriver
     return result;
   }
 
-  Future<List<Template>> getTemplateForFile(String filePath) async {
+  Future<List<Template>> getTemplatesForFile(String filePath) async {
     var templates = <Template>[];
     var isDartFile = filePath.endsWith('.dart');
     if (!isDartFile && !filePath.endsWith('.html')) {
@@ -343,7 +343,7 @@ class AngularDriver
         : await resolveHtml(filePath, ignoreCache: true);
     var directives = directiveResults.directives;
     if (directives == null) {
-      return null;
+      return templates;
     }
     for (var directive in directives) {
       if (directive is Component) {

--- a/analyzer_plugin/lib/src/model.dart
+++ b/analyzer_plugin/lib/src/model.dart
@@ -356,15 +356,32 @@ class View implements AnalysisTarget {
   final Component component;
   final List<AbstractDirective> directives;
   final List<DirectiveReference> directiveReferences;
-  final Map<String, List<AbstractDirective>> elementTagsInfo =
-      <String, List<AbstractDirective>>{};
   final String templateText;
   final int templateOffset;
   final Source templateUriSource;
   final SourceRange templateUrlRange;
   final dart.Annotation annotation;
 
+  Map<String, List<AbstractDirective>> _elementTagsInfo = null;
+
   int get end => templateOffset + templateText.length;
+
+  Map<String, List<AbstractDirective>> get elementTagsInfo {
+    if (_elementTagsInfo == null) {
+      _elementTagsInfo = new Map<String, List<AbstractDirective>>();
+      for (var directive in directives) {
+        if (directive.elementTags != null && directive.elementTags.isNotEmpty) {
+          for (var elementTag in directive.elementTags) {
+            String tagName = elementTag.toString();
+            _elementTagsInfo.putIfAbsent(
+                tagName, () => new List<AbstractDirective>());
+            _elementTagsInfo[tagName].add(directive);
+          }
+        }
+      }
+    }
+    return _elementTagsInfo;
+  }
 
   /**
    * The [Template] of this view, `null` until built.

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -119,6 +119,18 @@ class TemplateResolver {
     var allDirectives = <AbstractDirective>[]
       ..addAll(standardHtmlComponents)
       ..addAll(view.directives);
+
+    for (var directive in view.directives) {
+      if (directive.elementTags != null && directive.elementTags.isNotEmpty) {
+        for (var elementTag in directive.elementTags) {
+          String tagName = elementTag.toString();
+          view.elementTagsInfo
+              .putIfAbsent(tagName, () => new List<AbstractDirective>());
+          view.elementTagsInfo[tagName].add(directive);
+        }
+      }
+    }
+
     DirectiveResolver directiveResolver = new DirectiveResolver(
         allDirectives, templateSource, template, errorListener);
     root.accept(directiveResolver);

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -120,17 +120,6 @@ class TemplateResolver {
       ..addAll(standardHtmlComponents)
       ..addAll(view.directives);
 
-    for (var directive in view.directives) {
-      if (directive.elementTags != null && directive.elementTags.isNotEmpty) {
-        for (var elementTag in directive.elementTags) {
-          String tagName = elementTag.toString();
-          view.elementTagsInfo
-              .putIfAbsent(tagName, () => new List<AbstractDirective>());
-          view.elementTagsInfo[tagName].add(directive);
-        }
-      }
-    }
-
     DirectiveResolver directiveResolver = new DirectiveResolver(
         allDirectives, templateSource, template, errorListener);
     root.accept(directiveResolver);

--- a/analyzer_plugin/lib/src/view_extraction.dart
+++ b/analyzer_plugin/lib/src/view_extraction.dart
@@ -173,14 +173,6 @@ class ViewExtractor extends AnnotationProcessorMixin {
                   element.variable.constantValue != null) {
             directiveReferences.add(new DirectiveReference(
                 name, prefix, new SourceRange(item.offset, item.length)));
-            //DartObject value = element.variable.constantValue;
-            //bool success = _addDirectivesAndElementTagsForDartObject(
-            //    directiveReferences, value);
-            //if (!success) {
-            //  errorReporter.reportErrorForNode(
-            //      AngularWarningCode.TYPE_LITERAL_EXPECTED, item);
-            //  return null;
-            //}
             continue;
           }
         }

--- a/analyzer_plugin/lib/starter.dart
+++ b/analyzer_plugin/lib/starter.dart
@@ -26,7 +26,7 @@ class Starter {
     server.onResultErrorSupplementor = sumErrors;
     server.onNoAnalysisResult = sendHtmlResult;
     server.onNoAnalysisCompletion = sendAngularCompletions;
-    server.onExtraCompletionContributor = sendAngularContributor;
+    //server.onExtraCompletionContributor = sendAngularContributor;
   }
 
   void onCreateAnalysisDriver(

--- a/analyzer_plugin/lib/starter.dart
+++ b/analyzer_plugin/lib/starter.dart
@@ -26,7 +26,6 @@ class Starter {
     server.onResultErrorSupplementor = sumErrors;
     server.onNoAnalysisResult = sendHtmlResult;
     server.onNoAnalysisCompletion = sendAngularCompletions;
-    //server.onExtraCompletionContributor = sendAngularContributor;
   }
 
   void onCreateAnalysisDriver(
@@ -82,26 +81,6 @@ class Starter {
     sendFn(null, null, null);
   }
 
-  // Handles .dart completion. Returns a CompletionContributor to the
-  // domain completion.
-  Future<AngularCompletionContributor> sendAngularContributor(
-      CompletionRequestImpl request) async {
-    var filePath = request.result.path;
-    if (server.contextManager.isInAnalysisRoot(filePath)) {
-      for (final driverPath in angularDrivers.keys) {
-        if (server.contextManager.getContextFolderFor(filePath).path ==
-            driverPath) {
-          final driver = angularDrivers[driverPath];
-          var template = await driver.getTemplateForFile(filePath);
-          if (template != null) {
-            return new AngularCompletionContributor(driver);
-          }
-        }
-      }
-    }
-    return null;
-  }
-
   // Handles .html completion. Directly sends the suggestions to the
   // [completionHandler].
   Future sendAngularCompletions(
@@ -123,8 +102,8 @@ class Starter {
 
           var completionContributor = new AngularCompletionContributor(driver);
           CompletionRequestImpl completionRequest = new CompletionRequestImpl(
-              null,
-              null,
+              null, // AnalysisResult - unneeded for AngularCompletion
+              null, // AnalysisContext - unnedded for AngularCompletion
               server.resourceProvider,
               server.searchEngine,
               source,

--- a/analyzer_plugin/lib/starter.dart
+++ b/analyzer_plugin/lib/starter.dart
@@ -94,7 +94,7 @@ class Starter {
           final driver = angularDrivers[driverPath];
           var template = await driver.getTemplateForFile(filePath);
           if (template != null) {
-            return new AngularCompletionContributor(server, driver);
+            return new AngularCompletionContributor(driver);
           }
         }
       }
@@ -121,8 +121,7 @@ class Starter {
             driverPath) {
           final driver = angularDrivers[driverPath];
 
-          var completionContributor =
-              new AngularCompletionContributor(server, driver);
+          var completionContributor = new AngularCompletionContributor(driver);
           CompletionRequestImpl completionRequest = new CompletionRequestImpl(
               null,
               null,

--- a/playground/lib/counter_component.dart
+++ b/playground/lib/counter_component.dart
@@ -2,7 +2,7 @@ import 'package:angular2/angular2.dart';
 import 'dart:html';
 
 @Component(selector: 'my-counter',
-    template: r'<button (click)="increment($event)">++</button>')
+    template: r'<button  (click)="increment($event)">++</button>')
 class CounterComponent {
 
   @Input() int count;

--- a/playground/lib/counter_component.dart
+++ b/playground/lib/counter_component.dart
@@ -1,7 +1,8 @@
 import 'package:angular2/angular2.dart';
 import 'dart:html';
 
-@Component(selector: 'my-counter', template: r'{{count}} <button (click)="increment($event)">++</button>')
+@Component(selector: 'my-counter',
+    template: r'<button (click)="increment($event)">++</button>')
 class CounterComponent {
 
   @Input() int count;

--- a/playground/lib/overview_component.dart
+++ b/playground/lib/overview_component.dart
@@ -2,7 +2,10 @@ import 'package:angular2/angular2.dart';
 import 'counter_component.dart';
 import 'bubbled_directive.dart';
 
-@Component(selector: 'blah', directives: const[CounterComponent, NgFor, NgIf, BubbledDirective], templateUrl: 'overview_component.html')
+@Component(selector: 'blah',
+    directives: const[CounterComponent, NgFor, NgIf, BubbledDirective],
+    templateUrl: 'overview_component.html'
+)
 class OverviewComponent {
   String header;
   List<String> items;

--- a/server_plugin/lib/plugin.dart
+++ b/server_plugin/lib/plugin.dart
@@ -28,9 +28,9 @@ class AngularServerPlugin implements Plugin {
     //    new AngularNavigationContributor());
     //registerExtension(OCCURRENCES_CONTRIBUTOR_EXTENSION_POINT_ID,
     //    new AngularOccurrencesContributor());
-    registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
-        () => new AngularTemplateCompletionContributor());
-    registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
-        () => new AngularDartCompletionContributor());
+    //registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
+    //    () => new AngularTemplateCompletionContributor());
+    //registerExtension(COMPLETION_CONTRIBUTOR_EXTENSION_POINT_ID,
+    //    () => new AngularDartCompletionContributor());
   }
 }

--- a/server_plugin/lib/plugin.dart
+++ b/server_plugin/lib/plugin.dart
@@ -2,8 +2,6 @@ library angular2.src.analysis.server_plugin;
 
 //import 'package:analysis_server/plugin/analysis/navigation/navigation.dart';
 //import 'package:analysis_server/plugin/analysis/occurrences/occurrences.dart';
-import 'package:analysis_server/src/provisional/completion/completion.dart';
-import 'package:angular_analyzer_server_plugin/src/completion.dart';
 import 'package:plugin/plugin.dart';
 
 /**

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -222,7 +222,7 @@ class AngularCompletionContributor extends CompletionContributor {
 
     var events = driver.standardHtml.events.values;
     var attributes = driver.standardHtml.attributes.values;
-    var templates = await driver.getTemplateForFile(filePath);
+    var templates = await driver.getTemplatesForFile(filePath);
 
     if (templates.isEmpty) {
       return <CompletionSuggestion>[];

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:analysis_server/src/domain_completion.dart';
-import 'package:analysis_server/src/analysis_server.dart';
 import 'package:analysis_server/plugin/protocol/protocol.dart' as protocol
     show Element, ElementKind;
 import 'package:analysis_server/src/provisional/completion/completion_core.dart';

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -204,12 +204,11 @@ class ReplacementRangeCalculator extends AngularAstVisitor {
  * Contributor to contribute angular entities.
  */
 class AngularCompletionContributor extends CompletionContributor {
-  final AnalysisServer server;
   final AngularDriver driver;
 
   /// Initialize a newly created handler to handle requests for the given
   /// [server].
-  AngularCompletionContributor(this.server, this.driver);
+  AngularCompletionContributor(this.driver);
 
   /**
    * Return a [Future] that completes with a list of suggestions
@@ -356,8 +355,8 @@ class TemplateCompleter {
       }
 
       Component component = directive;
-      Template template = component?.view?.template;
-      if (template == null) {
+      var view = component?.view;
+      if (view == null) {
         continue;
       }
 
@@ -368,12 +367,8 @@ class TemplateCompleter {
 
         List<HtmlTagForSelector> tags = ngContent.selector.suggestTags();
         for (HtmlTagForSelector tag in tags) {
-          Location location = new Location(
-              template.view.templateSource.fullName,
-              ngContent.offset,
-              ngContent.length,
-              0,
-              0);
+          Location location = new Location(view.templateSource.fullName,
+              ngContent.offset, ngContent.length, 0, 0);
           suggestions.add(_createHtmlTagSuggestion(
               tag.toString(),
               RELEVANCE_TRANSCLUSION,

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -214,6 +214,7 @@ class AngularCompletionContributor extends CompletionContributor {
    */
   Future<List<CompletionSuggestion>> computeSuggestions(
       CompletionRequest request) async {
+    var suggestions = <CompletionSuggestion>[];
     var filePath = request.source.toString();
 
     await driver.getStandardHtml();
@@ -221,14 +222,21 @@ class AngularCompletionContributor extends CompletionContributor {
 
     var events = driver.standardHtml.events.values;
     var attributes = driver.standardHtml.attributes.values;
-    var template = await driver.getTemplateForFile(filePath);
+    var templates = await driver.getTemplateForFile(filePath);
 
-    if (template == null) {
-      return [];
+    if (templates.isEmpty) {
+      return <CompletionSuggestion>[];
     }
     var templateCompleter = new TemplateCompleter();
-    return templateCompleter.computeSuggestions(
-        request, template, events, attributes);
+    for (var template in templates) {
+      suggestions.addAll(await templateCompleter.computeSuggestions(
+        request,
+        template,
+        events,
+        attributes,
+      ));
+    }
+    return suggestions;
   }
 }
 

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:analysis_server/src/domain_completion.dart';
+import 'package:analysis_server/src/analysis_server.dart';
 import 'package:analysis_server/plugin/protocol/protocol.dart' as protocol
     show Element, ElementKind;
 import 'package:analysis_server/src/provisional/completion/completion_core.dart';
@@ -19,6 +20,7 @@ import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
+import 'package:angular_analyzer_plugin/src/angular_driver.dart';
 
 import 'package:analysis_server/src/protocol_server.dart'
     show CompletionSuggestion, CompletionSuggestionKind, Location;
@@ -198,16 +200,16 @@ class ReplacementRangeCalculator extends AngularAstVisitor {
   visitMustache(Mustache mustache) {}
 }
 
-class AngularDartCompletionContributor extends CompletionContributor {
-  final List<Template> templates;
-  final List<OutputElement> standardHtmlEvents;
-  final List<InputElement> standardHtmlAttributes;
+/**
+ * Contributor to contribute angular entities.
+ */
+class AngularCompletionContributor extends CompletionContributor {
+  final AnalysisServer server;
+  final AngularDriver driver;
 
-  AngularDartCompletionContributor(
-    this.templates,
-    this.standardHtmlEvents,
-    this.standardHtmlAttributes,
-  );
+  /// Initialize a newly created handler to handle requests for the given
+  /// [server].
+  AngularCompletionContributor(this.server, this.driver);
 
   /**
    * Return a [Future] that completes with a list of suggestions
@@ -215,152 +217,135 @@ class AngularDartCompletionContributor extends CompletionContributor {
    */
   Future<List<CompletionSuggestion>> computeSuggestions(
       CompletionRequest request) async {
-    var templateCompleter = new TemplateCompleter();
-    var completionResult = await templateCompleter.computeSuggestions(
-        request, templates, standardHtmlEvents, standardHtmlAttributes);
-    return completionResult.suggestions;
-  }
-}
+    var filePath = request.source.toString();
+    var events = driver.standardHtml.events.values;
+    var attributes = driver.standardHtml.attributes.values;
+    var template = await driver.getTemplateForFile(filePath);
 
-class AngularTemplateCompletionContributor extends CompletionContributor {
-  /**
-   * Return a [Future] that completes with a list of suggestions
-   * for the given completion [request]. This will
-   * throw [AbortCompletion] if the completion request has been aborted.
-   */
-  Future<List<CompletionSuggestion>> computeSuggestions(
-      CompletionRequest request) async {
-    if (request.source.shortName.endsWith('.html')) {
-      //return new TemplateCompleter().computeSuggestions(
-      //    request, templates, standardHtmlEvents, standardHtmlAttributes);
+    if (template == null) {
+      return [];
     }
-
-    return [];
+    var templateCompleter = new TemplateCompleter();
+    return templateCompleter.computeSuggestions(
+        request, template, events, attributes);
   }
 }
 
 class TemplateCompleter {
   static const int RELEVANCE_TRANSCLUSION = DART_RELEVANCE_DEFAULT + 10;
 
-  Future<CompletionResult> computeSuggestions(
+  Future<List<CompletionSuggestion>> computeSuggestions(
       CompletionRequest request,
-      List<Template> templates,
+      Template template,
       List<OutputElement> standardHtmlEvents,
       List<InputElement> standardHtmlAttributes) async {
     List<CompletionSuggestion> suggestions = <CompletionSuggestion>[];
-    for (Template template in templates) {
-      AngularAstNode target = findTarget(request.offset, template.ast);
-      target.accept(new ReplacementRangeCalculator(request));
-      DartSnippetExtractor extractor = new DartSnippetExtractor();
-      extractor.offset = request.offset;
-      target.accept(extractor);
-      if (extractor.dartSnippet != null) {
-        EmbeddedDartCompletionRequest dartRequest =
-            new EmbeddedDartCompletionRequest.from(
-                request, extractor.dartSnippet);
+    AngularAstNode target = findTarget(request.offset, template.ast);
+    target.accept(new ReplacementRangeCalculator(request));
+    DartSnippetExtractor extractor = new DartSnippetExtractor();
+    extractor.offset = request.offset;
+    target.accept(extractor);
+    if (extractor.dartSnippet != null) {
+      EmbeddedDartCompletionRequest dartRequest =
+          new EmbeddedDartCompletionRequest.from(
+              request, extractor.dartSnippet);
 
-        ReplacementRange range = new ReplacementRange.compute(
-            dartRequest.offset, dartRequest.target);
-        (request as CompletionRequestImpl)
-          ..replacementOffset = range.offset
-          ..replacementLength = range.length;
+      ReplacementRange range =
+          new ReplacementRange.compute(dartRequest.offset, dartRequest.target);
+      (request as CompletionRequestImpl)
+        ..replacementOffset = range.offset
+        ..replacementLength = range.length;
 
-        dartRequest.libraryElement = template.view.classElement.library;
-        TypeMemberContributor memberContributor = new TypeMemberContributor();
-        InheritedReferenceContributor inheritedContributor =
-            new InheritedReferenceContributor();
-        suggestions.addAll(inheritedContributor.computeSuggestionsForClass(
-            template.view.classElement, dartRequest,
-            skipChildClass: false));
-        suggestions
-            .addAll(await memberContributor.computeSuggestions(dartRequest));
+      dartRequest.libraryElement = template.view.classElement.library;
+      TypeMemberContributor memberContributor = new TypeMemberContributor();
+      InheritedReferenceContributor inheritedContributor =
+          new InheritedReferenceContributor();
+      suggestions.addAll(inheritedContributor.computeSuggestionsForClass(
+          template.view.classElement, dartRequest,
+          skipChildClass: false));
+      suggestions
+          .addAll(await memberContributor.computeSuggestions(dartRequest));
 
-        if (dartRequest.opType.includeIdentifiers) {
-          LocalVariablesExtractor varExtractor = new LocalVariablesExtractor();
-          target.accept(varExtractor);
-          if (varExtractor.variables != null) {
-            addLocalVariables(
-                suggestions, varExtractor.variables, dartRequest.opType);
-          }
+      if (dartRequest.opType.includeIdentifiers) {
+        LocalVariablesExtractor varExtractor = new LocalVariablesExtractor();
+        target.accept(varExtractor);
+        if (varExtractor.variables != null) {
+          addLocalVariables(
+              suggestions, varExtractor.variables, dartRequest.opType);
         }
-      } else if (target is ElementInfo &&
-          target.openingSpan == null &&
-          target.localName == 'html' &&
-          target.childNodes.isNotEmpty &&
-          target.childNodes.length == 2 &&
-          target.childNodes[1] is ElementInfo &&
-          (target.childNodes[1] as ElementInfo).localName == 'body' &&
-          (target.childNodes[1] as ElementInfo).childNodes.isEmpty) {
-        //On an empty document
-        suggestHtmlTags(template, suggestions);
-      } else if (target is ElementInfo &&
-          target.openingSpan != null &&
-          target.openingNameSpan != null &&
-          (offsetContained(request.offset, target.openingSpan.offset,
-              target.openingSpan.length))) {
-        if (!offsetContained(request.offset, target.openingNameSpan.offset,
-            target.openingNameSpan.length)) {
-          // TODO suggest these things if the target is ExpressionBoundInput with
-          // boundType of input
-          suggestInputs(target.boundDirectives, suggestions,
-              standardHtmlAttributes, target.boundStandardInputs);
-          suggestOutputs(target.boundDirectives, suggestions,
-              standardHtmlEvents, target.boundStandardOutputs);
-        } else {
-          suggestHtmlTags(template, suggestions);
-          if (target.parent != null) {
-            suggestTransclusions(target.parent, suggestions);
-          }
-        }
-      } else if (target is ElementInfo &&
-          target.openingSpan != null &&
-          target.openingNameSpan != null &&
-          target.closingSpan != null &&
-          target.closingNameSpan != null &&
-          request.offset ==
-              (target.closingSpan.offset + target.closingSpan.length)) {
-        suggestHtmlTags(template, suggestions);
-        suggestTransclusions(target.parent, suggestions);
-      } else if (target is ElementInfo &&
-          target.openingSpan != null &&
-          request.offset == target.childNodesMaxEnd) {
-        suggestHtmlTags(template, suggestions);
-        suggestTransclusions(target, suggestions);
-      } else if (target is ElementInfo) {
-        suggestHtmlTags(template, suggestions);
-        suggestTransclusions(target, suggestions);
-      } else if (target is ExpressionBoundAttribute &&
-          target.bound == ExpressionBoundType.input &&
-          offsetContained(request.offset, target.originalNameOffset,
-              target.originalName.length)) {
-        suggestInputs(target.parent.boundDirectives, suggestions,
-            standardHtmlAttributes, target.parent.boundStandardInputs,
-            currentAttr: target);
-      } else if (target is StatementsBoundAttribute) {
-        suggestOutputs(target.parent.boundDirectives, suggestions,
-            standardHtmlEvents, target.parent.boundStandardOutputs,
-            currentAttr: target);
-      } else if (target is TemplateAttribute) {
-        suggestInputs(target.parent.boundDirectives, suggestions,
-            standardHtmlAttributes, target.parent.boundStandardInputs);
-        suggestOutputs(target.parent.boundDirectives, suggestions,
-            standardHtmlEvents, target.parent.boundStandardOutputs);
-      } else if (target is TextAttribute) {
-        suggestInputs(target.parent.boundDirectives, suggestions,
-            standardHtmlAttributes, target.parent.boundStandardInputs);
-        suggestOutputs(target.parent.boundDirectives, suggestions,
-            standardHtmlEvents, target.parent.boundStandardOutputs);
-      } else if (target is TextInfo) {
-        suggestHtmlTags(template, suggestions);
-        suggestTransclusions(target.parent, suggestions);
       }
+    } else if (target is ElementInfo &&
+        target.openingSpan == null &&
+        target.localName == 'html' &&
+        target.childNodes.isNotEmpty &&
+        target.childNodes.length == 2 &&
+        target.childNodes[1] is ElementInfo &&
+        (target.childNodes[1] as ElementInfo).localName == 'body' &&
+        (target.childNodes[1] as ElementInfo).childNodes.isEmpty) {
+      //On an empty document
+      suggestHtmlTags(template, suggestions);
+    } else if (target is ElementInfo &&
+        target.openingSpan != null &&
+        target.openingNameSpan != null &&
+        (offsetContained(request.offset, target.openingSpan.offset,
+            target.openingSpan.length))) {
+      if (!offsetContained(request.offset, target.openingNameSpan.offset,
+          target.openingNameSpan.length)) {
+        // TODO suggest these things if the target is ExpressionBoundInput with
+        // boundType of input
+        suggestInputs(target.boundDirectives, suggestions,
+            standardHtmlAttributes, target.boundStandardInputs);
+        suggestOutputs(target.boundDirectives, suggestions, standardHtmlEvents,
+            target.boundStandardOutputs);
+      } else {
+        suggestHtmlTags(template, suggestions);
+        if (target.parent != null) {
+          suggestTransclusions(target.parent, suggestions);
+        }
+      }
+    } else if (target is ElementInfo &&
+        target.openingSpan != null &&
+        target.openingNameSpan != null &&
+        target.closingSpan != null &&
+        target.closingNameSpan != null &&
+        request.offset ==
+            (target.closingSpan.offset + target.closingSpan.length)) {
+      suggestHtmlTags(template, suggestions);
+      suggestTransclusions(target.parent, suggestions);
+    } else if (target is ElementInfo &&
+        target.openingSpan != null &&
+        request.offset == target.childNodesMaxEnd) {
+      suggestHtmlTags(template, suggestions);
+      suggestTransclusions(target, suggestions);
+    } else if (target is ElementInfo) {
+      suggestHtmlTags(template, suggestions);
+      suggestTransclusions(target, suggestions);
+    } else if (target is ExpressionBoundAttribute &&
+        target.bound == ExpressionBoundType.input &&
+        offsetContained(request.offset, target.originalNameOffset,
+            target.originalName.length)) {
+      suggestInputs(target.parent.boundDirectives, suggestions,
+          standardHtmlAttributes, target.parent.boundStandardInputs,
+          currentAttr: target);
+    } else if (target is StatementsBoundAttribute) {
+      suggestOutputs(target.parent.boundDirectives, suggestions,
+          standardHtmlEvents, target.parent.boundStandardOutputs,
+          currentAttr: target);
+    } else if (target is TemplateAttribute) {
+      suggestInputs(target.parent.boundDirectives, suggestions,
+          standardHtmlAttributes, target.parent.boundStandardInputs);
+      suggestOutputs(target.parent.boundDirectives, suggestions,
+          standardHtmlEvents, target.parent.boundStandardOutputs);
+    } else if (target is TextAttribute) {
+      suggestInputs(target.parent.boundDirectives, suggestions,
+          standardHtmlAttributes, target.parent.boundStandardInputs);
+      suggestOutputs(target.parent.boundDirectives, suggestions,
+          standardHtmlEvents, target.parent.boundStandardOutputs);
+    } else if (target is TextInfo) {
+      suggestHtmlTags(template, suggestions);
+      suggestTransclusions(target.parent, suggestions);
     }
-
-    return new CompletionResult(
-      (request as CompletionRequestImpl).offset,
-      (request as CompletionRequestImpl).replacementLength,
-      suggestions,
-    );
+    return suggestions;
   }
 
   suggestTransclusions(

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -215,6 +215,10 @@ class AngularCompletionContributor extends CompletionContributor {
   Future<List<CompletionSuggestion>> computeSuggestions(
       CompletionRequest request) async {
     var filePath = request.source.toString();
+
+    await driver.getStandardHtml();
+    assert(driver.standardHtml != null);
+
     var events = driver.standardHtml.events.values;
     var attributes = driver.standardHtml.attributes.values;
     var template = await driver.getTemplateForFile(filePath);

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -3,6 +3,8 @@ library angular2.src.analysis.server_plugin.analysis_test;
 import 'package:analysis_server/plugin/analysis/navigation/navigation_core.dart';
 import 'package:analysis_server/plugin/analysis/occurrences/occurrences_core.dart';
 import 'package:analysis_server/plugin/protocol/protocol.dart' as protocol;
+import 'package:analysis_server/src/plugin/notification_manager.dart';
+import 'package:analysis_server/src/analysis_server.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/context/context.dart' show AnalysisContextImpl;
@@ -13,9 +15,17 @@ import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/task/driver.dart';
 import 'package:analyzer/src/task/manager.dart';
+import 'package:analyzer/source/package_map_resolver.dart';
 import 'package:analyzer/task/model.dart';
+import 'package:analyzer/context/context_root.dart';
+import 'package:analyzer/src/dart/analysis/driver.dart' as nonTask
+    show AnalysisDriver, AnalysisDriverScheduler, PerformanceLog;
+import 'package:analyzer/src/dart/analysis/file_state.dart';
+import 'package:analyzer/src/generated/engine.dart';
+import 'package:analyzer/src/dart/analysis/byte_store.dart';
 import 'package:angular_analyzer_plugin/plugin.dart';
 import 'package:angular_analyzer_server_plugin/src/analysis.dart';
+import 'package:angular_analyzer_plugin/src/angular_driver.dart';
 import 'package:plugin/manager.dart';
 import 'package:plugin/plugin.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
@@ -335,6 +345,12 @@ class GatheringErrorListener implements AnalysisErrorListener {
   void onError(AnalysisError error) {
     _errors.add(error);
   }
+
+  void addAll(List<AnalysisError> errors) {
+    for (AnalysisError error in errors) {
+      onError(error);
+    }
+  }
 }
 
 class NavigationCollectorMock extends TypedMock implements NavigationCollector {
@@ -559,4 +575,226 @@ class _RecordedNavigationRegion {
   String toString() {
     return '$offset $length $targetKind $targetLocation';
   }
+}
+
+class AbstractAngularTest {
+  MemoryResourceProvider resourceProvider;
+
+  DartSdk sdk;
+  AngularDriver angularDriver;
+  nonTask.AnalysisDriver dartDriver;
+
+  GatheringErrorListener errorListener;
+
+  void setUp() {
+    nonTask.PerformanceLog logger =
+        new nonTask.PerformanceLog(new StringBuffer());
+    var byteStore = new MemoryByteStore();
+
+    nonTask.AnalysisDriverScheduler scheduler =
+        new nonTask.AnalysisDriverScheduler(logger);
+    scheduler.start();
+    resourceProvider = new MemoryResourceProvider();
+
+    sdk = new MockSdk(resourceProvider: resourceProvider);
+    final packageMap = new Map<String, List<Folder>>();
+    PackageMapUriResolver packageResolver =
+        new PackageMapUriResolver(resourceProvider, packageMap);
+    SourceFactory sf = new SourceFactory([
+      new DartUriResolver(sdk),
+      packageResolver,
+      new ResourceUriResolver(resourceProvider),
+    ]);
+    var testPath = resourceProvider.convertPath('/test');
+    var contextRoot = new ContextRoot(testPath, []);
+
+    dartDriver = new nonTask.AnalysisDriver(
+      scheduler,
+      logger,
+      resourceProvider,
+      byteStore,
+      new FileContentOverlay(),
+      contextRoot,
+      sf,
+      new AnalysisOptionsImpl(),
+    );
+
+    angularDriver = new AngularDriver(new MockAnalysisServer(), dartDriver,
+        scheduler, byteStore, sf, new FileContentOverlay());
+
+    errorListener = new GatheringErrorListener();
+    addAngularSources();
+  }
+
+  Source newSource(String path, [String content = '']) {
+    File file = resourceProvider.newFile(path, content);
+    final source = file.createSource();
+    angularDriver.addFile(path);
+    dartDriver.addFile(path);
+    return source;
+  }
+
+  void fillErrorListener(List<AnalysisError> errors) {
+    errorListener.addAll(errors);
+  }
+
+  void addAngularSources() {
+    newSource(
+        '/angular2/angular2.dart',
+        r'''
+library angular2;
+
+export 'src/core/async.dart';
+export 'src/core/metadata.dart';
+export 'src/core/ng_if.dart';
+export 'src/core/ng_for.dart';
+''');
+    newSource(
+        '/angular2/src/core/metadata.dart',
+        r'''
+library angular2.src.core.metadata;
+
+import 'dart:async';
+
+abstract class Directive {
+  const Directive(
+      {String selector,
+      List<String> inputs,
+      List<String> outputs,
+      @Deprecated('Use `inputs` or `@Input` instead') List<String> properties,
+      @Deprecated('Use `outputs` or `@Output` instead') List<String> events,
+      Map<String, String> host,
+      @Deprecated('Use `providers` instead') List bindings,
+      List providers,
+      String exportAs,
+      String moduleId,
+      Map<String, dynamic> queries})
+      : super(
+            selector: selector,
+            inputs: inputs,
+            outputs: outputs,
+            properties: properties,
+            events: events,
+            host: host,
+            bindings: bindings,
+            providers: providers,
+            exportAs: exportAs,
+            moduleId: moduleId,
+            queries: queries);
+}
+
+class Component extends Directive {
+  const Component(
+      {String selector,
+      List<String> inputs,
+      List<String> outputs,
+      @Deprecated('Use `inputs` or `@Input` instead') List<String> properties,
+      @Deprecated('Use `outputs` or `@Output` instead') List<String> events,
+      Map<String, String> host,
+      @Deprecated('Use `providers` instead') List bindings,
+      List providers,
+      String exportAs,
+      String moduleId,
+      Map<String, dynamic> queries,
+      @Deprecated('Use `viewProviders` instead') List viewBindings,
+      List viewProviders,
+      ChangeDetectionStrategy changeDetection,
+      String templateUrl,
+      String template,
+      dynamic directives,
+      dynamic pipes,
+      ViewEncapsulation encapsulation,
+      List<String> styles,
+      List<String> styleUrls});
+}
+
+class View {
+  const View(
+      {String templateUrl,
+      String template,
+      dynamic directives,
+      dynamic pipes,
+      ViewEncapsulation encapsulation,
+      List<String> styles,
+      List<String> styleUrls});
+}
+
+class Input {
+  final String bindingPropertyName;
+  const InputMetadata([this.bindingPropertyName]);
+}
+
+class Output {
+  final String bindingPropertyName;
+  const OutputMetadata([this.bindingPropertyName]);
+}
+''');
+    newSource(
+        '/angular2/src/core/async.dart',
+        r'''
+library angular2.core.facade.async;
+import 'dart:async';
+
+class EventEmitter<T> extends Stream<T> {
+  StreamController<dynamic> _controller;
+
+  /**
+   * Creates an instance of [EventEmitter], which depending on [isAsync],
+   * delivers events synchronously or asynchronously.
+   */
+  EventEmitter([bool isAsync = true]) {
+    _controller = new StreamController.broadcast(sync: !isAsync);
+  }
+
+  StreamSubscription listen(void onData(dynamic line),
+      {void onError(Error error), void onDone(), bool cancelOnError}) {
+    return _controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  void add(value) {
+    _controller.add(value);
+  }
+
+  void addError(error) {
+    _controller.addError(error);
+  }
+
+  void close() {
+    _controller.close();
+  }
+}
+''');
+    newSource(
+        '/angular2/src/core/ng_if.dart',
+        r'''
+library angular2.ng_if;
+import 'metadata.dart';
+
+@Directive(selector: "[ngIf]", inputs: const ["ngIf"])
+class NgIf {
+  set ngIf(newCondition) {}
+}
+''');
+    newSource(
+        '/angular2/src/core/ng_for.dart',
+        r'''
+library angular2.ng_for;
+import 'metadata.dart';
+
+@Directive(
+    selector: "[ngFor][ngForOf]",
+    inputs: const ["ngForOf", "ngForTemplate"])
+class NgFor {
+  set ngForOf(dynamic value) {}
+}
+''');
+  }
+}
+
+class MockAnalysisServer extends TypedMock implements AnalysisServer {
+  NotificationManager notificationManager = new MockNotificationManager();
+}
+
+class MockNotificationManager extends TypedMock implements NotificationManager {
 }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -1,12 +1,5 @@
-import 'dart:async';
-import 'package:analyzer/src/generated/source.dart';
-
 import 'package:analysis_server/src/provisional/completion/completion_core.dart';
 import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
-import 'package:angular_analyzer_plugin/ast.dart';
-import 'package:angular_analyzer_plugin/src/model.dart';
-import 'package:angular_analyzer_plugin/src/selector.dart';
-import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:angular_analyzer_server_plugin/src/completion.dart';
 import 'package:unittest/unittest.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -1,5 +1,12 @@
+import 'dart:async';
+import 'package:analyzer/src/generated/source.dart';
+
 import 'package:analysis_server/src/provisional/completion/completion_core.dart';
 import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
+import 'package:angular_analyzer_plugin/ast.dart';
+import 'package:angular_analyzer_plugin/src/model.dart';
+import 'package:angular_analyzer_plugin/src/selector.dart';
+import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:angular_analyzer_server_plugin/src/completion.dart';
 import 'package:unittest/unittest.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
@@ -22,7 +29,7 @@ class DartCompletionContributorTest extends AbstractCompletionContributorTest {
 
   @override
   CompletionContributor createContributor() {
-    return new AngularCompletionContributor();
+    return new AngularCompletionContributor(angularDriver);
   }
 
   test_completeMemberInMustache() async {
@@ -443,15 +450,16 @@ class HtmlCompletionContributorTest extends AbstractCompletionContributorTest {
   setUp() {
     testFile = '/completionTest.html';
     super.setUp();
+    createContributor();
   }
 
   @override
   CompletionContributor createContributor() {
-    return new AngularCompletionContributor();
+    return new AngularCompletionContributor(angularDriver);
   }
 
   test_completeMemberInMustache() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -462,10 +470,8 @@ class MyComp {
     ''');
 
     addTestSource('html file {{^}} with mustache');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -475,7 +481,7 @@ class MyComp {
   }
 
   test_completeDotMemberInMustache() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -486,10 +492,8 @@ class MyComp {
     ''');
 
     addTestSource('html file {{text.^}} with mustache');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -497,7 +501,7 @@ class MyComp {
   }
 
   test_completeDotMemberAlreadyStartedInMustache() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -508,10 +512,8 @@ class MyComp {
     ''');
 
     addTestSource('html file {{text.le^}} with mustache');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 'le'.length);
     expect(replacementLength, 'le'.length);
@@ -519,7 +521,7 @@ class MyComp {
   }
 
   test_completeDotMemberInNgFor() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -530,10 +532,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let item of text.^"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -541,7 +541,7 @@ class MyComp {
   }
 
   test_completeMemberInNgFor() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -552,10 +552,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let item of ^"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -565,7 +563,7 @@ class MyComp {
   }
 
   test_noCompleteMemberInNgForRightAfterLet() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -576,10 +574,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let^ item of [text]"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -587,7 +583,7 @@ class MyComp {
   }
 
   test_noCompleteMemberInNgForInLet() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -598,10 +594,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="l^et item of [text]"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -609,7 +603,7 @@ class MyComp {
   }
 
   test_noCompleteMemberInNgForAfterLettedName() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -620,10 +614,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let item^ of [text]"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -631,7 +623,7 @@ class MyComp {
   }
 
   test_noCompleteMemberInNgForInLettedName() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -642,10 +634,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let i^tem of [text]"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -653,7 +643,7 @@ class MyComp {
   }
 
   test_noCompleteMemberInNgFor_forLettedName() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -664,10 +654,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let ^"></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -675,7 +663,7 @@ class MyComp {
   }
 
   test_completeNgForItem() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -686,10 +674,8 @@ class MyComp {
     ''');
 
     addTestSource('<div *ngFor="let item of items">{{^}}</div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -697,7 +683,7 @@ class MyComp {
   }
 
   test_completeHashVar() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -707,10 +693,8 @@ class MyComp {
     ''');
 
     addTestSource('<button #buttonEl>button</button> {{^}}');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -718,7 +702,7 @@ class MyComp {
   }
 
   test_completeNgVars_notAfterDot() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -730,10 +714,8 @@ class MyComp {
 
     addTestSource(
         '<button #buttonEl>button</button><div *ngFor="item of items">{{hashCode.^}}</div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -742,7 +724,7 @@ class MyComp {
   }
 
   test_findCompletionTarget_afterUnclosedDom() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -753,10 +735,8 @@ class MyComp {
     ''');
 
     addTestSource('<input /> {{^}}');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -764,7 +744,7 @@ class MyComp {
   }
 
   test_completeStatements() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -775,10 +755,8 @@ class MyComp {
     ''');
 
     addTestSource('<button (click)="^"></button>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -787,7 +765,7 @@ class MyComp {
   }
 
   test_completeUnclosedMustache() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -798,10 +776,8 @@ class MyComp {
     ''');
 
     addTestSource('some text and {{^   <div>some html</div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -809,7 +785,7 @@ class MyComp {
   }
 
   test_completeEmptyExpressionDoesntIncludeVoid() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -820,10 +796,8 @@ class MyComp {
     ''');
 
     addTestSource('{{^}}');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -831,7 +805,7 @@ class MyComp {
   }
 
   test_completeInMiddleOfExpressionDoesntIncludeVoid() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -843,10 +817,8 @@ class MyComp {
     ''');
 
     addTestSource('{{takesArg(^)}}');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -854,7 +826,7 @@ class MyComp {
   }
 
   test_completeInputOutput() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -870,10 +842,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag ^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -885,7 +855,7 @@ class OtherComp {
   }
 
   test_completeInputOutput_at_incompleteTag_with_newTag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -901,10 +871,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag ^<div></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -916,7 +884,7 @@ class OtherComp {
   }
 
   test_completeInputStarted_at_incompleteTag_with_newTag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -932,10 +900,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [^<div></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -946,7 +912,7 @@ class OtherComp {
   }
 
   test_completeOutputStarted_at_incompleteTag_with_newTag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -962,10 +928,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (^<div></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -977,7 +941,7 @@ class OtherComp {
   }
 
   test_completeInputOutput_at_incompleteTag_with_EOF() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -993,10 +957,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag ^');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1008,7 +970,7 @@ class OtherComp {
   }
 
   test_completeInputStarted_at_incompleteTag_with_EOF() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1024,10 +986,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [^');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1038,7 +998,7 @@ class OtherComp {
   }
 
   test_completeOutputStarted_at_incompleteTag_with_EOF() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1054,10 +1014,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (^');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1069,7 +1027,7 @@ class OtherComp {
   }
 
   test_completeInputNotSuggestedTwice() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1085,10 +1043,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [name]="\'bob\'" ^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1099,7 +1055,7 @@ class OtherComp {
   }
 
   test_completeStandardInputNotSuggestedTwice() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1115,10 +1071,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [hidden]="true" ^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1130,7 +1084,7 @@ class OtherComp {
   }
 
   test_completeInputSuggestsItself() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1146,10 +1100,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [name^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '[name'.length);
     expect(replacementLength, '[name'.length);
@@ -1157,7 +1109,7 @@ class OtherComp {
   }
 
   test_completeStandardInputSuggestsItself() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1173,10 +1125,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [hidden^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '[hidden'.length);
     expect(replacementLength, '[hidden'.length);
@@ -1184,7 +1134,7 @@ class OtherComp {
   }
 
   test_completeOutputNotSuggestedTwice() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1200,10 +1150,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (nameEvent)="" ^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1215,7 +1163,7 @@ class OtherComp {
   }
 
   test_completeOutputSuggestsItself() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1231,10 +1179,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (nameEvent^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '(nameEvent'.length);
     expect(replacementLength, '(nameEvent'.length);
@@ -1242,7 +1188,7 @@ class OtherComp {
   }
 
   test_completeStdOutputNotSuggestedTwice() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1258,10 +1204,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (click)="" ^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1272,7 +1216,7 @@ class OtherComp {
   }
 
   test_completeStdOutputSuggestsItself() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1288,10 +1232,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (click^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '(click'.length);
     expect(replacementLength, '(click'.length);
@@ -1300,7 +1242,7 @@ class OtherComp {
   }
 
   test_completeInputOutputNotSuggestedAfterTwoWay() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1317,10 +1259,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [(name)]="name" ^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1329,7 +1269,7 @@ class OtherComp {
   }
 
   test_completeInputStarted() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1345,10 +1285,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1359,7 +1297,7 @@ class OtherComp {
   }
 
   test_completeOutputStarted() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1375,10 +1313,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1389,7 +1325,7 @@ class OtherComp {
   }
 
   test_completeInputReplacing() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1405,10 +1341,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag [^input]="4"></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, '[input]'.length);
@@ -1419,7 +1353,7 @@ class OtherComp {
   }
 
   test_completeOutputReplacing() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1435,10 +1369,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag (^output)="4"></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, '(output)'.length);
@@ -1449,7 +1381,7 @@ class OtherComp {
   }
 
   test_noCompleteInOutputInCloseTag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1465,10 +1397,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag></my-tag ^>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1479,7 +1409,7 @@ class OtherComp {
   }
 
   test_noCompleteEmptyTagContents() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1495,10 +1425,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag>^</my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1509,7 +1437,7 @@ class OtherComp {
   }
 
   test_noCompleteInOutputsOnTagNameCompletion() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1525,10 +1453,8 @@ class OtherComp {
     ''');
 
     addTestSource('<my-tag^></my-tag>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, 0);
     expect(replacementLength, '<my-tag'.length);
@@ -1539,7 +1465,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_beginning() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1552,10 +1478,8 @@ class OtherComp {
       class MyChildComponent2
       ''');
     addTestSource('<^<div></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1565,7 +1489,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_beginning_with_partial() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1578,10 +1502,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('<my^<div></div>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '<my'.length);
     expect(replacementLength, '<my'.length);
@@ -1591,7 +1513,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_middle() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1604,10 +1526,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('''<div><div><^</div></div>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1617,7 +1537,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_middle_of_text() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1630,10 +1550,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('''<div><div> some text<^</div></div>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1643,7 +1561,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_middle_with_partial() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1656,10 +1574,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('''<div><div><my^</div></div>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '<my'.length);
     expect(replacementLength, '<my'.length);
@@ -1669,7 +1585,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_end() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1682,10 +1598,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('''<div><div></div></div><^''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1695,7 +1609,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_end_with_partial() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1709,10 +1623,8 @@ class OtherComp {
       ''');
     addTestSource('''<div><div></div></div>
     <my^''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - '<my'.length);
     expect(replacementLength, '<my'.length);
@@ -1722,7 +1634,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_on_empty_document() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1735,10 +1647,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('^');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1748,7 +1658,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag_at_end_after_close() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1761,10 +1671,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('<div><div></div></div>^');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1774,7 +1682,7 @@ class OtherComp {
   }
 
   test_completeHtmlSelectorTag__in_middle_of_unclosed_tag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
       import '/angular2/angular2.dart';
@@ -1787,10 +1695,8 @@ class OtherComp {
       class MyChildComponent2{}
       ''');
     addTestSource('<div>some text<^');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 1);
     expect(replacementLength, 1);
@@ -1800,7 +1706,7 @@ class OtherComp {
   }
 
   test_completeTransclusionSuggestion() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1814,10 +1720,8 @@ class MyComp{}
 class ContainerComponent{}
       ''');
     addTestSource('<container>^</container>');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1827,7 +1731,7 @@ class ContainerComponent{}
   }
 
   test_completeTransclusionSuggestionInWhitespace() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1844,10 +1748,8 @@ class ContainerComponent{}
 <container>
   ^
 </container>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1857,7 +1759,7 @@ class ContainerComponent{}
   }
 
   test_completeTransclusionSuggestionStarted() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1874,10 +1776,8 @@ class ContainerComponent{}
 <container>
   <^
 </container>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     //expect(replacementOffset, completionOffset - 1);
     //expect(replacementLength, 1);
@@ -1887,7 +1787,7 @@ class ContainerComponent{}
   }
 
   test_completeTransclusionSuggestionStartedTagName() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1904,10 +1804,8 @@ class ContainerComponent{}
 <container>
   <tag^
 </container>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     //expect(replacementOffset, completionOffset - 4);
     //expect(replacementLength, 4);
@@ -1917,7 +1815,7 @@ class ContainerComponent{}
   }
 
   test_completeTransclusionSuggestionAfterTag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1935,10 +1833,8 @@ class ContainerComponent{}
   <blah></blah>
   ^
 </container>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
@@ -1948,7 +1844,7 @@ class ContainerComponent{}
   }
 
   test_completeTransclusionSuggestionBeforeTag() async {
-    newSource(
+    var dartSource = newSource(
         '/completionTest.dart',
         '''
 import '/angular2/angular2.dart';
@@ -1966,10 +1862,8 @@ class ContainerComponent{}
   ^
   <blah></blah>
 </container>''');
-    //LibrarySpecificUnit target =
-    //    new LibrarySpecificUnit(dartSource, dartSource);
-    //computeResult(target, VIEWS_WITH_HTML_TEMPLATES2);
 
+    await resolveSingleTemplate(dartSource);
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -9,7 +9,7 @@ import 'completion_contributor_test_util.dart';
 main() {
   // TODO: get these working again on the latest SDK
   //defineReflectiveTests(DartCompletionContributorTest);
-  //defineReflectiveTests(HtmlCompletionContributorTest);
+  defineReflectiveTests(HtmlCompletionContributorTest);
 }
 
 @reflectiveTest
@@ -22,7 +22,8 @@ class DartCompletionContributorTest extends AbstractCompletionContributorTest {
 
   @override
   CompletionContributor createContributor() {
-    return new AngularDartCompletionContributor();
+    return new AngularCompletionContributor(
+        angularDriver.server, angularDriver);
   }
 
   test_completeMemberInMustache() async {
@@ -447,7 +448,7 @@ class HtmlCompletionContributorTest extends AbstractCompletionContributorTest {
 
   @override
   CompletionContributor createContributor() {
-    return new AngularTemplateCompletionContributor();
+    return new AngularCompletionContributor();
   }
 
   test_completeMemberInMustache() async {

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -22,8 +22,7 @@ class DartCompletionContributorTest extends AbstractCompletionContributorTest {
 
   @override
   CompletionContributor createContributor() {
-    return new AngularCompletionContributor(
-        angularDriver.server, angularDriver);
+    return new AngularCompletionContributor();
   }
 
   test_completeMemberInMustache() async {

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -15,19 +15,10 @@ import 'package:analysis_server/src/provisional/completion/completion_core.dart'
 import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';
 import 'package:analysis_server/src/services/completion/completion_core.dart';
 import 'package:analysis_server/src/services/completion/completion_performance.dart';
-import 'package:analysis_server/src/services/completion/dart/completion_manager.dart'
-    show DartCompletionRequestImpl;
 import 'package:analysis_server/src/services/index/index.dart';
 import 'package:analysis_server/src/services/search/search_engine_internal.dart';
-import 'package:analyzer/src/dart/analysis/driver.dart'
-    show AnalysisDriver, AnalysisDriverScheduler, PerformanceLog;
 import 'package:analyzer/src/generated/source.dart';
-import 'package:analyzer/task/dart.dart';
-import 'package:angular_analyzer_plugin/src/angular_driver.dart';
-import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
-import 'package:angular_analyzer_plugin/src/selector.dart';
-import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:unittest/unittest.dart';
 
 import 'analysis_test.dart';

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -73,7 +73,6 @@ abstract class AbstractCompletionContributorTest
         await angularDriver.resolveHtml(htmlPath);
       }
     }
-    await angularDriver.getStandardHtml();
   }
 }
 

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -106,8 +106,8 @@ abstract class AbstractCompletionContributorTest
     context.analysisPriorityOrder = [testSource];
     CompletionRequestImpl request = new CompletionRequestImpl(
       null,
+      context,
       null,
-      resourceProvider,
       searchEngine,
       testSource,
       completionOffset,

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -24,6 +24,10 @@ import 'package:analyzer/src/dart/analysis/driver.dart'
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/task/dart.dart';
 import 'package:angular_analyzer_plugin/src/angular_driver.dart';
+import 'package:angular_analyzer_plugin/ast.dart';
+import 'package:angular_analyzer_plugin/src/model.dart';
+import 'package:angular_analyzer_plugin/src/selector.dart';
+import 'package:angular_analyzer_plugin/tasks.dart';
 import 'package:unittest/unittest.dart';
 
 import 'analysis_test.dart';
@@ -32,61 +36,6 @@ int suggestionComparator(CompletionSuggestion s1, CompletionSuggestion s2) {
   String c1 = s1.completion.toLowerCase();
   String c2 = s2.completion.toLowerCase();
   return c1.compareTo(c2);
-}
-
-abstract class AbstractDartCompletionContributorTest
-    extends BaseCompletionContributorTest {
-  DartCompletionContributor contributor;
-  DartCompletionRequest request;
-
-  @override
-  void setUp() {
-    super.setUp();
-    contributor = createContributor();
-  }
-
-  DartCompletionContributor createContributor();
-
-  Future computeSuggestions([int times = 200]) async {
-    context.analysisPriorityOrder = [testSource];
-    CompletionRequestImpl baseRequest = new CompletionRequestImpl(
-      null,
-      context,
-      null,
-      searchEngine,
-      testSource,
-      completionOffset,
-      new CompletionPerformance(),
-      null,
-    );
-
-    // Build the request
-    Completer<DartCompletionRequest> requestCompleter =
-        new Completer<DartCompletionRequest>();
-    DartCompletionRequestImpl
-        .from(baseRequest)
-        .then((DartCompletionRequest request) {
-      requestCompleter.complete(request);
-    });
-    request = await performAnalysis(times, requestCompleter);
-
-    replacementOffset = (request as CompletionRequestImpl).replacementOffset;
-    replacementLength = (request as CompletionRequestImpl).replacementLength;
-    Completer<List<CompletionSuggestion>> suggestionCompleter =
-        new Completer<List<CompletionSuggestion>>();
-
-    // Request completions
-    contributor
-        .computeSuggestions(request)
-        .then((List<CompletionSuggestion> computedSuggestions) {
-      suggestionCompleter.complete(computedSuggestions);
-    });
-
-    // Perform analysis until the suggestions have been computed
-    // or the max analysis cycles ([times]) has been reached
-    suggestions = await performAnalysis(times, suggestionCompleter);
-    expect(suggestions, isNotNull, reason: 'expected suggestions');
-  }
 }
 
 abstract class AbstractCompletionContributorTest
@@ -103,10 +52,9 @@ abstract class AbstractCompletionContributorTest
   CompletionContributor createContributor();
 
   Future computeSuggestions([int times = 200]) async {
-    context.analysisPriorityOrder = [testSource];
     CompletionRequestImpl request = new CompletionRequestImpl(
       null,
-      context,
+      null,
       null,
       searchEngine,
       testSource,
@@ -115,32 +63,30 @@ abstract class AbstractCompletionContributorTest
       null,
     );
 
-    // Build the request
-    Completer<CompletionRequest> requestCompleter =
-        new Completer<CompletionRequest>();
-    requestCompleter.complete(request);
-    request = await performAnalysis<CompletionRequest>(times, requestCompleter);
-
-    Completer<List<CompletionSuggestion>> suggestionCompleter =
-        new Completer<List<CompletionSuggestion>>();
-
     // Request completions
-    contributor
-        .computeSuggestions(request)
-        .then((List<CompletionSuggestion> computedSuggestions) {
-      suggestionCompleter.complete(computedSuggestions);
-    });
-
-    // Perform analysis until the suggestions have been computed
-    // or the max analysis cycles ([times]) has been reached
-    suggestions = await performAnalysis(times, suggestionCompleter);
+    suggestions = await contributor.computeSuggestions(request);
     replacementOffset = request.replacementOffset;
     replacementLength = request.replacementLength;
     expect(suggestions, isNotNull, reason: 'expected suggestions');
   }
+
+  /**
+   * Compute all the views declared in the given [dartSource], and resolve the
+   * external template of all the views.
+   */
+  Future resolveSingleTemplate(Source dartSource) async {
+    final result = await angularDriver.resolveDart(dartSource.fullName);
+    for (var d in result.directives) {
+      if (d is Component && d.view.templateUriSource != null) {
+        var htmlPath = d.view.templateUriSource.fullName;
+        await angularDriver.resolveHtml(htmlPath);
+      }
+    }
+    await angularDriver.getStandardHtml();
+  }
 }
 
-abstract class BaseCompletionContributorTest extends AbstractAngularTaskTest {
+abstract class BaseCompletionContributorTest extends AbstractAngularTest {
   Index index;
   SearchEngineImpl searchEngine;
   String testFile;
@@ -563,27 +509,6 @@ abstract class BaseCompletionContributorTest extends AbstractAngularTaskTest {
     return cs;
   }
 
-  /**
-   * Return a [Future] that completes with the containing library information
-   * after it is accessible via [context.getLibrariesContaining].
-   */
-  Future computeLibrariesContaining([int times = 200]) {
-    List<Source> libraries = context.getLibrariesContaining(testSource);
-    if (libraries.isNotEmpty) {
-      return new Future.value(libraries);
-    }
-    if (times == 0) {
-      fail('failed to determine libraries containing $testSource');
-    }
-    context.performAnalysisTask();
-    // We use a delayed future to allow microtask events to finish. The
-    // Future.value or Future() constructors use scheduleMicrotask themselves and
-    // would therefore not wait for microtask callbacks that are scheduled after
-    // invoking this method.
-    return new Future.delayed(
-        Duration.ZERO, () => computeLibrariesContaining(times - 1));
-  }
-
   Future computeSuggestions([int times = 200]);
 
   void failedCompletion(String message,
@@ -628,28 +553,6 @@ abstract class BaseCompletionContributorTest extends AbstractAngularTaskTest {
       });
     }
     return cs;
-  }
-
-  Future<E> performAnalysis<E>(int times, Completer<E> completer) {
-    if (completer.isCompleted) {
-      return completer.future;
-    }
-    if (times == 0 || context == null) {
-      return new Future.value();
-    }
-    context.performAnalysisTask();
-    // We use a delayed future to allow microtask events to finish. The
-    // Future.value or Future() constructors use scheduleMicrotask themselves and
-    // would therefore not wait for microtask callbacks that are scheduled after
-    // invoking this method.
-    return new Future.delayed(
-        Duration.ZERO, () => performAnalysis(times - 1, completer));
-  }
-
-  void resolveSource(String path, String content) {
-    Source libSource = newSource(path, content);
-    var target = new LibrarySpecificUnit(libSource, libSource);
-    context.computeResult(target, RESOLVED_UNIT);
   }
 
   @override

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -19,8 +19,11 @@ import 'package:analysis_server/src/services/completion/dart/completion_manager.
     show DartCompletionRequestImpl;
 import 'package:analysis_server/src/services/index/index.dart';
 import 'package:analysis_server/src/services/search/search_engine_internal.dart';
+import 'package:analyzer/src/dart/analysis/driver.dart'
+    show AnalysisDriver, AnalysisDriverScheduler, PerformanceLog;
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/task/dart.dart';
+import 'package:angular_analyzer_plugin/src/angular_driver.dart';
 import 'package:unittest/unittest.dart';
 
 import 'analysis_test.dart';
@@ -103,8 +106,8 @@ abstract class AbstractCompletionContributorTest
     context.analysisPriorityOrder = [testSource];
     CompletionRequestImpl request = new CompletionRequestImpl(
       null,
-      context,
       null,
+      resourceProvider,
       searchEngine,
       testSource,
       completionOffset,

--- a/server_plugin/test/mock_sdk.dart
+++ b/server_plugin/test/mock_sdk.dart
@@ -4,47 +4,164 @@ import 'package:analyzer/file_system/file_system.dart' as resource;
 import 'package:analyzer/file_system/memory_file_system.dart' as resource;
 import 'package:analyzer/src/context/cache.dart';
 import 'package:analyzer/src/context/context.dart';
-import 'package:analyzer/src/generated/engine.dart'
-    show AnalysisEngine, ChangeSet;
+import 'package:analyzer/src/generated/engine.dart' show AnalysisEngine;
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
-import 'package:analyzer/src/summary/idl.dart';
+import 'package:analyzer/src/summary/idl.dart' show PackageBundle;
+import 'package:analyzer/src/summary/summary_file_builder.dart';
 
-class MockSdk implements DartSdk {
-  static const _MockSdkLibrary LIB_CORE = const _MockSdkLibrary(
-      'dart:core',
-      '/lib/core/core.dart',
-      '''
+const String librariesContent = r'''
+const Map<String, LibraryInfo> libraries = const {
+  "async": const LibraryInfo("async/async.dart"),
+  "collection": const LibraryInfo("collection/collection.dart"),
+  "convert": const LibraryInfo("convert/convert.dart"),
+  "core": const LibraryInfo("core/core.dart"),
+  "html": const LibraryInfo(
+    "html/dartium/html_dartium.dart",
+    dart2jsPath: "html/dart2js/html_dart2js.dart"),
+  "math": const LibraryInfo("math/math.dart"),
+  "_foreign_helper": const LibraryInfo("_internal/js_runtime/lib/foreign_helper.dart"),
+};
+''';
+
+const String sdkRoot = '/sdk';
+
+const _MockSdkLibrary _LIB_ASYNC = const _MockSdkLibrary(
+    'dart:async',
+    '$sdkRoot/lib/async/async.dart',
+    '''
+library dart.async;
+
+import 'dart:math';
+
+part 'stream.dart';
+
+class Future<T> {
+  factory Future(computation()) => null;
+  factory Future.delayed(Duration duration, [T computation()]) => null;
+  factory Future.value([value]) => null;
+
+  static Future<List/*<T>*/> wait/*<T>*/(
+      Iterable<Future/*<T>*/> futures) => null;
+  Future/*<R>*/ then/*<R>*/(FutureOr/*<R>*/ onValue(T value)) => null;
+
+  Future<T> whenComplete(action());
+}
+
+class FutureOr<T> {}
+
+abstract class Completer<T> {
+  factory Completer() => new _AsyncCompleter<T>();
+  factory Completer.sync() => new _SyncCompleter<T>();
+  Future<T> get future;
+  void complete([value]);
+  void completeError(Object error, [StackTrace stackTrace]);
+  bool get isCompleted;
+}
+''',
+    const <String, String>{
+      '$sdkRoot/lib/async/stream.dart': r'''
+part of dart.async;
+abstract class Stream<T> {
+  Future<T> get first;
+  StreamSubscription<T> listen(void onData(T event),
+                               { Function onError,
+                                 void onDone(),
+                                 bool cancelOnError});
+}
+
+abstract class StreamSubscription<T> {
+  Future cancel();
+  void onData(void handleData(T data));
+  void onError(Function handleError);
+  void onDone(void handleDone());
+  void pause([Future resumeSignal]);
+  void resume();
+  bool get isPaused;
+  Future<E> asFuture<E>([E futureValue]);
+}
+
+abstract class StreamTransformer<S, T> {}
+'''
+    });
+
+const _MockSdkLibrary _LIB_COLLECTION = const _MockSdkLibrary(
+    'dart:collection',
+    '$sdkRoot/lib/collection/collection.dart',
+    '''
+library dart.collection;
+
+abstract class HashMap<K, V> implements Map<K, V> {}
+''');
+
+const _MockSdkLibrary _LIB_CONVERT = const _MockSdkLibrary(
+    'dart:convert',
+    '$sdkRoot/lib/convert/convert.dart',
+    '''
+library dart.convert;
+
+import 'dart:async';
+
+abstract class Converter<S, T> implements StreamTransformer {}
+class JsonDecoder extends Converter<String, Object> {}
+''');
+
+const _MockSdkLibrary _LIB_CORE = const _MockSdkLibrary(
+    'dart:core',
+    '$sdkRoot/lib/core/core.dart',
+    '''
 library dart.core;
 
 import 'dart:async';
 
 class Object {
+  const Object() {}
   bool operator ==(other) => identical(this, other);
   String toString() => 'a string';
   int get hashCode => 0;
+  Type get runtimeType => null;
+  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 class Function {}
 class StackTrace {}
-class Symbol {}
+
+class Symbol {
+  const factory Symbol(String name) {
+    return null;
+  }
+}
+
 class Type {}
 
 abstract class Comparable<T> {
   int compareTo(T other);
 }
 
-abstract class String implements Comparable<String> {
+abstract class Pattern {}
+abstract class String implements Comparable<String>, Pattern {
   external factory String.fromCharCodes(Iterable<int> charCodes,
                                         [int start = 0, int end]);
+  String operator +(String other) => null;
   bool get isEmpty => false;
   bool get isNotEmpty => false;
   int get length => 0;
+  String substring(int len) => null;
+  String toLowerCase();
   String toUpperCase();
   List<int> get codeUnits;
 }
+abstract class RegExp implements Pattern {
+  external factory RegExp(String source);
+}
 
-class bool extends Object {}
+class bool extends Object {
+  external const factory bool.fromEnvironment(String name,
+                                              {bool defaultValue: false});
+}
+
+abstract class Invocation {}
+
 abstract class num implements Comparable<num> {
   bool operator <(num other);
   bool operator <=(num other);
@@ -54,20 +171,75 @@ abstract class num implements Comparable<num> {
   num operator -(num other);
   num operator *(num other);
   num operator /(num other);
+  int operator ^(int other);
+  int operator |(int other);
+  int operator <<(int other);
+  int operator >>(int other);
+  int operator ~/(num other);
+  num operator %(num other);
+  int operator ~();
+  num operator -();
   int toInt();
+  double toDouble();
   num abs();
   int round();
 }
 abstract class int extends num {
+  external const factory int.fromEnvironment(String name, {int defaultValue});
+
+  bool get isNegative;
   bool get isEven => false;
+
+  int operator &(int other);
+  int operator |(int other);
+  int operator ^(int other);
+  int operator ~();
+  int operator <<(int shiftAmount);
+  int operator >>(int shiftAmount);
+
   int operator -();
+
   external static int parse(String source,
                             { int radix,
                               int onError(String source) });
 }
-class double extends num {}
+
+abstract class double extends num {
+  static const double NAN = 0.0 / 0.0;
+  static const double INFINITY = 1.0 / 0.0;
+  static const double NEGATIVE_INFINITY = -INFINITY;
+  static const double MIN_POSITIVE = 5e-324;
+  static const double MAX_FINITE = 1.7976931348623157e+308;
+
+  double remainder(num other);
+  double operator +(num other);
+  double operator -(num other);
+  double operator *(num other);
+  double operator %(num other);
+  double operator /(num other);
+  int operator ~/(num other);
+  double operator -();
+  double abs();
+  double get sign;
+  int round();
+  int floor();
+  int ceil();
+  int truncate();
+  double roundToDouble();
+  double floorToDouble();
+  double ceilToDouble();
+  double truncateToDouble();
+  external static double parse(String source,
+                               [double onError(String source)]);
+}
+
 class DateTime extends Object {}
-class Null extends Object {}
+
+class Null extends Object {
+  factory Null._uninstantiable() {
+    throw new UnsupportedError('class Null cannot be instantiated');
+  }
+}
 
 class Deprecated extends Object {
   final String expires;
@@ -83,79 +255,211 @@ class Iterator<E> {
 abstract class Iterable<E> {
   Iterator<E> get iterator;
   bool get isEmpty;
+  E get first;
+
+  Iterable/*<R>*/ map/*<R>*/(/*=R*/ f(E e));
+
+  /*=R*/ fold/*<R>*/(/*=R*/ initialValue,
+      /*=R*/ combine(/*=R*/ previousValue, E element));
+
+  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(E element));
+
+  List<E> toList();
 }
 
-abstract class List<E> implements Iterable<E> {
-  void add(E value);
-  E operator [](int index);
-  void operator []=(int index, E value);
+class List<E> implements Iterable<E> {
+  List();
+  void add(E value) {}
+  void addAll(Iterable<E> iterable) {}
+  E operator [](int index) => null;
+  void operator []=(int index, E value) {}
   Iterator<E> get iterator => null;
-  void clear();
+  void clear() {}
+
+  bool get isEmpty => false;
+  E get first => null;
+  E get last => null;
+
+  Iterable/*<R>*/ map/*<R>*/(/*=R*/ f(E e)) => null;
+
+  /*=R*/ fold/*<R>*/(/*=R*/ initialValue,
+      /*=R*/ combine(/*=R*/ previousValue, E element)) => null;
+
 }
 
-abstract class Map<K, V> extends Object {
-  Iterable<K> get keys;
+class Map<K, V> extends Object {
+  V operator [](K key) => null;
+  void operator []=(K key, V value) {}
+  Iterable<K> get keys => null;
+  int get length;
+  Iterable<V> get values;
 }
 
 external bool identical(Object a, Object b);
 
 void print(Object object) {}
 
-class _Override {
-  const _Override();
-}
+class _Proxy { const _Proxy(); }
+const Object proxy = const _Proxy();
+
+class _Override { const _Override(); }
 const Object override = const _Override();
 ''');
 
-  static const _MockSdkLibrary LIB_ASYNC = const _MockSdkLibrary(
-      'dart:async',
-      '/lib/async/async.dart',
-      '''
-library dart.async;
+const _MockSdkLibrary _LIB_FOREIGN_HELPER = const _MockSdkLibrary(
+    'dart:_foreign_helper',
+    '$sdkRoot/lib/_foreign_helper/_foreign_helper.dart',
+    '''
+library dart._foreign_helper;
 
-import 'dart:math';
-
-class Future<T> {
-  factory Future.delayed(Duration duration, [T computation()]) => null;
-  factory Future.value([value]) => null;
-  static Future wait(List<Future> futures) => null;
-}
-
-class Stream<T> {}
-abstract class StreamTransformer<S, T> {}
+JS(String typeDescription, String codeTemplate,
+  [arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11])
+{}
 ''');
 
-  static const _MockSdkLibrary LIB_COLLECTION = const _MockSdkLibrary(
-      'dart:collection',
-      '/lib/collection/collection.dart',
-      '''
-library dart.collection;
-
-abstract class HashMap<K, V> implements Map<K, V> {}
+const _MockSdkLibrary _LIB_HTML_DART2JS = const _MockSdkLibrary(
+    'dart:html',
+    '$sdkRoot/lib/html/dartium/html_dartium.dart',
+    '''
+library dart.html;
+class HtmlElement {}
 ''');
 
-  static const _MockSdkLibrary LIB_CONVERT = const _MockSdkLibrary(
-      'dart:convert',
-      '/lib/convert/convert.dart',
-      '''
-library dart.convert;
-
+const _MockSdkLibrary _LIB_HTML_DARTIUM = const _MockSdkLibrary(
+    'dart:html',
+    '$sdkRoot/lib/html/dartium/html_dartium.dart',
+    '''
+library dart.html;
 import 'dart:async';
 
-abstract class Converter<S, T> implements StreamTransformer {}
-class JsonDecoder extends Converter<String, Object> {}
+class Event {}
+class MouseEvent extends Event {}
+
+class DomName {
+  final String name;
+  const DomName(this.name);
+}
+
+abstract class ElementStream<T extends Event> implements Stream<T> {}
+
+abstract class Element {
+  /// Stream of `cut` events handled by this [Element].
+  @DomName('Element.oncut')
+  ElementStream<Event> get onCut => null;
+  
+  @DomName('Element.id')
+  String get id => null;
+  
+  @DomName('Element.id')
+  set id(String value) => null;
+}
+
+class HtmlElement extends Element {
+  int tabIndex;
+  @DomName('Element.onchange')
+  ElementStream<Event> get onChange => null;
+  @DomName('Element.onclick')
+  ElementStream<MouseEvent> get onClick => null;
+  @DomName('Element.onkeyup')
+  ElementStream<Event> get onKeyUp => null;
+  
+  @DomName('HTMLElement.hidden')
+  bool get hidden => null;
+  @DomName('HTMLElement.hidden')
+  set hidden(bool value) => null;
+}
+
+dynamic JS(a, b, c, d) {}
+
+class AnchorElement extends HtmlElement {
+  factory AnchorElement({String href}) {
+    AnchorElement e = JS('returns:AnchorElement;creates:AnchorElement;new:true',
+        '#.createElement(#)', document, "a");
+    if (href != null) e.href = href;
+    return e;
+  }
+  String href;
+  String _privateField;
+}
+
+@DomName('HTMLBodyElement')
+class BodyElement extends HtmlElement {
+  factory BodyElement() => document.createElement("body");
+
+  @DomName('HTMLBodyElement.onunload')
+  ElementStream<Event> get onUnload => null;
+}
+
+class ButtonElement extends HtmlElement {
+  factory ButtonElement._() { throw new UnsupportedError("Not supported"); }
+  factory ButtonElement() => document.createElement("button");
+  bool autofocus;
+}
+
+class HeadingElement extends HtmlElement {
+  factory HeadingElement._() { throw new UnsupportedError("Not supported"); }
+  factory HeadingElement.h1() => document.createElement("h1");
+  factory HeadingElement.h2() => document.createElement("h2");
+  factory HeadingElement.h3() => document.createElement("h3");
+}
+
+class InputElement extends HtmlElement {
+  factory InputElement._() { throw new UnsupportedError("Not supported"); }
+  factory InputElement() => document.createElement("input");
+  String value;
+  String validationMessage;
+}
+
+class OptionElement extends HtmlElement {                                        
+  factory OptionElement({String data: '', String value : '', bool selected: false}) {
+  }                                                                              
+                                                                                 
+  @DomName('HTMLOptionElement.HTMLOptionElement')                                
+  @DocsEditable()                                                                
+  factory OptionElement._([String data, String value, bool defaultSelected, bool selected]) {
+  }    
+}
+
+class TableSectionElement extends HtmlElement {
+
+  @DomName('HTMLTableSectionElement.rows')
+  List<TableRowElement> get rows => null;
+
+  TableRowElement addRow() {
+  }
+
+  TableRowElement insertRow(int index) => null;
+
+  factory TableSectionElement._() { throw new UnsupportedError("Not supported"); }
+
+  @Deprecated("Internal Use Only")
+  external static Type get instanceRuntimeType;
+
+  @Deprecated("Internal Use Only")
+  TableSectionElement.internal_() : super.internal_();
+}
 ''');
 
-  static const _MockSdkLibrary LIB_MATH = const _MockSdkLibrary(
-      'dart:math',
-      '/lib/math/math.dart',
-      '''
+const _MockSdkLibrary _LIB_INTERCEPTORS = const _MockSdkLibrary(
+    'dart:_interceptors',
+    '$sdkRoot/lib/_internal/js_runtime/lib/interceptors.dart',
+    '''
+library dart._interceptors;
+''');
+
+const _MockSdkLibrary _LIB_MATH = const _MockSdkLibrary(
+    'dart:math',
+    '$sdkRoot/lib/math/math.dart',
+    '''
 library dart.math;
+
 const double E = 2.718281828459045;
 const double PI = 3.1415926535897932;
 const double LN10 =  2.302585092994046;
-num min(num a, num b) => 0;
-num max(num a, num b) => 0;
+
+T min<T extends num>(T a, T b) => null;
+T max<T extends num>(T a, T b) => null;
+
 external double cos(num x);
 external double sin(num x);
 external double sqrt(num x);
@@ -166,56 +470,77 @@ class Random {
 }
 ''');
 
-  static const _MockSdkLibrary LIB_HTML = const _MockSdkLibrary(
-      'dart:html',
-      '/lib/html/dartium/html_dartium.dart',
-      '''
-library dart.html;
-import 'dart:async';
-class DomName {
-  final String name;
-  const DomName(this.name);
-}
+const List<SdkLibrary> _LIBRARIES = const [
+  _LIB_CORE,
+  _LIB_ASYNC,
+  _LIB_COLLECTION,
+  _LIB_CONVERT,
+  _LIB_FOREIGN_HELPER,
+  _LIB_MATH,
+  _LIB_HTML_DART2JS,
+  _LIB_HTML_DARTIUM,
+  _LIB_INTERCEPTORS,
+];
 
-class Event {}
-class MouseEvent extends Event {}
-abstract class ElementStream<T extends Event> implements Stream<T> {}
+class MockSdk implements DartSdk {
+  static const Map<String, String> FULL_URI_MAP = const {
+    "dart:core": "$sdkRoot/lib/core/core.dart",
+    "dart:html": "$sdkRoot/lib/html/dartium/html_dartium.dart",
+    "dart:async": "$sdkRoot/lib/async/async.dart",
+    "dart:async/stream.dart": "$sdkRoot/lib/async/stream.dart",
+    "dart:collection": "$sdkRoot/lib/collection/collection.dart",
+    "dart:convert": "$sdkRoot/lib/convert/convert.dart",
+    "dart:_foreign_helper": "$sdkRoot/lib/_foreign_helper/_foreign_helper.dart",
+    "dart:_interceptors":
+        "$sdkRoot/lib/_internal/js_runtime/lib/interceptors.dart",
+    "dart:math": "$sdkRoot/lib/math/math.dart"
+  };
 
-class HtmlElement {
-  @DomName('Element.onclick')
-  ElementStream<MouseEvent> get onClick => null;
-  @DomName('Element.hidden')
-  bool hidden;
-}
+  static const Map<String, String> NO_ASYNC_URI_MAP = const {
+    "dart:core": "$sdkRoot/lib/core/core.dart",
+  };
 
-class ButtonElement extends HtmlElement {
-  factory ButtonElement._() { throw new UnsupportedError("Not supported"); }
-  factory ButtonElement() => document.createElement("button");
-  bool autofocus;
-}
-''');
+  final resource.MemoryResourceProvider provider;
 
-  static const List<SdkLibrary> LIBRARIES = const [
-    LIB_CORE,
-    LIB_ASYNC,
-    LIB_COLLECTION,
-    LIB_CONVERT,
-    LIB_MATH,
-    LIB_HTML,
-  ];
-
-  final resource.MemoryResourceProvider provider =
-      new resource.MemoryResourceProvider();
+  final Map<String, String> uriMap;
 
   /**
-   * The [AnalysisContext] which is used for all of the sources.
+   * The [AnalysisContextImpl] which is used for all of the sources.
    */
   AnalysisContextImpl _analysisContext;
 
-  MockSdk() {
-    LIBRARIES.forEach((SdkLibrary library) {
-      provider.newFile(library.path, (library as _MockSdkLibrary).content);
-    });
+  @override
+  final List<SdkLibrary> sdkLibraries;
+
+  /**
+   * The cached linked bundle of the SDK.
+   */
+  PackageBundle _bundle;
+
+  MockSdk(
+      {bool generateSummaryFiles: false,
+      bool dartAsync: true,
+      resource.MemoryResourceProvider resourceProvider})
+      : provider = resourceProvider ?? new resource.MemoryResourceProvider(),
+        sdkLibraries = dartAsync ? _LIBRARIES : [_LIB_CORE],
+        uriMap = dartAsync ? FULL_URI_MAP : NO_ASYNC_URI_MAP {
+    for (_MockSdkLibrary library in sdkLibraries) {
+      provider.newFile(provider.convertPath(library.path), library.content);
+      library.parts.forEach((String path, String content) {
+        provider.newFile(provider.convertPath(path), content);
+      });
+    }
+    provider.newFile(
+        provider.convertPath(
+            '$sdkRoot/lib/_internal/sdk_library_metadata/lib/libraries.dart'),
+        librariesContent);
+    if (generateSummaryFiles) {
+      List<int> bytes = _computeLinkedBundleBytes();
+      provider.newFileWithBytes(
+          provider.convertPath('/lib/_internal/spec.sum'), bytes);
+      provider.newFileWithBytes(
+          provider.convertPath('/lib/_internal/strong.sum'), bytes);
+    }
   }
 
   @override
@@ -224,57 +549,42 @@ class ButtonElement extends HtmlElement {
       _analysisContext = new _SdkAnalysisContext(this);
       SourceFactory factory = new SourceFactory([new DartUriResolver(this)]);
       _analysisContext.sourceFactory = factory;
-      ChangeSet changeSet = new ChangeSet();
-      for (String uri in uris) {
-        Source source = factory.forUri(uri);
-        changeSet.addedSource(source);
-      }
-      _analysisContext.applyChanges(changeSet);
     }
     return _analysisContext;
   }
 
   @override
-  List<SdkLibrary> get sdkLibraries => LIBRARIES;
+  String get sdkVersion => throw new UnimplementedError();
 
   @override
-  String get sdkVersion => throw unimplemented;
-
-  UnimplementedError get unimplemented => new UnimplementedError();
-
-  @override
-  List<String> get uris {
-    List<String> uris = <String>[];
-    for (SdkLibrary library in LIBRARIES) {
-      uris.add(library.shortName);
-    }
-    return uris;
-  }
+  List<String> get uris =>
+      sdkLibraries.map((SdkLibrary library) => library.shortName).toList();
 
   @override
   Source fromFileUri(Uri uri) {
-    String filePath = uri.path;
-    String libPath = '/lib';
-    if (!filePath.startsWith("$libPath/")) {
+    String filePath = provider.pathContext.fromUri(uri);
+    if (!filePath.startsWith(provider.convertPath('$sdkRoot/lib/'))) {
       return null;
     }
-    for (SdkLibrary library in LIBRARIES) {
-      String libraryPath = library.path;
-      if (filePath.replaceAll('\\', '/') == libraryPath) {
+    for (SdkLibrary library in sdkLibraries) {
+      String libraryPath = provider.convertPath(library.path);
+      if (filePath == libraryPath) {
         try {
-          resource.File file = provider.getResource(uri.path);
+          resource.File file = provider.getResource(filePath);
           Uri dartUri = Uri.parse(library.shortName);
           return file.createSource(dartUri);
         } catch (exception) {
           return null;
         }
       }
-      if (filePath.startsWith("$libraryPath/")) {
-        String pathInLibrary = filePath.substring(libraryPath.length + 1);
-        String path = '${library.shortName}/${pathInLibrary}';
+      String libraryRootPath = provider.pathContext.dirname(libraryPath) +
+          provider.pathContext.separator;
+      if (filePath.startsWith(libraryRootPath)) {
+        String pathInLibrary = filePath.substring(libraryRootPath.length);
+        String uriStr = '${library.shortName}/$pathInLibrary';
         try {
-          resource.File file = provider.getResource(uri.path);
-          Uri dartUri = new Uri(scheme: 'dart', path: path);
+          resource.File file = provider.getResource(filePath);
+          Uri dartUri = Uri.parse(uriStr);
           return file.createSource(dartUri);
         } catch (exception) {
           return null;
@@ -285,69 +595,100 @@ class ButtonElement extends HtmlElement {
   }
 
   @override
+  PackageBundle getLinkedBundle() {
+    if (_bundle == null) {
+      resource.File summaryFile =
+          provider.getFile(provider.convertPath('/lib/_internal/spec.sum'));
+      List<int> bytes;
+      if (summaryFile.exists) {
+        bytes = summaryFile.readAsBytesSync();
+      } else {
+        bytes = _computeLinkedBundleBytes();
+      }
+      _bundle = new PackageBundle.fromBuffer(bytes);
+    }
+    return _bundle;
+  }
+
+  @override
   SdkLibrary getSdkLibrary(String dartUri) {
-    // getSdkLibrary() is only used to determine whether a library is internal
-    // to the SDK.  The mock SDK doesn't have any internals, so it's safe to
-    // return null.
+    for (SdkLibrary library in _LIBRARIES) {
+      if (library.shortName == dartUri) {
+        return library;
+      }
+    }
     return null;
   }
 
   @override
   Source mapDartUri(String dartUri) {
-    const Map<String, String> uriToPath = const {
-      "dart:core": "/lib/core/core.dart",
-      "dart:html": "/lib/html/dartium/html_dartium.dart",
-      "dart:async": "/lib/async/async.dart",
-      "dart:collection": "/lib/collection/collection.dart",
-      "dart:convert": "/lib/convert/convert.dart",
-      "dart:math": "/lib/math/math.dart"
-    };
-
-    String path = uriToPath[dartUri];
+    String path = uriMap[dartUri];
     if (path != null) {
-      resource.File file = provider.getResource(path);
+      resource.File file = provider.getResource(provider.convertPath(path));
       Uri uri = new Uri(scheme: 'dart', path: dartUri.substring(5));
       return file.createSource(uri);
     }
-
     // If we reach here then we tried to use a dartUri that's not in the
     // table above.
     return null;
   }
 
-  @override
-  PackageBundle getLinkedBundle() => null;
+  /**
+   * This method is used to apply patches to [MockSdk].  It may be called only
+   * before analysis, i.e. before the analysis context was created.
+   */
+  void updateUriFile(String uri, String updateContent(String content)) {
+    assert(_analysisContext == null);
+    String path = FULL_URI_MAP[uri];
+    assert(path != null);
+    path = provider.convertPath(path);
+    String content = provider.getFile(path).readAsStringSync();
+    String newContent = updateContent(content);
+    provider.updateFile(path, newContent);
+  }
+
+  /**
+   * Compute the bytes of the linked bundle associated with this SDK.
+   */
+  List<int> _computeLinkedBundleBytes() {
+    List<Source> librarySources = sdkLibraries
+        .map((SdkLibrary library) => mapDartUri(library.shortName))
+        .toList();
+    return new SummaryBuilder(
+            librarySources, context, context.analysisOptions.strongMode)
+        .build();
+  }
 }
 
 class _MockSdkLibrary implements SdkLibrary {
   final String shortName;
   final String path;
   final String content;
+  final Map<String, String> parts;
 
-  const _MockSdkLibrary(this.shortName, this.path, this.content);
-
-  @override
-  String get category => throw unimplemented;
-
-  @override
-  bool get isDart2JsLibrary => throw unimplemented;
+  const _MockSdkLibrary(this.shortName, this.path, this.content,
+      [this.parts = const <String, String>{}]);
 
   @override
-  bool get isDocumented => throw unimplemented;
+  String get category => throw new UnimplementedError();
 
   @override
-  bool get isImplementation => throw unimplemented;
+  bool get isDart2JsLibrary => throw new UnimplementedError();
 
   @override
-  bool get isInternal => throw unimplemented;
+  bool get isDocumented => throw new UnimplementedError();
 
   @override
-  bool get isShared => throw unimplemented;
+  bool get isImplementation => throw new UnimplementedError();
 
   @override
-  bool get isVmLibrary => throw unimplemented;
+  bool get isInternal => shortName.startsWith('dart:_');
 
-  UnimplementedError get unimplemented => new UnimplementedError();
+  @override
+  bool get isShared => throw new UnimplementedError();
+
+  @override
+  bool get isVmLibrary => throw new UnimplementedError();
 }
 
 /**


### PR DESCRIPTION
Added support for autocompletion on .html files. Inline HTML found within .dart files still does not have support yet; will add them once plugin support is added. 

Breakdown: 
* Re-added directives into view.directives.
* Minor '.toList()' conversions to help with debugging.
* 'sendAngularCompletions()' is the primary function that will be called within the analysis_server to enable .html autocompletion.
* Contributor condensed into a single contributor; no longer separate ones for .dart-inline and .html.
* New base test case added for server tests: 'AbstractAngularTest' instead of 'AbstractAngularTaskTest'.

mock_sdk.dart is a copy and paste from analyzer component; no need for review.