### PR TITLE
Fix reference vs. let logic

### DIFF
--- a/analyzer_plugin/lib/src/converter.dart
+++ b/analyzer_plugin/lib/src/converter.dart
@@ -385,26 +385,30 @@ class HtmlTreeConverter {
 
   StatementsBoundAttribute _convertStatementsBoundAttribute(
       ParsedEventAst ast) {
+    final prefixToken = ast.prefixToken;
+    final nameToken = ast.nameToken;
+    final suffixToken = ast.suffixToken;
+
     final prefixComponent =
-        (ast.prefixToken.errorSynthetic ? '' : ast.prefixToken.lexeme);
+        (prefixToken.errorSynthetic ? '' : prefixToken.lexeme);
     final suffixComponent =
-        ((ast.suffixToken == null) || ast.suffixToken.errorSynthetic)
+        ((suffixToken == null) || suffixToken.errorSynthetic)
             ? ''
-            : ast.suffixToken.lexeme;
+            : suffixToken.lexeme;
     final origName = '$prefixComponent${ast.name}$suffixComponent';
-    final origNameOffset = ast.prefixToken.offset;
+    final origNameOffset = prefixToken.offset;
 
     final value = ast.value;
     if ((value == null || value.isEmpty) &&
-        !ast.prefixToken.errorSynthetic &&
-        (!ast?.suffixToken?.errorSynthetic ?? true)) {
+        !prefixToken.errorSynthetic &&
+        (suffixToken == null ? true : !suffixToken.errorSynthetic)) {
       errorListener.onError(new AnalysisError(templateSource, origNameOffset,
           origName.length, AngularWarningCode.EMPTY_BINDING, [ast.name]));
     }
     final valueOffset = ast.valueOffset;
 
-    final propName = ast.nameToken.lexeme;
-    final propNameOffset = ast.nameToken.offset;
+    final propName = nameToken.lexeme;
+    final propNameOffset = nameToken.offset;
 
     return new StatementsBoundAttribute(
         propName,
@@ -421,20 +425,22 @@ class HtmlTreeConverter {
     var bound = ExpressionBoundType.input;
 
     final parsed = ast as ParsedDecoratorAst;
+    final suffixToken = parsed.suffixToken;
+    final nameToken = parsed.nameToken;
+    final prefixToken = parsed.prefixToken;
+
     String origName;
     {
-      final _prefix =
-          parsed.prefixToken.errorSynthetic ? '' : parsed.prefixToken.lexeme;
-      final _suffix =
-          (parsed.suffixToken == null || parsed.suffixToken.errorSynthetic)
-              ? ''
-              : parsed.suffixToken.lexeme;
-      origName = '$_prefix${parsed.nameToken.lexeme}$_suffix';
+      final _prefix = prefixToken.errorSynthetic ? '' : prefixToken.lexeme;
+      final _suffix = (suffixToken == null || suffixToken.errorSynthetic)
+          ? ''
+          : suffixToken.lexeme;
+      origName = '$_prefix${nameToken.lexeme}$_suffix';
     }
-    final origNameOffset = parsed.prefixToken.offset;
+    final origNameOffset = prefixToken.offset;
 
-    var propName = parsed.nameToken.lexeme;
-    var propNameOffset = parsed.nameToken.offset;
+    var propName = nameToken.lexeme;
+    var propNameOffset = nameToken.offset;
 
     if (ast is ParsedPropertyAst) {
       final name = ast.name;
@@ -453,7 +459,7 @@ class HtmlTreeConverter {
         if (replacePropName) {
           final _unitName = ast.unit == null ? '' : '.${ast.unit}';
           propName = '${ast.postfix}$_unitName';
-          propNameOffset = parsed.nameToken.offset + name.length + '.'.length;
+          propNameOffset = nameToken.offset + name.length + '.'.length;
         }
       }
     } else {
@@ -462,9 +468,8 @@ class HtmlTreeConverter {
 
     final value = parsed.valueToken?.innerValue?.lexeme;
     if ((value == null || value.isEmpty) &&
-            !parsed.prefixToken.errorSynthetic &&
-            !parsed?.suffixToken?.errorSynthetic ??
-        true) {
+        !prefixToken.errorSynthetic &&
+        (suffixToken == null ? true : !suffixToken.errorSynthetic)) {
       errorListener.onError(new AnalysisError(
         templateSource,
         origNameOffset,

--- a/analyzer_plugin/lib/src/converter.dart
+++ b/analyzer_plugin/lib/src/converter.dart
@@ -397,7 +397,7 @@ class HtmlTreeConverter {
     final value = ast.value;
     if ((value == null || value.isEmpty) &&
         !ast.prefixToken.errorSynthetic &&
-        !ast.suffixToken.errorSynthetic) {
+        (!ast?.suffixToken?.errorSynthetic ?? true)) {
       errorListener.onError(new AnalysisError(templateSource, origNameOffset,
           origName.length, AngularWarningCode.EMPTY_BINDING, [ast.name]));
     }
@@ -462,8 +462,9 @@ class HtmlTreeConverter {
 
     final value = parsed.valueToken?.innerValue?.lexeme;
     if ((value == null || value.isEmpty) &&
-        !parsed.prefixToken.errorSynthetic &&
-        !parsed.suffixToken.errorSynthetic) {
+            !parsed.prefixToken.errorSynthetic &&
+            !parsed?.suffixToken?.errorSynthetic ??
+        true) {
       errorListener.onError(new AnalysisError(
         templateSource,
         origNameOffset,

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -341,38 +341,48 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
 
   @override
   void visitScopeRootTemplateElement(ElementInfo element) {
+    final exportAsMap = _defineExportAsVariables(element.directives);
     for (final directive in element.directives) {
-      _defineDirectiveVariables(element.attributes, directive);
       // This must be here for <template> tags.
       _defineNgForVariables(element.attributes, directive);
     }
 
-    _defineLocalVariablesForAttributes(element.attributes);
+    _defineReferenceVariablesForAttributes(
+        element.directives, element.attributes, exportAsMap);
+    _defineLetVariablesForAttributes(element.attributes);
 
     super.visitScopeRootTemplateElement(element);
+  }
+
+  @override
+  void visitBorderScopeTemplateElement(ElementInfo element) {
+    final exportAsMap = _defineExportAsVariables(element.directives);
+    _defineReferenceVariablesForAttributes(
+        element.directives, element.attributes, exportAsMap);
   }
 
   @override
   void visitScopeRootElementWithTemplateAttribute(ElementInfo element) {
     final templateAttr = element.templateAttribute;
 
+    final exportAsMap = _defineExportAsVariables(element.directives);
+
     // If this is how our scope begins, like we're within an ngFor, then
     // let the ngFor alter the current scope.
     for (final directive in templateAttr.directives) {
-      _defineDirectiveVariables(templateAttr.virtualAttributes, directive);
       _defineNgForVariables(templateAttr.virtualAttributes, directive);
     }
 
-    _defineLocalVariablesForAttributes(templateAttr.virtualAttributes);
+    _defineLetVariablesForAttributes(templateAttr.virtualAttributes);
 
     // Make sure the regular element also alters the current scope
     for (final directive in element.directives) {
-      _defineDirectiveVariables(element.attributes, directive);
       // This must be here for <template> tags.
       _defineNgForVariables(element.attributes, directive);
     }
 
-    _defineLocalVariablesForAttributes(element.attributes);
+    _defineReferenceVariablesForAttributes(
+        element.directives, element.attributes, exportAsMap);
 
     super.visitScopeRootElementWithTemplateAttribute(element);
   }
@@ -386,15 +396,10 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
 
   @override
   void visitElementInScope(ElementInfo element) {
+    final exportAsMap = _defineExportAsVariables(element.directives);
     // Regular element or component. Look for `#var`s.
-    for (final directive in element.directives) {
-      _defineDirectiveVariables(element.attributes, directive);
-      // This must be here for <template> tags.
-      _defineNgForVariables(element.attributes, directive);
-    }
-
-    _defineLocalVariablesForAttributes(element.attributes);
-
+    _defineReferenceVariablesForAttributes(
+        element.directives, element.attributes, exportAsMap);
     super.visitElementInScope(element);
   }
 
@@ -436,80 +441,146 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
     }
   }
 
-  /// Defines type of variables defined by the given [directive].
-  void _defineDirectiveVariables(
-      List<AttributeInfo> attributes, AbstractDirective directive) {
-    // add "exportAs"
-    {
+  /// Provides a map for 'exportAs' string to list ofclass element.
+  /// Return type must be a class to later resolve conflicts should they exist.
+  /// This is a shortlived variable existing only in the scope of
+  /// element tag, therefore don't use [internalVariables].
+  Map<String, List<ClassElement>> _defineExportAsVariables(
+      List<AbstractDirective> directives) {
+    final exportAsMap = <String, List<ClassElement>>{};
+    for (final directive in directives) {
       final exportAs = directive.exportAs;
       if (exportAs != null) {
         final name = exportAs.name;
-        final type = directive.classElement.type;
-        internalVariables[name] = new InternalVariable(name, exportAs, type);
+        final classElement = directive.classElement;
+        exportAsMap.putIfAbsent(name, () => <ClassElement>[]);
+        exportAsMap[name].add(classElement);
       }
     }
-    // add "$implicit
-    if (directive is Component) {
-      final classElement = directive.classElement;
-      internalVariables[r'$implicit'] = new InternalVariable(
-          r'$implicit', new DartElement(classElement), classElement.type);
-    }
+    return exportAsMap;
   }
 
-  /// Define new local variables into [localVariables] for `#name` attributes.
-  void _defineLocalVariablesForAttributes(List<AttributeInfo> attributes) {
+  /// Define reference variables [localVariables] for `#name` attributes.
+  void _defineReferenceVariablesForAttributes(
+      List<AbstractDirective> directives,
+      List<AttributeInfo> attributes,
+      Map<String, List<ClassElement>> exportAsMap) {
     for (final attribute in attributes) {
       var offset = attribute.nameOffset;
       var name = attribute.name;
 
       // check if defines local variable
-      final isLet = name.startsWith('let-'); // ng-for
       final isRef = name.startsWith('ref-'); // not ng-for
       final isHash = name.startsWith('#'); // not ng-for
       final isVar =
           name.startsWith('var-'); // either (deprecated but still works)
-      if (isHash || isLet || isVar || isRef) {
+      if (isHash || isVar || isRef) {
         final prefixLen = isHash ? 1 : 4;
         name = name.substring(prefixLen);
         offset += prefixLen;
-
-        // prepare internal variable name
-        final internalName = attribute.value ?? r'$implicit';
+        final refValue = attribute.value;
 
         // maybe an internal variable reference
         DartType type;
-        final internalVar = internalVariables[internalName];
-        if (internalVar != null) {
-          type = internalVar.type;
-          // add internal variable reference
-          if (attribute.value != null) {
-            template.addRange(
-                new SourceRange(attribute.valueOffset, attribute.valueLength),
-                internalVar.element);
+        ClassElement classElement;
+
+        if (refValue == null) {
+          // Find the corresponding Component to assign reference to.
+          for (final directive in directives) {
+            if (directive is Component) {
+              classElement = directive.classElement;
+              break;
+            }
           }
-        } else if (attribute.value != null) {
-          errorListener.onError(new AnalysisError(
+        } else {
+          final classElements = exportAsMap[refValue];
+          if (classElements == null || classElements.isEmpty) {
+            errorListener.onError(new AnalysisError(
               templateSource,
               attribute.valueOffset,
               attribute.value.length,
               AngularWarningCode.NO_DIRECTIVE_EXPORTED_BY_SPECIFIED_NAME,
-              [attribute.value]));
+              [attribute.value],
+            ));
+          } else if (classElements.length > 1) {
+            errorListener.onError(new AnalysisError(
+              templateSource,
+              attribute.valueOffset,
+              attribute.value.length,
+              AngularWarningCode.DIRECTIVE_EXPORTED_BY_AMBIGIOUS,
+              [attribute.value],
+            ));
+          } else {
+            classElement = classElements[0];
+          }
         }
 
-        // any unmatched values should be dynamic to prevent secondary errors
-        type ??= typeProvider.dynamicType;
+        if (classElement != null) {
+          type = classElement.type;
+          if (attribute.value != null) {
+            template.addRange(
+              new SourceRange(attribute.valueOffset, attribute.valueLength),
+              new DartElement(classElement),
+            );
+          }
 
-        // add a new local variable with type
+          final localVariableElement =
+              dartVariableManager.newLocalVariableElement(-1, name, type);
+          final localVariable = new LocalVariable(
+              name, offset, name.length, templateSource, localVariableElement);
+          localVariables[name] = localVariable;
+          template.addRange(
+            new SourceRange(
+                localVariable.nameOffset, localVariable.name.length),
+            localVariable,
+          );
+        }
+      }
+    }
+  }
+
+  /// Define reference variables [localVariables] for `#name` attributes.
+  ///
+  /// Begin by defining the type as 'dynamic'.
+  /// In cases of *ngFor, this dynamic type is overwritten only if
+  /// the value is defined within [internalVariables]. If value is null,
+  /// it defaults to '$implicit'. If value is provided but isn't one of
+  /// known implicit variables of ngFor, we can't throw an error since
+  /// the value could still be defined.
+  /// if '$implicit' is not defined within [internalVariables], we again
+  /// default it to dynamicType.
+  void _defineLetVariablesForAttributes(List<AttributeInfo> attributes) {
+    for (final attribute in attributes) {
+      var offset = attribute.nameOffset;
+      var name = attribute.name;
+      final value = attribute.value;
+
+      if (name.startsWith('let-')) {
+        final prefixLength = 'let-'.length;
+        name = name.substring(prefixLength);
+        offset += prefixLength;
+        var type = typeProvider.dynamicType;
+
+        final internalVar = internalVariables[value ?? r'$implicit'];
+        if (internalVar != null) {
+          type = internalVar.type;
+          if (value != null) {
+            template.addRange(
+              new SourceRange(attribute.valueOffset, attribute.valueLength),
+              internalVar.element,
+            );
+          }
+        }
+
         final localVariableElement =
             dartVariableManager.newLocalVariableElement(-1, name, type);
         final localVariable = new LocalVariable(
             name, offset, name.length, templateSource, localVariableElement);
         localVariables[name] = localVariable;
-        // add local declaration
         template.addRange(
-            new SourceRange(
-                localVariable.nameOffset, localVariable.name.length),
-            localVariable);
+          new SourceRange(offset, name.length),
+          localVariable,
+        );
       }
     }
   }

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -330,8 +330,6 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
   final DartVariableManager dartVariableManager;
   final AnalysisErrorListener errorListener;
 
-  List<AbstractDirective> directives;
-
   PrepareScopeVisitor(
       this.internalVariables,
       this.localVariables,
@@ -351,7 +349,6 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
 
     _defineLocalVariablesForAttributes(element.attributes);
 
-    directives = element.directives;
     super.visitScopeRootTemplateElement(element);
   }
 
@@ -377,7 +374,6 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
 
     _defineLocalVariablesForAttributes(element.attributes);
 
-    directives = element.directives;
     super.visitScopeRootElementWithTemplateAttribute(element);
   }
 
@@ -385,7 +381,6 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
   void visitBorderScopeTemplateAttribute(TemplateAttribute attr) {
     // Border to the next scope. Make sure the virtual properties are bound
     // to the scope we're building now. But nothing else.
-    directives = attr.directives;
     visitTemplateAttr(attr);
   }
 
@@ -400,7 +395,6 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
 
     _defineLocalVariablesForAttributes(element.attributes);
 
-    directives = element.directives;
     super.visitElementInScope(element);
   }
 

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -481,7 +481,7 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
         final refValue = attribute.value;
 
         // maybe an internal variable reference
-        DartType type;
+        var type = typeProvider.dynamicType;
         AngularElement angularElement;
 
         if (refValue == null) {
@@ -519,25 +519,22 @@ class PrepareScopeVisitor extends AngularScopeVisitor {
           }
         }
 
-        if (angularElement != null) {
-          if (attribute.value != null) {
-            template.addRange(
-              new SourceRange(attribute.valueOffset, attribute.valueLength),
-              angularElement,
-            );
-          }
-
-          final localVariableElement =
-              dartVariableManager.newLocalVariableElement(-1, name, type);
-          final localVariable = new LocalVariable(
-              name, offset, name.length, templateSource, localVariableElement);
-          localVariables[name] = localVariable;
+        if (attribute.value != null) {
           template.addRange(
-            new SourceRange(
-                localVariable.nameOffset, localVariable.name.length),
-            localVariable,
+            new SourceRange(attribute.valueOffset, attribute.valueLength),
+            angularElement,
           );
         }
+
+        final localVariableElement =
+            dartVariableManager.newLocalVariableElement(offset, name, type);
+        final localVariable = new LocalVariable(
+            name, offset, name.length, templateSource, localVariableElement);
+        localVariables[name] = localVariable;
+        template.addRange(
+          new SourceRange(localVariable.nameOffset, localVariable.name.length),
+          localVariable,
+        );
       }
     }
   }

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -259,6 +259,12 @@ class AngularWarningCode extends ErrorCode {
       const AngularWarningCode('NO_DIRECTIVE_EXPORTED_BY_SPECIFIED_NAME',
           'No directives matching this element are exported by the name {0}');
 
+  /// An error code indicating in <div dir1 dir2 #y="x">, x is ambigious since
+  /// both directives dir1 and dir2 have same exportAs name "x".
+  static const DIRECTIVE_EXPORTED_BY_AMBIGIOUS = const AngularWarningCode(
+      'DIRECTIVE_EXPORTED_BY_AMBIGIOUS',
+      "More than one directive's exportAs value matches '{0}'.");
+
   /// An error code indicating that a custom component appears to require a star.
   static const AngularWarningCode CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE =
       const AngularWarningCode(

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -247,6 +247,10 @@ class AngularWarningCode extends ErrorCode {
       'The binding {} is not a valid dart identifer, attribute, style, or class'
       ' binding');
 
+  static const INVALID_LET_BINDING = const AngularWarningCode(
+      'INVALID_LET_BINDING',
+      "'let-' bindings can only be used <template> elements, use '#' instead");
+
   /// An error code indicating that ngIf or ngFor were used without a template
   static const STRUCTURAL_DIRECTIVES_REQUIRE_TEMPLATE =
       const AngularWarningCode(

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -76,7 +76,8 @@ ResolvedRange getResolvedRangeAtString(
     }
     return false;
   }, orElse: () {
-    fail('ResolvedRange at $offset was not found in [\n${ranges.join('\n')}]');
+    fail(
+        'ResolvedRange at $offset of $str was not found in [\n${ranges.join('\n')}]');
     return null;
   });
 }

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2163,8 +2163,8 @@ class TestPanel {
     _addDartSource(r'''
 import 'dart:html';
 
-@Component(selector: 'test-panel')
-@View(templateUrl: 'test_panel.html')
+@Component(selector: 'test-panel',
+  templateUrl: 'test_panel.html')
 class TestPanel {
   void handleClick(Element e) {}
 }

--- a/analyzer_plugin/test/resolver_test.dart
+++ b/analyzer_plugin/test/resolver_test.dart
@@ -2164,14 +2164,17 @@ class TestPanel {
 import 'dart:html';
 
 @Component(selector: 'test-panel',
-  templateUrl: 'test_panel.html')
+  directives: const [MyDivComponent])
+@View(templateUrl: 'test_panel.html')
 class TestPanel {
   void handleClick(Element e) {}
 }
+@Component(selector: 'my-div', template: '')
+class MyDivComponent{}
 ''');
     _addHtmlSource(r"""
 <h1 (click)='handleClick(myTargetElement)'>
-  <div #myTargetElement></div>
+  <my-div #myTargetElement></my-div>
 </h1>
 """);
     await _resolveSingleTemplate(dartSource);


### PR DESCRIPTION
Pretty large change in terms of how let- and # variables are defined and resolved as.
Resolves issues: #167  #176  #321 

Major changes:
- `let-` binding is now only allowed to be used in `<template>` bindings, throws an error otherwise.
- `#ref` now properly references `TemplateRef` object when used inside template: `<template #ref>`
- `$implicit` logic is changed. Only in the case of `ngFor` will `$implicit` be defined. Otherwise, all other `let-noValue` bindings will link to a dynamic type. In addition, let bindings with value will also automatically be defined to dynamic type. (we can possibly, in the future, resolve these types)
- Added checks for ambiguous exportAs referencing. If two directives have the same `exportAs` value and both directives are used in the same tag linked to a `#ref`, it will throw an error. When this occurs in Angular, no error is thrown but that segment silently fails. Note that this will ONLY be thrown if ambigious exportAs value is attempted to be assigned to a reference, otherwise it won't complain. Example, suppose dir1 and dir2 have same `exportAs` value: `<div dir1 dir2></div>` won't throw an error. `<div dir1 dir2 #ref='ambigious'></div>` will complain.

Minor changes:
- In `_convertAttributes`, changed `<ParsedX>` types to be standard base type. Was doing bad forced casting. Better follows OOP design.
