### PR TITLE
Autocomplete stars

### DIFF
--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -231,10 +231,10 @@ abstract class HasDirectives {
 /// Naming here is important: "bound directive" != "directive binding."
 class DirectiveBinding {
   final AbstractDirective boundDirective;
-  final List<InputBinding> inputBindings = [];
-  final List<OutputBinding> outputBindings = [];
-  final Map<ContentChild, ContentChildBinding> contentChildBindings = {};
-  final Map<ContentChild, ContentChildBinding> contentChildrenBindings = {};
+  final inputBindings = <InputBinding>[];
+  final outputBindings = <OutputBinding>[];
+  final contentChildBindings = <ContentChild, ContentChildBinding>{};
+  final contentChildrenBindings = <ContentChild, ContentChildBinding>{};
 
   DirectiveBinding(this.boundDirective);
 }

--- a/analyzer_plugin/lib/ast.dart
+++ b/analyzer_plugin/lib/ast.dart
@@ -97,11 +97,15 @@ class TemplateAttribute extends BoundAttributeInfo implements HasDirectives {
   final boundStandardOutputs = <OutputBinding>[];
   @override
   final boundStandardInputs = <InputBinding>[];
+
   List<AbstractDirective> get directives =>
       boundDirectives.map((bd) => bd.boundDirective).toList();
 
+  String prefix;
+
   TemplateAttribute(String name, int nameOffset, String value, int valueOffset,
-      String originalName, int originalNameOffset, this.virtualAttributes)
+      String originalName, int originalNameOffset, this.virtualAttributes,
+      {this.prefix})
       : super(name, nameOffset, value, valueOffset, originalName,
             originalNameOffset);
 
@@ -164,12 +168,10 @@ class TextAttribute extends AttributeInfo {
   final List<Mustache> mustaches;
   @override
   List<AngularAstNode> get children => new List<AngularAstNode>.from(mustaches);
-  final bool fromTemplate;
 
   TextAttribute(String name, int nameOffset, String value, int valueOffset,
       this.mustaches)
-      : fromTemplate = false,
-        super(name, nameOffset, value, valueOffset, name, nameOffset);
+      : super(name, nameOffset, value, valueOffset, name, nameOffset);
 
   TextAttribute.synthetic(
       String name,
@@ -179,8 +181,7 @@ class TextAttribute extends AttributeInfo {
       String originalName,
       int originalNameOffset,
       this.mustaches)
-      : fromTemplate = true,
-        super(name, nameOffset, value, valueOffset, originalName,
+      : super(name, nameOffset, value, valueOffset, originalName,
             originalNameOffset);
 
   @override

--- a/analyzer_plugin/lib/src/directive_linking.dart
+++ b/analyzer_plugin/lib/src/directive_linking.dart
@@ -326,6 +326,12 @@ class ChildDirectiveLinker implements DirectiveMatcher {
           await _fileDirectiveProvider.getHtmlNgContent(source.fullName));
     }
 
+    // NOTE: Require the Exact type TemplateRef because that's what the
+    // injector does.
+    directive.looksLikeTemplate = directive.classElement.constructors.any(
+        (constructor) => constructor.parameters
+            .any((param) => param.type == _standardAngular.templateRef.type));
+
     // ignore errors from linking subcomponents content childs
     final errorIgnorer = new ErrorReporter(
         new IgnoringErrorListener(), directive.classElement.source);

--- a/analyzer_plugin/lib/src/model.dart
+++ b/analyzer_plugin/lib/src/model.dart
@@ -38,6 +38,14 @@ abstract class AbstractDirective {
   final contentChilds = <ContentChild>[];
   final contentChildren = <ContentChild>[];
 
+  /**
+   * Its very hard to tell which directives are meant to be used with a *star.
+   * However, any directives which have a `TemplateRef` as a constructor
+   * parameter are almost certainly meant to be used with one. We use this for
+   * whatever validation we can, and autocomplete suggestions.
+   */
+  bool looksLikeTemplate = false;
+
   AbstractDirective(this.classElement,
       {this.exportAs,
       this.inputs,

--- a/analyzer_plugin/lib/src/model.dart
+++ b/analyzer_plugin/lib/src/model.dart
@@ -38,12 +38,10 @@ abstract class AbstractDirective {
   final contentChilds = <ContentChild>[];
   final contentChildren = <ContentChild>[];
 
-  /**
-   * Its very hard to tell which directives are meant to be used with a *star.
-   * However, any directives which have a `TemplateRef` as a constructor
-   * parameter are almost certainly meant to be used with one. We use this for
-   * whatever validation we can, and autocomplete suggestions.
-   */
+  /// Its very hard to tell which directives are meant to be used with a *star.
+  /// However, any directives which have a `TemplateRef` as a constructor
+  /// parameter are almost certainly meant to be used with one. We use this for
+  /// whatever validation we can, and autocomplete suggestions.
   bool looksLikeTemplate = false;
 
   AbstractDirective(this.classElement,

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -710,7 +710,7 @@ class DirectiveResolver extends AngularAstVisitor {
           outerBindings.add(binding);
         }
 
-        // Specifically exclude NgIfand NgFor, they have their own error since
+        // Specifically exclude NgIf and NgFor, they have their own error since
         // we *know* they require a template.
         if (directive.looksLikeTemplate &&
             !element.isTemplate &&

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -37,6 +37,8 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.INVALID_CSS_PROPERTY_NAME,
   AngularWarningCode.INVALID_BINDING_NAME,
   AngularWarningCode.STRUCTURAL_DIRECTIVES_REQUIRE_TEMPLATE,
+  AngularWarningCode.CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE,
+  AngularWarningCode.TEMPLATE_ATTR_NOT_USED,
   AngularWarningCode.NO_DIRECTIVE_EXPORTED_BY_SPECIFIED_NAME,
   AngularWarningCode.OFFSETS_CANNOT_BE_CREATED,
   AngularWarningCode.CONTENT_NOT_TRANSCLUDED,
@@ -253,6 +255,21 @@ class AngularWarningCode extends ErrorCode {
   static const NO_DIRECTIVE_EXPORTED_BY_SPECIFIED_NAME =
       const AngularWarningCode('NO_DIRECTIVE_EXPORTED_BY_SPECIFIED_NAME',
           'No directives matching this element are exported by the name {0}');
+
+  /// An error code indicating that a custom component appears to require a star.
+  static const AngularWarningCode CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE =
+      const AngularWarningCode(
+          'CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE',
+          'The directive {0} accepts a TemplateRef in its constructor,' +
+              ' so it may require a *-style-attr to work correctly.');
+
+  /// An error code indicating that a custom component appears to require a star.
+  static const AngularWarningCode TEMPLATE_ATTR_NOT_USED =
+      const AngularWarningCode(
+          'TEMPLATE_ATTR_NOT_USED',
+          'This template attr does not match any directives that use the'
+          ' resulting hidden template. Check that all directives are being'
+          ' imported and used correctly.');
 
   /// An error code indicating that an output-bound statement
   /// must be an [ExpressionStatement].

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -260,8 +260,8 @@ class AngularWarningCode extends ErrorCode {
   static const AngularWarningCode CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE =
       const AngularWarningCode(
           'CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE',
-          'The directive {0} accepts a TemplateRef in its constructor,' +
-              ' so it may require a *-style-attr to work correctly.');
+          'The directive {0} accepts a TemplateRef in its constructor, so it'
+          ' may require a *-style-attr to work correctly.');
 
   /// An error code indicating that a custom component appears to require a star.
   static const AngularWarningCode TEMPLATE_ATTR_NOT_USED =

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -305,6 +305,7 @@ import 'metadata.dart';
 
 @Directive(selector: "[ngIf]", inputs: const ["ngIf"])
 class NgIf {
+  NgIf(TemplateRef tpl);
   set ngIf(newCondition) {}
 }
 ''');
@@ -317,6 +318,7 @@ import 'metadata.dart';
     selector: "[ngFor][ngForOf]",
     inputs: const ["ngForOf", "ngForTemplate"])
 class NgFor {
+  NgFor(TemplateRef tpl);
   set ngForOf(dynamic value) {}
 }
 ''');

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2385,6 +2385,151 @@ class TestPanel {
   }
 
   // ignore: non_constant_identifier_names
+  Future test_customDirective_noStarError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [CustomTemplateDirective])
+class TestPanel {
+}
+
+@Directive(selector: '[customTemplateDirective]')
+class CustomTemplateDirective {
+  CustomTemplateDirective(TemplateRef tpl);
+}
+''');
+    final code = r"""
+<div customTemplateDirective></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE,
+        code,
+        "<div customTemplateDirective>");
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customDirective_withStarOk() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [CustomTemplateDirective])
+class TestPanel {
+}
+
+@Directive(selector: '[customTemplateDirective]')
+class CustomTemplateDirective {
+  CustomTemplateDirective(TemplateRef tpl);
+}
+''');
+    final code = r"""
+<div *customTemplateDirective></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customDirective_asTemplateAttrOk() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html',
+    directives: const [CustomTemplateDirective])
+class TestPanel {
+}
+
+@Directive(selector: '[customTemplateDirective]')
+class CustomTemplateDirective {
+  CustomTemplateDirective(TemplateRef tpl);
+}
+''');
+    final code = r"""
+<div template="customTemplateDirective"></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customDirective_starDoesntTakeTemplateError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NotTemplateDirective])
+class TestPanel {
+}
+
+@Directive(selector: '[notTemplateDirective]')
+class NotTemplateDirective {
+}
+''');
+    final code = r"""
+<div *notTemplateDirective></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(AngularWarningCode.TEMPLATE_ATTR_NOT_USED, code,
+        "*notTemplateDirective");
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_starNoDirectives() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [])
+class TestPanel {
+}
+''');
+    final code = r"""
+<div *foo></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TEMPLATE_ATTR_NOT_USED, code, "*foo");
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customDirective_templateDoesntTakeTemplateError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [NotTemplateDirective])
+class TestPanel {
+}
+
+@Directive(selector: '[notTemplateDirective]')
+class NotTemplateDirective {
+}
+''');
+    final code = r"""
+<div template="notTemplateDirective"></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TEMPLATE_ATTR_NOT_USED, code, 'template');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_templateNoDirectives() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel')
+@View(templateUrl: 'test_panel.html', directives: const [])
+class TestPanel {
+}
+''');
+    final code = r"""
+<div template="foo"></div>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.TEMPLATE_ATTR_NOT_USED, code, 'template');
+  }
+
+  // ignore: non_constant_identifier_names
   Future test_ngFor_star_itemHiddenInElement() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel')
@@ -2724,7 +2869,9 @@ class TestPanel {
   Future test_template_attribute_withoutValue() async {
     _addDartSource(r'''
 @Directive(selector: '[deferred-content]')
-class DeferredContentDirective {}
+class DeferredContentDirective {
+  DeferredContentDirective(TemplateRef tpl);
+}
 
 @Component(selector: 'test-panel')
 @View(

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -360,7 +360,7 @@ class TemplateCompleter {
     } else if (target is ElementInfo) {
       suggestHtmlTags(template, suggestions);
       suggestTransclusions(target, suggestions);
-    } else if (target.parent is TemplateAttribute) {
+    } else if (target is AttributeInfo && target.parent is TemplateAttribute) {
       // `let foo`. Nothing to suggest.
       if (target is TextAttribute && target.name.startsWith("let-")) {
         return suggestions;

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -708,10 +708,10 @@ class TemplateCompleter {
       InputElement inputElement,
       int defaultRelevance,
       protocol.Element element) {
-    final completionCapitalized = inputElement.name.substring(prefix.length);
-    // ignore: prefer_interpolation_to_compose_strings
-    final completion = completionCapitalized.substring(0, 1).toLowerCase() +
-        completionCapitalized.substring(1);
+    final capitalized = inputElement.name.substring(prefix.length);
+    final firstLetter = capitalized.substring(0, 1).toLowerCase();
+    final remaining = capitalized.substring(1);
+    final completion = '$firstLetter$remaining:';
     return new CompletionSuggestion(CompletionSuggestionKind.INVOCATION,
         defaultRelevance, completion, completion.length, 0, false, false,
         element: element);

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -533,7 +533,7 @@ class TemplateCompleter {
           .map((b) => b.boundInput)).toSet();
 
       for (final input in binding.boundDirective.inputs) {
-        // don't recommend [name] [name] [name]
+        // don't recommend trackBy: x trackBy: x trackBy: x
         if (usedInputs.contains(input)) {
           continue;
         }

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -412,6 +412,7 @@ library angular2;
 
 export 'src/core/async.dart';
 export 'src/core/metadata.dart';
+export 'src/core/linker/template_ref.dart';
 export 'src/core/ng_if.dart';
 export 'src/core/ng_for.dart';
 ''');
@@ -536,9 +537,11 @@ class EventEmitter<T> extends Stream<T> {
         r'''
 library angular2.ng_if;
 import 'metadata.dart';
+import 'linker/template_ref.dart';
 
 @Directive(selector: "[ngIf]", inputs: const ["ngIf"])
 class NgIf {
+  NgIf(TemplateRef tpl);
   set ngIf(newCondition) {}
 }
 ''');
@@ -547,16 +550,25 @@ class NgIf {
         r'''
 library angular2.ng_for;
 import 'metadata.dart';
+import 'linker/template_ref.dart';
 
 @Directive(
     selector: "[ngFor][ngForOf]",
     inputs: const ["ngForOf", "ngForTemplate", "ngForTrackBy"])
 class NgFor {
+  NgFor(TemplateRef tpl);
   set ngForOf(dynamic value) {}
   set ngForTrackBy(TrackByFn value) {}
 }
 
 typedef dynamic TrackByFn(num index, dynamic item);
+''');
+    newSource(
+        '/angular2/src/core/linker/template_ref.dart',
+        r'''
+library angular2.template_ref;
+
+class TemplateRef {}
 ''');
   }
 
@@ -648,6 +660,7 @@ library angular2;
 
 export 'src/core/async.dart';
 export 'src/core/metadata.dart';
+export 'src/core/linker/template_ref.dart';
 export 'src/core/ng_if.dart';
 export 'src/core/ng_for.dart';
 ''');
@@ -772,9 +785,11 @@ class EventEmitter<T> extends Stream<T> {
         r'''
 library angular2.ng_if;
 import 'metadata.dart';
+import 'linker/template_ref.dart';
 
 @Directive(selector: "[ngIf]", inputs: const ["ngIf"])
 class NgIf {
+  NgIf(TemplateRef tpl);
   set ngIf(newCondition) {}
 }
 ''');
@@ -783,16 +798,25 @@ class NgIf {
         r'''
 library angular2.ng_for;
 import 'metadata.dart';
+import 'linker/template_ref.dart';
 
 @Directive(
     selector: "[ngFor][ngForOf]",
     inputs: const ["ngForOf", "ngForTemplate", "ngForTrackBy"])
 class NgFor {
+  NgFor(TemplateRef tpl);
   set ngForOf(dynamic value) {}
   set ngForTrackBy(TrackByFn value) {}
 }
 
 typedef dynamic TrackByFn(num index, dynamic item);
+''');
+    newSource(
+        '/angular2/src/core/linker/template_ref.dart',
+        r'''
+library angular2.template_ref;
+
+class TemplateRef {}
 ''');
   }
 }

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -550,10 +550,13 @@ import 'metadata.dart';
 
 @Directive(
     selector: "[ngFor][ngForOf]",
-    inputs: const ["ngForOf", "ngForTemplate"])
+    inputs: const ["ngForOf", "ngForTemplate", "ngForTrackBy"])
 class NgFor {
   set ngForOf(dynamic value) {}
+  set ngForTrackBy(TrackByFn value) {}
 }
+
+typedef dynamic TrackByFn(num index, dynamic item);
 ''');
   }
 
@@ -783,10 +786,13 @@ import 'metadata.dart';
 
 @Directive(
     selector: "[ngFor][ngForOf]",
-    inputs: const ["ngForOf", "ngForTemplate"])
+    inputs: const ["ngForOf", "ngForTemplate", "ngForTrackBy"])
 class NgFor {
   set ngForOf(dynamic value) {}
+  set ngForTrackBy(TrackByFn value) {}
 }
+
+typedef dynamic TrackByFn(num index, dynamic item);
 ''');
   }
 }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -2110,8 +2110,9 @@ class ContainerComponent{}
         relevance: TemplateCompleter.RELEVANCE_TRANSCLUSION);
   }
 
