### PR TITLE
Fix build: analyzer_plugin driver changes, no MethodElement locals

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -641,11 +641,6 @@ class DartVariableManager {
     localVariable.name.length;
     localVariable.type = type;
 
-    // add the local variable to the enclosing element
-    final localVariables = <LocalVariableElement>[]
-      ..addAll(htmlMethodElement.localVariables)
-      ..add(localVariable);
-    htmlMethodElement.localVariables = localVariables;
     return localVariable;
   }
 }

--- a/new_plugin/lib/plugin.dart
+++ b/new_plugin/lib/plugin.dart
@@ -125,9 +125,9 @@ class AngularAnalysisPlugin extends ServerPlugin with CompletionMixin {
 
   @override
   Future<CompletionRequest> getCompletionRequest(
-      plugin.CompletionGetSuggestionsParams parameters,
-      AngularDriver driver) async {
+      plugin.CompletionGetSuggestionsParams parameters) async {
     final path = parameters.file;
+    final AngularDriver driver = driverForPath(path);
     final offset = parameters.offset;
     final templates = await driver.getTemplatesForFile(path);
     final standardHtml = await driver.getStandardHtml();
@@ -137,7 +137,7 @@ class AngularAnalysisPlugin extends ServerPlugin with CompletionMixin {
   }
 
   @override
-  List<CompletionContributor> getCompletionContributors(AngularDriver driver) =>
+  List<CompletionContributor> getCompletionContributors(String path) =>
       <CompletionContributor>[
         new AngularCompletionContributor(),
         new NgInheritedReferenceContributor(),


### PR DESCRIPTION
Not sure what method element local variables were doing before.
Removing that code seemed to cause no changes in behavior.

Removing the driver in place for a path was simple enough.