### PR TITLE
Update imports after another breaking change

### DIFF
--- a/new_plugin/lib/plugin.dart
+++ b/new_plugin/lib/plugin.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer/src/generated/engine.dart' hide AnalysisResult;
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer_plugin/plugin/plugin.dart';
+import 'package:analyzer_plugin/protocol/protocol_common.dart' as plugin;
 import 'package:analyzer_plugin/protocol/protocol_constants.dart' as plugin;
 import 'package:analyzer_plugin/protocol/protocol_generated.dart' as plugin;
 import 'package:analyzer_plugin/utilities/analyzer_converter.dart';

--- a/server_plugin/lib/src/analysis.dart
+++ b/server_plugin/lib/src/analysis.dart
@@ -2,6 +2,7 @@ import 'package:analysis_server/plugin/analysis/navigation/navigation_core.dart'
 import 'package:analysis_server/plugin/analysis/occurrences/occurrences_core.dart';
 import 'package:analysis_server/protocol/protocol_generated.dart' as protocol;
 import 'package:analysis_server/plugin/protocol/protocol_dart.dart' as protocol;
+import 'package:analyzer_plugin/protocol/protocol_common.dart' as protocol;
 import 'package:analyzer/dart/element/element.dart' as engine;
 import 'package:analyzer/src/dart/element/member.dart';
 import 'package:analyzer/src/generated/engine.dart';

--- a/server_plugin/lib/src/completion.dart
+++ b/server_plugin/lib/src/completion.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:analysis_server/protocol/protocol_generated.dart' as protocol
+import 'package:analyzer_plugin/protocol/protocol_common.dart' as protocol
     show Element, ElementKind;
 import 'package:analysis_server/src/provisional/completion/completion_core.dart';
 import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';

--- a/server_plugin/pubspec.yaml
+++ b/server_plugin/pubspec.yaml
@@ -8,9 +8,10 @@ dependencies:
   angular_analyzer_plugin:
     path: ../analyzer_plugin
   analysis_server: any
+  analyzer_plugin: any
   plugin: '^0.2.0'
 dev_dependencies:
-  test_reflective_loader: '^0.0.3'
+  test_reflective_loader: '^0.1.0'
   typed_mock: '^0.0.4'
   unittest: '^0.11.0'
 dependency_overrides:
@@ -18,5 +19,7 @@ dependency_overrides:
      path: ../../sdk/pkg/analyzer
   analysis_server:
      path: ../../sdk/pkg/analysis_server
+  analyzer_plugin:
+     path: ../../sdk/pkg/analyzer_plugin
   front_end:
      path: ../../sdk/pkg/front_end

--- a/server_plugin/test/analysis_test.dart
+++ b/server_plugin/test/analysis_test.dart
@@ -3,6 +3,7 @@ library angular2.src.analysis.server_plugin.analysis_test;
 import 'package:analysis_server/plugin/analysis/navigation/navigation_core.dart';
 import 'package:analysis_server/plugin/analysis/occurrences/occurrences_core.dart';
 import 'package:analysis_server/protocol/protocol_generated.dart' as protocol;
+import 'package:analyzer_plugin/protocol/protocol_common.dart' as protocol;
 import 'package:analysis_server/src/plugin/notification_manager.dart';
 import 'package:analysis_server/src/analysis_server.dart';
 import 'package:analyzer/file_system/file_system.dart';

--- a/server_plugin/test/completion_contributor_test_util.dart
+++ b/server_plugin/test/completion_contributor_test_util.dart
@@ -6,9 +6,9 @@ library test.services.completion.dart.util;
 
 import 'dart:async';
 
-import 'package:analysis_server/protocol/protocol_generated.dart' as protocol
+import 'package:analyzer_plugin/protocol/protocol_common.dart' as protocol
     show ElementKind;
-import 'package:analysis_server/protocol/protocol_generated.dart'
+import 'package:analyzer_plugin/protocol/protocol_common.dart'
     hide Element, ElementKind;
 import 'package:analysis_server/src/provisional/completion/completion_core.dart';
 import 'package:analysis_server/src/provisional/completion/dart/completion_dart.dart';


### PR DESCRIPTION
There has been another breaking change in server.

The server and plugin wire protocols both defined several types that were the same between the two (such things as AnalysisError and CompletionSuggestion). These types were previously being generated in two different places, forcing us to convert one representation to the other, even though the representations were identical (other than being two distinct classes). I have fixed that so that we now have a single definition of these types, but that means that several files now need to import these common classes.

This is my attempt to clean up after myself by updating your code appropriately.