### PR TITLE
Fix for source; null check added

### DIFF
--- a/analyzer_plugin/lib/src/directive_linking.dart
+++ b/analyzer_plugin/lib/src/directive_linking.dart
@@ -226,7 +226,7 @@ class ChildDirectiveLinker implements DirectiveMatcher {
             new StringToken(TokenType.IDENTIFIER, reference.name, 0)),
         null);
 
-    if (type != null) {
+    if (type != null && type.source != null) {
       final fileDirectives = await _fileDirectiveProvider
           .getUnlinkedDirectives(type.source.fullName);
 


### PR DESCRIPTION
Fix for: https://github.com/dart-lang/sdk/issues/29576#issuecomment-299958547

I've been trying to repro the issue by removing source imports before parsing - but haven't been able to do so. It's odd that the 'type'(ClassElement) could be found but the 'source' is showing up as null. 

This is a temporary fix in place, but it might cause strange errors to appear in the future since the directive-linking is affected. With this solution at least it won't cause a full-on crash.