-  test_completeInputInStarReplacing() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeInputInStarReplacing() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2132,8 +2133,9 @@ class MyComp {
     assertNotSuggested("items");
   }
 
-  test_completeInputInStarReplacingBeforeValue() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeInputInStarReplacingBeforeValue() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2154,8 +2156,9 @@ class MyComp {
     assertNotSuggested("items");
   }
 
-  test_completeInputInStar() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeInputInStar() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2176,8 +2179,9 @@ class MyComp {
     assertNotSuggested("items");
   }
 
-  test_completeInputInStarValueAlready() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeInputInStarValueAlready() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2198,8 +2202,9 @@ class MyComp {
     assertNotSuggested("items");
   }
 
-  test_completeNgForStarted() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeNgForStarted() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2221,8 +2226,9 @@ class MyComp {
     assertNotSuggested("id");
   }
 
-  test_completeNgForStartedWithValue() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeNgForStartedWithValue() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2244,8 +2250,9 @@ class MyComp {
     assertNotSuggested("id");
   }
 
-  test_completeStarAttrsNotStarted() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeStarAttrsNotStarted() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';
@@ -2278,8 +2285,9 @@ class NotTemplateDirective {
     assertNotSuggested("*ngForOf");
   }
 
-  test_completeStarAttrsOnlyStar() async {
-    var dartSource = newSource(
+  // ignore: non_constant_identifier_names
+  Future test_completeStarAttrsOnlyStar() async {
+    final dartSource = newSource(
         '/completionTest.dart',
         '''
 import 'package:angular2/angular2.dart';

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -665,8 +665,8 @@ class MyComp {
 
     await resolveSingleTemplate(dartSource);
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 'let'.length);
+    expect(replacementLength, 'let item'.length);
     assertNotSuggested('text');
   }
 
@@ -686,8 +686,8 @@ class MyComp {
 
     await resolveSingleTemplate(dartSource);
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 'let item'.length);
     assertNotSuggested('text');
   }
 
@@ -707,8 +707,8 @@ class MyComp {
 
     await resolveSingleTemplate(dartSource);
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 'let item'.length);
+    expect(replacementLength, 'let item'.length);
     assertNotSuggested('text');
   }
 
@@ -728,8 +728,8 @@ class MyComp {
 
     await resolveSingleTemplate(dartSource);
     await computeSuggestions();
-    expect(replacementOffset, completionOffset);
-    expect(replacementLength, 0);
+    expect(replacementOffset, completionOffset - 'let i'.length);
+    expect(replacementLength, 'let item'.length);
     assertNotSuggested('text');
   }
 
@@ -2108,5 +2108,93 @@ class ContainerComponent{}
   void assertSuggestTransclusion(String name) {
     assertSuggestClassTypeAlias(name,
         relevance: TemplateCompleter.RELEVANCE_TRANSCLUSION);
+  }
+
+  test_completeInputInStarReplacing() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  List<String> items;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let x of items; trackBy^: foo"></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset - 'trackBy'.length);
+    expect(replacementLength, 'trackBy'.length);
+    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertNotSuggested("of");
+    assertNotSuggested("items");
+  }
+
+  test_completeInputInStarReplacingBeforeValue() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  List<String> items;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let x of items; trackBy^"></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset - 'trackBy'.length);
+    expect(replacementLength, 'trackBy'.length);
+    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertNotSuggested("of");
+    assertNotSuggested("items");
+  }
+
+  test_completeInputInStar() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  List<String> items;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let x of items; ^"></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertNotSuggested("of");
+    assertNotSuggested("items");
+  }
+
+  test_completeInputInStarValueAlready() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import '/angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  List<String> items;
+}
+    ''');
+
+    addTestSource('<div *ngFor="let x of items; ^ : foo"></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertNotSuggested("of");
+    assertNotSuggested("items");
   }
 }

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -2128,8 +2128,10 @@ class MyComp {
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 'trackBy'.length);
     expect(replacementLength, 'trackBy'.length);
-    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertSuggestTemplateInput("trackBy:", elementName: '[ngForTrackBy]');
     assertNotSuggested("of");
+    assertNotSuggested("of:");
+    assertNotSuggested("trackBy"); // without the colon
     assertNotSuggested("items");
   }
 
@@ -2151,8 +2153,10 @@ class MyComp {
     await computeSuggestions();
     expect(replacementOffset, completionOffset - 'trackBy'.length);
     expect(replacementLength, 'trackBy'.length);
-    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertSuggestTemplateInput("trackBy:", elementName: '[ngForTrackBy]');
     assertNotSuggested("of");
+    assertNotSuggested("of:");
+    assertNotSuggested("trackBy"); // without the colon
     assertNotSuggested("items");
   }
 
@@ -2174,8 +2178,10 @@ class MyComp {
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
-    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertSuggestTemplateInput("trackBy:", elementName: '[ngForTrackBy]');
     assertNotSuggested("of");
+    assertNotSuggested("of:");
+    assertNotSuggested("trackBy"); // without the colon
     assertNotSuggested("items");
   }
 
@@ -2197,8 +2203,10 @@ class MyComp {
     await computeSuggestions();
     expect(replacementOffset, completionOffset);
     expect(replacementLength, 0);
-    assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
+    assertSuggestTemplateInput("trackBy:", elementName: '[ngForTrackBy]');
     assertNotSuggested("of");
+    assertNotSuggested("of:");
+    assertNotSuggested("trackBy"); // without the colon
     assertNotSuggested("items");
   }
 

--- a/server_plugin/test/completion_contributor_test.dart
+++ b/server_plugin/test/completion_contributor_test.dart
@@ -29,7 +29,7 @@ class DartCompletionContributorTest extends AbstractCompletionContributorTest {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInMustache() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '{{^}}', selector: 'a')
 class MyComp {
   String text;
@@ -45,7 +45,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInInputBinding() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<h1 [hidden]="^"></h1>', selector: 'a')
 class MyComp {
   String text;
@@ -61,7 +61,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInClassBinding() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<h1 [class.my-class]="^"></h1>', selector: 'a')
 class MyComp {
   String text;
@@ -77,7 +77,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInInputOutput_at_incompleteTag_with_newTag() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag ^<div></div>', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -97,7 +97,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeInputStarted_at_incompleteTag_with_newTag() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag [^<div></div>', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -117,7 +117,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeInputNotStarted_at_incompleteTag_with_newTag() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag ^<div></div>', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -136,7 +136,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeInput_as_plainAttribute() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag ^<div></div>', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -164,7 +164,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeStandardInput_as_plainAttribute() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag ^<div></div>', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -183,7 +183,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeOutputStarted_at_incompleteTag_with_newTag() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag (^<div></div>', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -203,7 +203,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInInputOutput_at_incompleteTag_with_EOF() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag ^', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -223,7 +223,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeInputStarted_at_incompleteTag_with_EOF() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag [^', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -243,7 +243,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeOutputStarted_at_incompleteTag_with_EOF() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<child-tag (^', selector: 'my-tag',
 directives: const [MyChildComponent])
 class MyComponent {}
@@ -263,7 +263,7 @@ class MyChildComponent {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInStyleBinding() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<h1 [style.background-color]="^"></h1>', selector: 'a')
 class MyComp {
   String text;
@@ -279,7 +279,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeMemberInAttrBinding() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<h1 [attr.on-click]="^"></h1>', selector: 'a')
 class MyComp {
   String text;
@@ -295,7 +295,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeMemberMustacheAttrBinding() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<h1 title="{{^}}"></h1>', selector: 'a')
 class MyComp {
   String text;
@@ -311,7 +311,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeMultipleMembers() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '{{d^}}', selector: 'a')
 class MyComp {
   String text;
@@ -329,7 +329,7 @@ class MyComp {
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_beginning() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<^<div></div>', selector: 'my-parent', directives: const[MyChildComponent1, MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -349,7 +349,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_beginning_with_partial() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<my^<div></div>', selector: 'my-parent', directives: const[MyChildComponent1, MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -369,7 +369,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_middle() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div><div><^</div></div>', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -389,7 +389,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_middle_of_text() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div><div> some text<^</div></div>', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -409,7 +409,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_middle_with_partial() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div><div><my^</div></div>', selector: 'my-parent', directives: const[MyChildComponent1, MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -429,7 +429,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_end() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div><div></div></div><^', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -449,7 +449,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_end_with_partial() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div><div></div></div><m^', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -469,7 +469,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_on_empty_document() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '^', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -489,7 +489,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_at_end_after_close() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div><div></div></div>^', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -509,7 +509,7 @@ class MyChildComponent2{}
   // ignore: non_constant_identifier_names
   Future test_completeInlineHtmlSelectorTag_in_middle_of_unclosed_tag() async {
     addTestSource('''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(template: '<div>some text<^', selector: 'my-parent', directives: const[MyChildComponent1,MyChildComponent2])
 class MyParentComponent{}
 @Component(template: '', selector: 'my-child1, my-child2')
@@ -545,7 +545,7 @@ class HtmlCompletionContributorTest extends AbstractCompletionContributorTest {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   String text;
@@ -568,7 +568,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   String text;
@@ -589,7 +589,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   String text;
@@ -610,7 +610,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -631,7 +631,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -654,7 +654,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -675,7 +675,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -696,7 +696,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -717,7 +717,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -738,7 +738,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   String text;
@@ -759,7 +759,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   List<String> items;
@@ -780,7 +780,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
 }
@@ -800,7 +800,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   List<String> items;
@@ -823,7 +823,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   String text;
@@ -844,7 +844,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   String text;
@@ -866,7 +866,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   String text;
@@ -887,7 +887,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   void dontCompleteMe() {}
@@ -908,7 +908,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a')
 class MyComp {
   bool takesArg(dynamic arg) {};
@@ -930,7 +930,7 @@ class MyComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -960,7 +960,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -990,7 +990,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1019,7 +1019,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1049,7 +1049,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1079,7 +1079,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1108,7 +1108,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1138,7 +1138,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1167,7 +1167,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1197,7 +1197,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1223,7 +1223,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1249,7 +1249,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1279,7 +1279,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1305,7 +1305,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1334,7 +1334,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1361,7 +1361,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1389,7 +1389,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1418,7 +1418,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1444,7 +1444,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1478,7 +1478,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1512,7 +1512,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1541,7 +1541,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1570,7 +1570,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1599,7 +1599,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1628,7 +1628,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1657,7 +1657,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [OtherComp])
 class MyComp {
@@ -1686,7 +1686,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1711,7 +1711,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1736,7 +1736,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1761,7 +1761,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1786,7 +1786,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1811,7 +1811,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1836,7 +1836,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1862,7 +1862,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1887,7 +1887,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1912,7 +1912,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-      import '/angular2/angular2.dart';
+      import 'package:angular2/angular2.dart';
       @Component(templateUrl: 'completionTest.html', selector: 'a',
         directives: const [MyChildComponent1, MyChildComponent2])
         class MyComp{}
@@ -1937,7 +1937,7 @@ class OtherComp {
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [ContainerComponent])
 class MyComp{}
@@ -1963,7 +1963,7 @@ class ContainerComponent{}
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [ContainerComponent])
 class MyComp{}
@@ -1992,7 +1992,7 @@ class ContainerComponent{}
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [ContainerComponent])
 class MyComp{}
@@ -2021,7 +2021,7 @@ class ContainerComponent{}
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [ContainerComponent])
 class MyComp{}
@@ -2050,7 +2050,7 @@ class ContainerComponent{}
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [ContainerComponent])
 class MyComp{}
@@ -2080,7 +2080,7 @@ class ContainerComponent{}
     final dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a',
     directives: const [ContainerComponent])
 class MyComp{}
@@ -2114,7 +2114,7 @@ class ContainerComponent{}
     var dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   List<String> items;
@@ -2136,7 +2136,7 @@ class MyComp {
     var dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   List<String> items;
@@ -2158,7 +2158,7 @@ class MyComp {
     var dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   List<String> items;
@@ -2180,7 +2180,7 @@ class MyComp {
     var dartSource = newSource(
         '/completionTest.dart',
         '''
-import '/angular2/angular2.dart';
+import 'package:angular2/angular2.dart';
 @Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
 class MyComp {
   List<String> items;
@@ -2196,5 +2196,116 @@ class MyComp {
     assertSuggestTemplateInput("trackBy", elementName: '[ngForTrackBy]');
     assertNotSuggested("of");
     assertNotSuggested("items");
+  }
+
+  test_completeNgForStarted() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import 'package:angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  List<String> items;
+}
+    ''');
+
+    addTestSource('<div *ngFor^');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset - '*ngFor'.length);
+    expect(replacementLength, '*ngFor'.length);
+    assertSuggestStar("*ngFor");
+    assertNotSuggested("*ngForOf");
+    assertNotSuggested("[id]");
+    assertNotSuggested("id");
+  }
+
+  test_completeNgForStartedWithValue() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import 'package:angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgFor])
+class MyComp {
+  List<String> items;
+}
+    ''');
+
+    addTestSource('<div *ngFor^="let x of items"></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset - '*ngFor'.length);
+    expect(replacementLength, '*ngFor'.length);
+    assertSuggestStar("*ngFor");
+    assertNotSuggested("*ngForOf");
+    assertNotSuggested("[id]");
+    assertNotSuggested("id");
+  }
+
+  test_completeStarAttrsNotStarted() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import 'package:angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [NgFor, NgIf, CustomTemplateDirective, NotTemplateDirective])
+class MyComp {
+  List<String> items;
+}
+
+@Directive(selector: '[customTemplateDirective]')
+class CustomTemplateDirective {
+  CustomTemplateDirective(TemplateRef tpl);
+}
+
+@Directive(selector: '[notTemplateDirective]')
+class NotTemplateDirective {
+}
+    ''');
+
+    addTestSource('<div ^></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestStar("*ngFor");
+    assertSuggestStar("*ngIf");
+    assertSuggestStar("*customTemplateDirective");
+    assertNotSuggested("*notTemplateDirective");
+    assertNotSuggested("*ngForOf");
+  }
+
+  test_completeStarAttrsOnlyStar() async {
+    var dartSource = newSource(
+        '/completionTest.dart',
+        '''
+import 'package:angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [NgFor, NgIf, CustomTemplateDirective])
+class MyComp {
+  List<String> items;
+}
+
+@Directive(selector: '[customTemplateDirective]')
+class CustomTemplateDirective {
+  CustomTemplateDirective(TemplateRef tpl);
+}
+    ''');
+
+    addTestSource('<div *^></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset - 1);
+    expect(replacementLength, 1);
+    assertSuggestStar("*ngFor");
+    assertSuggestStar("*ngIf");
+    assertSuggestStar("*customTemplateDirective");
+    assertNotSuggested("*ngForOf");
+    assertNotSuggested("[id]");
+    assertNotSuggested("id");
   }
 }

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -437,6 +437,27 @@ abstract class BaseCompletionContributorTest extends AbstractAngularTest {
     return cs;
   }
 
+  CompletionSuggestion assertSuggestTemplateInput(String name,
+      {String elementName,
+      int relevance: DART_RELEVANCE_DEFAULT,
+      String importUri,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION}) {
+    CompletionSuggestion cs = assertSuggest(name,
+        csKind: kind,
+        relevance: relevance,
+        importUri: importUri,
+        elemKind: protocol.ElementKind.SETTER);
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.SETTER));
+    expect(element.name, equals(elementName));
+    if (element.returnType != null) {
+      expect(element.returnType, 'dynamic');
+    }
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
   CompletionSuggestion assertSuggestTopLevelVar(String name, String returnType,
       {int relevance: DART_RELEVANCE_DEFAULT,
       CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -442,12 +442,12 @@ abstract class BaseCompletionContributorTest extends AbstractAngularTest {
       int relevance: DART_RELEVANCE_DEFAULT,
       String importUri,
       CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION}) {
-    CompletionSuggestion cs = assertSuggest(name,
+    final cs = assertSuggest(name,
         csKind: kind,
         relevance: relevance,
         importUri: importUri,
         elemKind: protocol.ElementKind.SETTER);
-    protocol.Element element = cs.element;
+    final element = cs.element;
     expect(element, isNotNull);
     expect(element.kind, equals(protocol.ElementKind.SETTER));
     expect(element.name, equals(elementName));
@@ -461,9 +461,8 @@ abstract class BaseCompletionContributorTest extends AbstractAngularTest {
   CompletionSuggestion assertSuggestStar(String name,
       {int relevance: DART_RELEVANCE_DEFAULT,
       CompletionSuggestionKind kind: CompletionSuggestionKind.IDENTIFIER}) {
-    CompletionSuggestion cs =
-        assertSuggest(name, csKind: kind, relevance: relevance);
-    protocol.Element element = cs.element;
+    final cs = assertSuggest(name, csKind: kind, relevance: relevance);
+    final element = cs.element;
     expect(element, isNotNull);
     expect(element.kind, equals(protocol.ElementKind.CLASS));
     expect(element.name, equals(name));

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -458,6 +458,21 @@ abstract class BaseCompletionContributorTest extends AbstractAngularTest {
     return cs;
   }
 
+  CompletionSuggestion assertSuggestStar(String name,
+      {int relevance: DART_RELEVANCE_DEFAULT,
+      CompletionSuggestionKind kind: CompletionSuggestionKind.IDENTIFIER}) {
+    CompletionSuggestion cs =
+        assertSuggest(name, csKind: kind, relevance: relevance);
+    protocol.Element element = cs.element;
+    expect(element, isNotNull);
+    expect(element.kind, equals(protocol.ElementKind.CLASS));
+    expect(element.name, equals(name));
+    expect(element.parameters, isNull);
+    expect(element.returnType, isNull);
+    assertHasNoParameterInfo(cs);
+    return cs;
+  }
+
   CompletionSuggestion assertSuggestTopLevelVar(String name, String returnType,
       {int relevance: DART_RELEVANCE_DEFAULT,
       CompletionSuggestionKind kind: CompletionSuggestionKind.INVOCATION,


### PR DESCRIPTION
Complete inputs inside of template elements  …
Complete, for instance, `trackBy` inside of an ngFor.

Analyze and suggest directives that appear to want `*star` syntax.  …
If a `TemplateRef` is in the constructor, it works with star syntax.
Warn when not used with star syntax, and warn when star syntax is used
on a directive that does not have this special ctor as otherwise the
template will go unused.

Its not a foolproof system, I don't think. So detect that separately
from detection of ngIf and ngFor without stars. Especially so that in
the cases where this goes wrong, users can opt out of the error without
losing errors for those core directives' validation...and give
different messages.

Not sure what's more likely...that this expects too many things to be
used with stars, or not enough...

Also suggest this in autocomplete for great profit. Assume that these
directives rely on a property binding, so suggest *p for all p which
are property selectors.

Note this is also a less than perfect system, as it includes suggesting
`*ngForOf`, since that's part of `NgFor`s selector. Hardcode that out,
at least for now.

With this plus suggesting `trackBy:`, we now (I think) suggest
everything relevant for two way autocomplete except `template=`
attributes themselves and the `let` keyword. Wanted to do the latter
but it seemed like it might be a bit treacherous: think `ngIf="^"` vs
`ngFor="^"`, it would be the first time we'd suggest both dart and
non-dart things at once.