### PR TITLE
Track -- but don't validate yet -- annotated member inheritance

### DIFF
--- a/angular_analyzer_plugin/lib/src/model.dart
+++ b/angular_analyzer_plugin/lib/src/model.dart
@@ -13,19 +13,13 @@ import 'package:angular_analyzer_plugin/src/standard_components.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/errors.dart';
 
-/// An abstract model of an Angular directive.
-abstract class AbstractDirective {
+/// Might be a directive, or a component, or neither. It might simply have
+/// annotated @Inputs, @Outputs() intended to be inherited.
+class AngularAnnotatedClass {
   /// The [ClassElement] this annotation is associated with.
   final dart.ClassElement classElement;
-
-  final AngularElement exportAs;
   final List<InputElement> inputs;
   final List<OutputElement> outputs;
-  final Selector selector;
-  final List<ElementNameSelector> elementTags;
-  final attributes = <AngularElement>[];
-
-  bool get isHtml;
 
   /// Which fields have been marked `@ContentChild`, and the range of the type
   /// argument. The element model contains the rest. This should be stored in the
@@ -33,6 +27,22 @@ abstract class AbstractDirective {
   /// against the range we saw it the AST.
   List<ContentChildField> contentChildrenFields;
   List<ContentChildField> contentChildFields;
+
+  AngularAnnotatedClass(this.classElement, this.inputs, this.outputs,
+      this.contentChildFields, this.contentChildrenFields);
+}
+
+/// An abstract model of an Angular directive.
+abstract class AbstractDirective extends AngularAnnotatedClass {
+  final AngularElement exportAs;
+  final Selector selector;
+  final List<ElementNameSelector> elementTags;
+  final attributes = <AngularElement>[];
+
+  bool get isHtml;
+
+  // See [AngularAnnotatedClassMembers.contentChildrenFields]. These are the
+  // linked versions.
   final contentChilds = <ContentChild>[];
   final contentChildren = <ContentChild>[];
 
@@ -42,14 +52,16 @@ abstract class AbstractDirective {
   /// whatever validation we can, and autocomplete suggestions.
   bool looksLikeTemplate = false;
 
-  AbstractDirective(this.classElement,
+  AbstractDirective(dart.ClassElement classElement,
       {this.exportAs,
-      this.inputs,
-      this.outputs,
+      List<InputElement> inputs,
+      List<OutputElement> outputs,
       this.selector,
       this.elementTags,
-      this.contentChildFields,
-      this.contentChildrenFields});
+      List<ContentChildField> contentChildFields,
+      List<ContentChildField> contentChildrenFields})
+      : super(classElement, inputs, outputs, contentChildFields,
+            contentChildrenFields);
 
   /// The source that contains this directive.
   Source get source => classElement.source;

--- a/angular_analyzer_plugin/lib/src/summary/format.dart
+++ b/angular_analyzer_plugin/lib/src/summary/format.dart
@@ -5,6 +5,8 @@
 // This file has been automatically generated.  Please do not edit it manually.
 // To regenerate the file, use the script "pkg/analyzer/tool/generate_files".
 
+library analyzer.src.summary.format;
+
 import 'dart:convert' as convert;
 
 import 'package:front_end/src/base/api_signature.dart' as api_sig;
@@ -589,6 +591,7 @@ class UnlinkedDartSummaryBuilder extends Object
     with _UnlinkedDartSummaryMixin
     implements idl.UnlinkedDartSummary {
   List<SummarizedDirectiveBuilder> _directiveSummaries;
+  List<SummarizedClassAnnotationsBuilder> _annotatedClasses;
   List<SummarizedAnalysisErrorBuilder> _errors;
 
   @override
@@ -597,6 +600,14 @@ class UnlinkedDartSummaryBuilder extends Object
 
   void set directiveSummaries(List<SummarizedDirectiveBuilder> value) {
     this._directiveSummaries = value;
+  }
+
+  @override
+  List<SummarizedClassAnnotationsBuilder> get annotatedClasses =>
+      _annotatedClasses ??= <SummarizedClassAnnotationsBuilder>[];
+
+  void set annotatedClasses(List<SummarizedClassAnnotationsBuilder> value) {
+    this._annotatedClasses = value;
   }
 
   @override
@@ -609,8 +620,10 @@ class UnlinkedDartSummaryBuilder extends Object
 
   UnlinkedDartSummaryBuilder(
       {List<SummarizedDirectiveBuilder> directiveSummaries,
+      List<SummarizedClassAnnotationsBuilder> annotatedClasses,
       List<SummarizedAnalysisErrorBuilder> errors})
       : _directiveSummaries = directiveSummaries,
+        _annotatedClasses = annotatedClasses,
         _errors = errors;
 
   /**
@@ -618,6 +631,7 @@ class UnlinkedDartSummaryBuilder extends Object
    */
   void flushInformative() {
     _directiveSummaries?.forEach((b) => b.flushInformative());
+    _annotatedClasses?.forEach((b) => b.flushInformative());
     _errors?.forEach((b) => b.flushInformative());
   }
 
@@ -630,6 +644,14 @@ class UnlinkedDartSummaryBuilder extends Object
     } else {
       signature.addInt(this._directiveSummaries.length);
       for (var x in this._directiveSummaries) {
+        x?.collectApiSignature(signature);
+      }
+    }
+    if (this._annotatedClasses == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._annotatedClasses.length);
+      for (var x in this._annotatedClasses) {
         x?.collectApiSignature(signature);
       }
     }
@@ -650,10 +672,15 @@ class UnlinkedDartSummaryBuilder extends Object
 
   fb.Offset finish(fb.Builder fbBuilder) {
     fb.Offset offset_directiveSummaries;
+    fb.Offset offset_annotatedClasses;
     fb.Offset offset_errors;
     if (!(_directiveSummaries == null || _directiveSummaries.isEmpty)) {
       offset_directiveSummaries = fbBuilder.writeList(
           _directiveSummaries.map((b) => b.finish(fbBuilder)).toList());
+    }
+    if (!(_annotatedClasses == null || _annotatedClasses.isEmpty)) {
+      offset_annotatedClasses = fbBuilder.writeList(
+          _annotatedClasses.map((b) => b.finish(fbBuilder)).toList());
     }
     if (!(_errors == null || _errors.isEmpty)) {
       offset_errors =
@@ -663,8 +690,11 @@ class UnlinkedDartSummaryBuilder extends Object
     if (offset_directiveSummaries != null) {
       fbBuilder.addOffset(0, offset_directiveSummaries);
     }
+    if (offset_annotatedClasses != null) {
+      fbBuilder.addOffset(1, offset_annotatedClasses);
+    }
     if (offset_errors != null) {
-      fbBuilder.addOffset(1, offset_errors);
+      fbBuilder.addOffset(2, offset_errors);
     }
     return fbBuilder.endTable();
   }
@@ -693,6 +723,7 @@ class _UnlinkedDartSummaryImpl extends Object
   _UnlinkedDartSummaryImpl(this._bc, this._bcOffset);
 
   List<idl.SummarizedDirective> _directiveSummaries;
+  List<idl.SummarizedClassAnnotations> _annotatedClasses;
   List<idl.SummarizedAnalysisError> _errors;
 
   @override
@@ -704,10 +735,18 @@ class _UnlinkedDartSummaryImpl extends Object
   }
 
   @override
+  List<idl.SummarizedClassAnnotations> get annotatedClasses {
+    _annotatedClasses ??= const fb.ListReader<idl.SummarizedClassAnnotations>(
+            const _SummarizedClassAnnotationsReader())
+        .vTableGet(_bc, _bcOffset, 1, const <idl.SummarizedClassAnnotations>[]);
+    return _annotatedClasses;
+  }
+
+  @override
   List<idl.SummarizedAnalysisError> get errors {
     _errors ??= const fb.ListReader<idl.SummarizedAnalysisError>(
             const _SummarizedAnalysisErrorReader())
-        .vTableGet(_bc, _bcOffset, 1, const <idl.SummarizedAnalysisError>[]);
+        .vTableGet(_bc, _bcOffset, 2, const <idl.SummarizedAnalysisError>[]);
     return _errors;
   }
 }
@@ -719,6 +758,9 @@ abstract class _UnlinkedDartSummaryMixin implements idl.UnlinkedDartSummary {
     if (directiveSummaries.isNotEmpty)
       _result["directiveSummaries"] =
           directiveSummaries.map((_value) => _value.toJson()).toList();
+    if (annotatedClasses.isNotEmpty)
+      _result["annotatedClasses"] =
+          annotatedClasses.map((_value) => _value.toJson()).toList();
     if (errors.isNotEmpty)
       _result["errors"] = errors.map((_value) => _value.toJson()).toList();
     return _result;
@@ -727,7 +769,262 @@ abstract class _UnlinkedDartSummaryMixin implements idl.UnlinkedDartSummary {
   @override
   Map<String, Object> toMap() => {
         "directiveSummaries": directiveSummaries,
+        "annotatedClasses": annotatedClasses,
         "errors": errors,
+      };
+
+  @override
+  String toString() => convert.JSON.encode(toJson());
+}
+
+class SummarizedClassAnnotationsBuilder extends Object
+    with _SummarizedClassAnnotationsMixin
+    implements idl.SummarizedClassAnnotations {
+  String _className;
+  List<SummarizedBindableBuilder> _inputs;
+  List<SummarizedBindableBuilder> _outputs;
+  List<SummarizedContentChildFieldBuilder> _contentChildFields;
+  List<SummarizedContentChildFieldBuilder> _contentChildrenFields;
+
+  @override
+  String get className => _className ??= '';
+
+  void set className(String value) {
+    this._className = value;
+  }
+
+  @override
+  List<SummarizedBindableBuilder> get inputs =>
+      _inputs ??= <SummarizedBindableBuilder>[];
+
+  void set inputs(List<SummarizedBindableBuilder> value) {
+    this._inputs = value;
+  }
+
+  @override
+  List<SummarizedBindableBuilder> get outputs =>
+      _outputs ??= <SummarizedBindableBuilder>[];
+
+  void set outputs(List<SummarizedBindableBuilder> value) {
+    this._outputs = value;
+  }
+
+  @override
+  List<SummarizedContentChildFieldBuilder> get contentChildFields =>
+      _contentChildFields ??= <SummarizedContentChildFieldBuilder>[];
+
+  void set contentChildFields(List<SummarizedContentChildFieldBuilder> value) {
+    this._contentChildFields = value;
+  }
+
+  @override
+  List<SummarizedContentChildFieldBuilder> get contentChildrenFields =>
+      _contentChildrenFields ??= <SummarizedContentChildFieldBuilder>[];
+
+  void set contentChildrenFields(
+      List<SummarizedContentChildFieldBuilder> value) {
+    this._contentChildrenFields = value;
+  }
+
+  SummarizedClassAnnotationsBuilder(
+      {String className,
+      List<SummarizedBindableBuilder> inputs,
+      List<SummarizedBindableBuilder> outputs,
+      List<SummarizedContentChildFieldBuilder> contentChildFields,
+      List<SummarizedContentChildFieldBuilder> contentChildrenFields})
+      : _className = className,
+        _inputs = inputs,
+        _outputs = outputs,
+        _contentChildFields = contentChildFields,
+        _contentChildrenFields = contentChildrenFields;
+
+  /**
+   * Flush [informative] data recursively.
+   */
+  void flushInformative() {
+    _inputs?.forEach((b) => b.flushInformative());
+    _outputs?.forEach((b) => b.flushInformative());
+    _contentChildFields?.forEach((b) => b.flushInformative());
+    _contentChildrenFields?.forEach((b) => b.flushInformative());
+  }
+
+  /**
+   * Accumulate non-[informative] data into [signature].
+   */
+  void collectApiSignature(api_sig.ApiSignature signature) {
+    signature.addString(this._className ?? '');
+    if (this._inputs == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._inputs.length);
+      for (var x in this._inputs) {
+        x?.collectApiSignature(signature);
+      }
+    }
+    if (this._outputs == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._outputs.length);
+      for (var x in this._outputs) {
+        x?.collectApiSignature(signature);
+      }
+    }
+    if (this._contentChildFields == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._contentChildFields.length);
+      for (var x in this._contentChildFields) {
+        x?.collectApiSignature(signature);
+      }
+    }
+    if (this._contentChildrenFields == null) {
+      signature.addInt(0);
+    } else {
+      signature.addInt(this._contentChildrenFields.length);
+      for (var x in this._contentChildrenFields) {
+        x?.collectApiSignature(signature);
+      }
+    }
+  }
+
+  fb.Offset finish(fb.Builder fbBuilder) {
+    fb.Offset offset_className;
+    fb.Offset offset_inputs;
+    fb.Offset offset_outputs;
+    fb.Offset offset_contentChildFields;
+    fb.Offset offset_contentChildrenFields;
+    if (_className != null) {
+      offset_className = fbBuilder.writeString(_className);
+    }
+    if (!(_inputs == null || _inputs.isEmpty)) {
+      offset_inputs =
+          fbBuilder.writeList(_inputs.map((b) => b.finish(fbBuilder)).toList());
+    }
+    if (!(_outputs == null || _outputs.isEmpty)) {
+      offset_outputs = fbBuilder
+          .writeList(_outputs.map((b) => b.finish(fbBuilder)).toList());
+    }
+    if (!(_contentChildFields == null || _contentChildFields.isEmpty)) {
+      offset_contentChildFields = fbBuilder.writeList(
+          _contentChildFields.map((b) => b.finish(fbBuilder)).toList());
+    }
+    if (!(_contentChildrenFields == null || _contentChildrenFields.isEmpty)) {
+      offset_contentChildrenFields = fbBuilder.writeList(
+          _contentChildrenFields.map((b) => b.finish(fbBuilder)).toList());
+    }
+    fbBuilder.startTable();
+    if (offset_className != null) {
+      fbBuilder.addOffset(0, offset_className);
+    }
+    if (offset_inputs != null) {
+      fbBuilder.addOffset(1, offset_inputs);
+    }
+    if (offset_outputs != null) {
+      fbBuilder.addOffset(2, offset_outputs);
+    }
+    if (offset_contentChildFields != null) {
+      fbBuilder.addOffset(3, offset_contentChildFields);
+    }
+    if (offset_contentChildrenFields != null) {
+      fbBuilder.addOffset(4, offset_contentChildrenFields);
+    }
+    return fbBuilder.endTable();
+  }
+}
+
+class _SummarizedClassAnnotationsReader
+    extends fb.TableReader<_SummarizedClassAnnotationsImpl> {
+  const _SummarizedClassAnnotationsReader();
+
+  @override
+  _SummarizedClassAnnotationsImpl createObject(
+          fb.BufferContext bc, int offset) =>
+      new _SummarizedClassAnnotationsImpl(bc, offset);
+}
+
+class _SummarizedClassAnnotationsImpl extends Object
+    with _SummarizedClassAnnotationsMixin
+    implements idl.SummarizedClassAnnotations {
+  final fb.BufferContext _bc;
+  final int _bcOffset;
+
+  _SummarizedClassAnnotationsImpl(this._bc, this._bcOffset);
+
+  String _className;
+  List<idl.SummarizedBindable> _inputs;
+  List<idl.SummarizedBindable> _outputs;
+  List<idl.SummarizedContentChildField> _contentChildFields;
+  List<idl.SummarizedContentChildField> _contentChildrenFields;
+
+  @override
+  String get className {
+    _className ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 0, '');
+    return _className;
+  }
+
+  @override
+  List<idl.SummarizedBindable> get inputs {
+    _inputs ??= const fb.ListReader<idl.SummarizedBindable>(
+            const _SummarizedBindableReader())
+        .vTableGet(_bc, _bcOffset, 1, const <idl.SummarizedBindable>[]);
+    return _inputs;
+  }
+
+  @override
+  List<idl.SummarizedBindable> get outputs {
+    _outputs ??= const fb.ListReader<idl.SummarizedBindable>(
+            const _SummarizedBindableReader())
+        .vTableGet(_bc, _bcOffset, 2, const <idl.SummarizedBindable>[]);
+    return _outputs;
+  }
+
+  @override
+  List<idl.SummarizedContentChildField> get contentChildFields {
+    _contentChildFields ??=
+        const fb.ListReader<idl.SummarizedContentChildField>(
+                const _SummarizedContentChildFieldReader())
+            .vTableGet(
+                _bc, _bcOffset, 3, const <idl.SummarizedContentChildField>[]);
+    return _contentChildFields;
+  }
+
+  @override
+  List<idl.SummarizedContentChildField> get contentChildrenFields {
+    _contentChildrenFields ??=
+        const fb.ListReader<idl.SummarizedContentChildField>(
+                const _SummarizedContentChildFieldReader())
+            .vTableGet(
+                _bc, _bcOffset, 4, const <idl.SummarizedContentChildField>[]);
+    return _contentChildrenFields;
+  }
+}
+
+abstract class _SummarizedClassAnnotationsMixin
+    implements idl.SummarizedClassAnnotations {
+  @override
+  Map<String, Object> toJson() {
+    Map<String, Object> _result = <String, Object>{};
+    if (className != '') _result["className"] = className;
+    if (inputs.isNotEmpty)
+      _result["inputs"] = inputs.map((_value) => _value.toJson()).toList();
+    if (outputs.isNotEmpty)
+      _result["outputs"] = outputs.map((_value) => _value.toJson()).toList();
+    if (contentChildFields.isNotEmpty)
+      _result["contentChildFields"] =
+          contentChildFields.map((_value) => _value.toJson()).toList();
+    if (contentChildrenFields.isNotEmpty)
+      _result["contentChildrenFields"] =
+          contentChildrenFields.map((_value) => _value.toJson()).toList();
+    return _result;
+  }
+
+  @override
+  Map<String, Object> toMap() => {
+        "className": className,
+        "inputs": inputs,
+        "outputs": outputs,
+        "contentChildFields": contentChildFields,
+        "contentChildrenFields": contentChildrenFields,
       };
 
   @override
@@ -737,10 +1034,10 @@ abstract class _UnlinkedDartSummaryMixin implements idl.UnlinkedDartSummary {
 class SummarizedDirectiveBuilder extends Object
     with _SummarizedDirectiveMixin
     implements idl.SummarizedDirective {
+  SummarizedClassAnnotationsBuilder _classAnnotations;
   bool _isComponent;
   String _selectorStr;
   int _selectorOffset;
-  String _decoratedClassName;
   String _exportAs;
   int _exportAsOffset;
   String _templateUrl;
@@ -749,12 +1046,15 @@ class SummarizedDirectiveBuilder extends Object
   String _templateText;
   int _templateOffset;
   List<SummarizedNgContentBuilder> _ngContents;
-  List<SummarizedBindableBuilder> _inputs;
-  List<SummarizedBindableBuilder> _outputs;
   List<SummarizedDirectiveUseBuilder> _subdirectives;
-  List<SummarizedContentChildFieldBuilder> _contentChildFields;
-  List<SummarizedContentChildFieldBuilder> _contentChildrenFields;
   List<SummarizedExportedIdentifierBuilder> _exports;
+
+  @override
+  SummarizedClassAnnotationsBuilder get classAnnotations => _classAnnotations;
+
+  void set classAnnotations(SummarizedClassAnnotationsBuilder value) {
+    this._classAnnotations = value;
+  }
 
   @override
   bool get isComponent => _isComponent ??= false;
@@ -776,13 +1076,6 @@ class SummarizedDirectiveBuilder extends Object
   void set selectorOffset(int value) {
     assert(value == null || value >= 0);
     this._selectorOffset = value;
-  }
-
-  @override
-  String get decoratedClassName => _decoratedClassName ??= '';
-
-  void set decoratedClassName(String value) {
-    this._decoratedClassName = value;
   }
 
   @override
@@ -847,44 +1140,11 @@ class SummarizedDirectiveBuilder extends Object
   }
 
   @override
-  List<SummarizedBindableBuilder> get inputs =>
-      _inputs ??= <SummarizedBindableBuilder>[];
-
-  void set inputs(List<SummarizedBindableBuilder> value) {
-    this._inputs = value;
-  }
-
-  @override
-  List<SummarizedBindableBuilder> get outputs =>
-      _outputs ??= <SummarizedBindableBuilder>[];
-
-  void set outputs(List<SummarizedBindableBuilder> value) {
-    this._outputs = value;
-  }
-
-  @override
   List<SummarizedDirectiveUseBuilder> get subdirectives =>
       _subdirectives ??= <SummarizedDirectiveUseBuilder>[];
 
   void set subdirectives(List<SummarizedDirectiveUseBuilder> value) {
     this._subdirectives = value;
-  }
-
-  @override
-  List<SummarizedContentChildFieldBuilder> get contentChildFields =>
-      _contentChildFields ??= <SummarizedContentChildFieldBuilder>[];
-
-  void set contentChildFields(List<SummarizedContentChildFieldBuilder> value) {
-    this._contentChildFields = value;
-  }
-
-  @override
-  List<SummarizedContentChildFieldBuilder> get contentChildrenFields =>
-      _contentChildrenFields ??= <SummarizedContentChildFieldBuilder>[];
-
-  void set contentChildrenFields(
-      List<SummarizedContentChildFieldBuilder> value) {
-    this._contentChildrenFields = value;
   }
 
   @override
@@ -896,10 +1156,10 @@ class SummarizedDirectiveBuilder extends Object
   }
 
   SummarizedDirectiveBuilder(
-      {bool isComponent,
+      {SummarizedClassAnnotationsBuilder classAnnotations,
+      bool isComponent,
       String selectorStr,
       int selectorOffset,
-      String decoratedClassName,
       String exportAs,
       int exportAsOffset,
       String templateUrl,
@@ -908,16 +1168,12 @@ class SummarizedDirectiveBuilder extends Object
       String templateText,
       int templateOffset,
       List<SummarizedNgContentBuilder> ngContents,
-      List<SummarizedBindableBuilder> inputs,
-      List<SummarizedBindableBuilder> outputs,
       List<SummarizedDirectiveUseBuilder> subdirectives,
-      List<SummarizedContentChildFieldBuilder> contentChildFields,
-      List<SummarizedContentChildFieldBuilder> contentChildrenFields,
       List<SummarizedExportedIdentifierBuilder> exports})
-      : _isComponent = isComponent,
+      : _classAnnotations = classAnnotations,
+        _isComponent = isComponent,
         _selectorStr = selectorStr,
         _selectorOffset = selectorOffset,
-        _decoratedClassName = decoratedClassName,
         _exportAs = exportAs,
         _exportAsOffset = exportAsOffset,
         _templateUrl = templateUrl,
@@ -926,23 +1182,16 @@ class SummarizedDirectiveBuilder extends Object
         _templateText = templateText,
         _templateOffset = templateOffset,
         _ngContents = ngContents,
-        _inputs = inputs,
-        _outputs = outputs,
         _subdirectives = subdirectives,
-        _contentChildFields = contentChildFields,
-        _contentChildrenFields = contentChildrenFields,
         _exports = exports;
 
   /**
    * Flush [informative] data recursively.
    */
   void flushInformative() {
+    _classAnnotations?.flushInformative();
     _ngContents?.forEach((b) => b.flushInformative());
-    _inputs?.forEach((b) => b.flushInformative());
-    _outputs?.forEach((b) => b.flushInformative());
     _subdirectives?.forEach((b) => b.flushInformative());
-    _contentChildFields?.forEach((b) => b.flushInformative());
-    _contentChildrenFields?.forEach((b) => b.flushInformative());
     _exports?.forEach((b) => b.flushInformative());
   }
 
@@ -950,10 +1199,11 @@ class SummarizedDirectiveBuilder extends Object
    * Accumulate non-[informative] data into [signature].
    */
   void collectApiSignature(api_sig.ApiSignature signature) {
+    signature.addBool(this._classAnnotations != null);
+    this._classAnnotations?.collectApiSignature(signature);
     signature.addBool(this._isComponent == true);
     signature.addString(this._selectorStr ?? '');
     signature.addInt(this._selectorOffset ?? 0);
-    signature.addString(this._decoratedClassName ?? '');
     signature.addString(this._exportAs ?? '');
     signature.addInt(this._exportAsOffset ?? 0);
     signature.addString(this._templateUrl ?? '');
@@ -969,43 +1219,11 @@ class SummarizedDirectiveBuilder extends Object
         x?.collectApiSignature(signature);
       }
     }
-    if (this._inputs == null) {
-      signature.addInt(0);
-    } else {
-      signature.addInt(this._inputs.length);
-      for (var x in this._inputs) {
-        x?.collectApiSignature(signature);
-      }
-    }
-    if (this._outputs == null) {
-      signature.addInt(0);
-    } else {
-      signature.addInt(this._outputs.length);
-      for (var x in this._outputs) {
-        x?.collectApiSignature(signature);
-      }
-    }
     if (this._subdirectives == null) {
       signature.addInt(0);
     } else {
       signature.addInt(this._subdirectives.length);
       for (var x in this._subdirectives) {
-        x?.collectApiSignature(signature);
-      }
-    }
-    if (this._contentChildFields == null) {
-      signature.addInt(0);
-    } else {
-      signature.addInt(this._contentChildFields.length);
-      for (var x in this._contentChildFields) {
-        x?.collectApiSignature(signature);
-      }
-    }
-    if (this._contentChildrenFields == null) {
-      signature.addInt(0);
-    } else {
-      signature.addInt(this._contentChildrenFields.length);
-      for (var x in this._contentChildrenFields) {
         x?.collectApiSignature(signature);
       }
     }
@@ -1020,23 +1238,19 @@ class SummarizedDirectiveBuilder extends Object
   }
 
   fb.Offset finish(fb.Builder fbBuilder) {
+    fb.Offset offset_classAnnotations;
     fb.Offset offset_selectorStr;
-    fb.Offset offset_decoratedClassName;
     fb.Offset offset_exportAs;
     fb.Offset offset_templateUrl;
     fb.Offset offset_templateText;
     fb.Offset offset_ngContents;
-    fb.Offset offset_inputs;
-    fb.Offset offset_outputs;
     fb.Offset offset_subdirectives;
-    fb.Offset offset_contentChildFields;
-    fb.Offset offset_contentChildrenFields;
     fb.Offset offset_exports;
+    if (_classAnnotations != null) {
+      offset_classAnnotations = _classAnnotations.finish(fbBuilder);
+    }
     if (_selectorStr != null) {
       offset_selectorStr = fbBuilder.writeString(_selectorStr);
-    }
-    if (_decoratedClassName != null) {
-      offset_decoratedClassName = fbBuilder.writeString(_decoratedClassName);
     }
     if (_exportAs != null) {
       offset_exportAs = fbBuilder.writeString(_exportAs);
@@ -1051,42 +1265,26 @@ class SummarizedDirectiveBuilder extends Object
       offset_ngContents = fbBuilder
           .writeList(_ngContents.map((b) => b.finish(fbBuilder)).toList());
     }
-    if (!(_inputs == null || _inputs.isEmpty)) {
-      offset_inputs =
-          fbBuilder.writeList(_inputs.map((b) => b.finish(fbBuilder)).toList());
-    }
-    if (!(_outputs == null || _outputs.isEmpty)) {
-      offset_outputs = fbBuilder
-          .writeList(_outputs.map((b) => b.finish(fbBuilder)).toList());
-    }
     if (!(_subdirectives == null || _subdirectives.isEmpty)) {
       offset_subdirectives = fbBuilder
           .writeList(_subdirectives.map((b) => b.finish(fbBuilder)).toList());
-    }
-    if (!(_contentChildFields == null || _contentChildFields.isEmpty)) {
-      offset_contentChildFields = fbBuilder.writeList(
-          _contentChildFields.map((b) => b.finish(fbBuilder)).toList());
-    }
-    if (!(_contentChildrenFields == null || _contentChildrenFields.isEmpty)) {
-      offset_contentChildrenFields = fbBuilder.writeList(
-          _contentChildrenFields.map((b) => b.finish(fbBuilder)).toList());
     }
     if (!(_exports == null || _exports.isEmpty)) {
       offset_exports = fbBuilder
           .writeList(_exports.map((b) => b.finish(fbBuilder)).toList());
     }
     fbBuilder.startTable();
+    if (offset_classAnnotations != null) {
+      fbBuilder.addOffset(0, offset_classAnnotations);
+    }
     if (_isComponent == true) {
-      fbBuilder.addBool(0, true);
+      fbBuilder.addBool(1, true);
     }
     if (offset_selectorStr != null) {
-      fbBuilder.addOffset(1, offset_selectorStr);
+      fbBuilder.addOffset(2, offset_selectorStr);
     }
     if (_selectorOffset != null && _selectorOffset != 0) {
-      fbBuilder.addUint32(2, _selectorOffset);
-    }
-    if (offset_decoratedClassName != null) {
-      fbBuilder.addOffset(3, offset_decoratedClassName);
+      fbBuilder.addUint32(3, _selectorOffset);
     }
     if (offset_exportAs != null) {
       fbBuilder.addOffset(4, offset_exportAs);
@@ -1112,23 +1310,11 @@ class SummarizedDirectiveBuilder extends Object
     if (offset_ngContents != null) {
       fbBuilder.addOffset(11, offset_ngContents);
     }
-    if (offset_inputs != null) {
-      fbBuilder.addOffset(12, offset_inputs);
-    }
-    if (offset_outputs != null) {
-      fbBuilder.addOffset(13, offset_outputs);
-    }
     if (offset_subdirectives != null) {
-      fbBuilder.addOffset(14, offset_subdirectives);
-    }
-    if (offset_contentChildFields != null) {
-      fbBuilder.addOffset(15, offset_contentChildFields);
-    }
-    if (offset_contentChildrenFields != null) {
-      fbBuilder.addOffset(16, offset_contentChildrenFields);
+      fbBuilder.addOffset(12, offset_subdirectives);
     }
     if (offset_exports != null) {
-      fbBuilder.addOffset(17, offset_exports);
+      fbBuilder.addOffset(13, offset_exports);
     }
     return fbBuilder.endTable();
   }
@@ -1151,10 +1337,10 @@ class _SummarizedDirectiveImpl extends Object
 
   _SummarizedDirectiveImpl(this._bc, this._bcOffset);
 
+  idl.SummarizedClassAnnotations _classAnnotations;
   bool _isComponent;
   String _selectorStr;
   int _selectorOffset;
-  String _decoratedClassName;
   String _exportAs;
   int _exportAsOffset;
   String _templateUrl;
@@ -1163,36 +1349,32 @@ class _SummarizedDirectiveImpl extends Object
   String _templateText;
   int _templateOffset;
   List<idl.SummarizedNgContent> _ngContents;
-  List<idl.SummarizedBindable> _inputs;
-  List<idl.SummarizedBindable> _outputs;
   List<idl.SummarizedDirectiveUse> _subdirectives;
-  List<idl.SummarizedContentChildField> _contentChildFields;
-  List<idl.SummarizedContentChildField> _contentChildrenFields;
   List<idl.SummarizedExportedIdentifier> _exports;
 
   @override
+  idl.SummarizedClassAnnotations get classAnnotations {
+    _classAnnotations ??= const _SummarizedClassAnnotationsReader()
+        .vTableGet(_bc, _bcOffset, 0, null);
+    return _classAnnotations;
+  }
+
+  @override
   bool get isComponent {
-    _isComponent ??= const fb.BoolReader().vTableGet(_bc, _bcOffset, 0, false);
+    _isComponent ??= const fb.BoolReader().vTableGet(_bc, _bcOffset, 1, false);
     return _isComponent;
   }
 
   @override
   String get selectorStr {
-    _selectorStr ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 1, '');
+    _selectorStr ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 2, '');
     return _selectorStr;
   }
 
   @override
   int get selectorOffset {
-    _selectorOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 2, 0);
+    _selectorOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 3, 0);
     return _selectorOffset;
-  }
-
-  @override
-  String get decoratedClassName {
-    _decoratedClassName ??=
-        const fb.StringReader().vTableGet(_bc, _bcOffset, 3, '');
-    return _decoratedClassName;
   }
 
   @override
@@ -1249,47 +1431,11 @@ class _SummarizedDirectiveImpl extends Object
   }
 
   @override
-  List<idl.SummarizedBindable> get inputs {
-    _inputs ??= const fb.ListReader<idl.SummarizedBindable>(
-            const _SummarizedBindableReader())
-        .vTableGet(_bc, _bcOffset, 12, const <idl.SummarizedBindable>[]);
-    return _inputs;
-  }
-
-  @override
-  List<idl.SummarizedBindable> get outputs {
-    _outputs ??= const fb.ListReader<idl.SummarizedBindable>(
-            const _SummarizedBindableReader())
-        .vTableGet(_bc, _bcOffset, 13, const <idl.SummarizedBindable>[]);
-    return _outputs;
-  }
-
-  @override
   List<idl.SummarizedDirectiveUse> get subdirectives {
     _subdirectives ??= const fb.ListReader<idl.SummarizedDirectiveUse>(
             const _SummarizedDirectiveUseReader())
-        .vTableGet(_bc, _bcOffset, 14, const <idl.SummarizedDirectiveUse>[]);
+        .vTableGet(_bc, _bcOffset, 12, const <idl.SummarizedDirectiveUse>[]);
     return _subdirectives;
-  }
-
-  @override
-  List<idl.SummarizedContentChildField> get contentChildFields {
-    _contentChildFields ??=
-        const fb.ListReader<idl.SummarizedContentChildField>(
-                const _SummarizedContentChildFieldReader())
-            .vTableGet(
-                _bc, _bcOffset, 15, const <idl.SummarizedContentChildField>[]);
-    return _contentChildFields;
-  }
-
-  @override
-  List<idl.SummarizedContentChildField> get contentChildrenFields {
-    _contentChildrenFields ??=
-        const fb.ListReader<idl.SummarizedContentChildField>(
-                const _SummarizedContentChildFieldReader())
-            .vTableGet(
-                _bc, _bcOffset, 16, const <idl.SummarizedContentChildField>[]);
-    return _contentChildrenFields;
   }
 
   @override
@@ -1297,7 +1443,7 @@ class _SummarizedDirectiveImpl extends Object
     _exports ??= const fb.ListReader<idl.SummarizedExportedIdentifier>(
             const _SummarizedExportedIdentifierReader())
         .vTableGet(
-            _bc, _bcOffset, 17, const <idl.SummarizedExportedIdentifier>[]);
+            _bc, _bcOffset, 13, const <idl.SummarizedExportedIdentifier>[]);
     return _exports;
   }
 }
@@ -1306,11 +1452,11 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
   @override
   Map<String, Object> toJson() {
     Map<String, Object> _result = <String, Object>{};
+    if (classAnnotations != null)
+      _result["classAnnotations"] = classAnnotations.toJson();
     if (isComponent != false) _result["isComponent"] = isComponent;
     if (selectorStr != '') _result["selectorStr"] = selectorStr;
     if (selectorOffset != 0) _result["selectorOffset"] = selectorOffset;
-    if (decoratedClassName != '')
-      _result["decoratedClassName"] = decoratedClassName;
     if (exportAs != '') _result["exportAs"] = exportAs;
     if (exportAsOffset != 0) _result["exportAsOffset"] = exportAsOffset;
     if (templateUrl != '') _result["templateUrl"] = templateUrl;
@@ -1323,19 +1469,9 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
     if (ngContents.isNotEmpty)
       _result["ngContents"] =
           ngContents.map((_value) => _value.toJson()).toList();
-    if (inputs.isNotEmpty)
-      _result["inputs"] = inputs.map((_value) => _value.toJson()).toList();
-    if (outputs.isNotEmpty)
-      _result["outputs"] = outputs.map((_value) => _value.toJson()).toList();
     if (subdirectives.isNotEmpty)
       _result["subdirectives"] =
           subdirectives.map((_value) => _value.toJson()).toList();
-    if (contentChildFields.isNotEmpty)
-      _result["contentChildFields"] =
-          contentChildFields.map((_value) => _value.toJson()).toList();
-    if (contentChildrenFields.isNotEmpty)
-      _result["contentChildrenFields"] =
-          contentChildrenFields.map((_value) => _value.toJson()).toList();
     if (exports.isNotEmpty)
       _result["exports"] = exports.map((_value) => _value.toJson()).toList();
     return _result;
@@ -1343,10 +1479,10 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
 
   @override
   Map<String, Object> toMap() => {
+        "classAnnotations": classAnnotations,
         "isComponent": isComponent,
         "selectorStr": selectorStr,
         "selectorOffset": selectorOffset,
-        "decoratedClassName": decoratedClassName,
         "exportAs": exportAs,
         "exportAsOffset": exportAsOffset,
         "templateUrl": templateUrl,
@@ -1355,11 +1491,7 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
         "templateText": templateText,
         "templateOffset": templateOffset,
         "ngContents": ngContents,
-        "inputs": inputs,
-        "outputs": outputs,
         "subdirectives": subdirectives,
-        "contentChildFields": contentChildFields,
-        "contentChildrenFields": contentChildrenFields,
         "exports": exports,
       };
 

--- a/angular_analyzer_plugin/lib/src/summary/format.fbs
+++ b/angular_analyzer_plugin/lib/src/summary/format.fbs
@@ -33,17 +33,31 @@ table LinkedDartSummary {
 table UnlinkedDartSummary {
   directiveSummaries:[SummarizedDirective] (id: 0);
 
-  errors:[SummarizedAnalysisError] (id: 1);
+  annotatedClasses:[SummarizedClassAnnotations] (id: 1);
+
+  errors:[SummarizedAnalysisError] (id: 2);
+}
+
+table SummarizedClassAnnotations {
+  className:string (id: 0);
+
+  inputs:[SummarizedBindable] (id: 1);
+
+  outputs:[SummarizedBindable] (id: 2);
+
+  contentChildFields:[SummarizedContentChildField] (id: 3);
+
+  contentChildrenFields:[SummarizedContentChildField] (id: 4);
 }
 
 table SummarizedDirective {
-  isComponent:bool (id: 0);
+  classAnnotations:SummarizedClassAnnotations (id: 0);
 
-  selectorStr:string (id: 1);
+  isComponent:bool (id: 1);
 
-  selectorOffset:uint (id: 2);
+  selectorStr:string (id: 2);
 
-  decoratedClassName:string (id: 3);
+  selectorOffset:uint (id: 3);
 
   exportAs:string (id: 4);
 
@@ -61,17 +75,9 @@ table SummarizedDirective {
 
   ngContents:[SummarizedNgContent] (id: 11);
 
-  inputs:[SummarizedBindable] (id: 12);
+  subdirectives:[SummarizedDirectiveUse] (id: 12);
 
-  outputs:[SummarizedBindable] (id: 13);
-
-  subdirectives:[SummarizedDirectiveUse] (id: 14);
-
-  contentChildFields:[SummarizedContentChildField] (id: 15);
-
-  contentChildrenFields:[SummarizedContentChildField] (id: 16);
-
-  exports:[SummarizedExportedIdentifier] (id: 17);
+  exports:[SummarizedExportedIdentifier] (id: 13);
 }
 
 table SummarizedAnalysisError {

--- a/angular_analyzer_plugin/lib/src/summary/idl.dart
+++ b/angular_analyzer_plugin/lib/src/summary/idl.dart
@@ -57,20 +57,34 @@ abstract class UnlinkedDartSummary extends base.SummaryClass {
 
   @Id(0)
   List<SummarizedDirective> get directiveSummaries;
-
   @Id(1)
+  List<SummarizedClassAnnotations> get annotatedClasses;
+  @Id(2)
   List<SummarizedAnalysisError> get errors;
+}
+
+abstract class SummarizedClassAnnotations extends base.SummaryClass {
+  @Id(0)
+  String get className;
+  @Id(1)
+  List<SummarizedBindable> get inputs;
+  @Id(2)
+  List<SummarizedBindable> get outputs;
+  @Id(3)
+  List<SummarizedContentChildField> get contentChildFields;
+  @Id(4)
+  List<SummarizedContentChildField> get contentChildrenFields;
 }
 
 abstract class SummarizedDirective extends base.SummaryClass {
   @Id(0)
-  bool get isComponent;
+  SummarizedClassAnnotations get classAnnotations;
   @Id(1)
-  String get selectorStr;
+  bool get isComponent;
   @Id(2)
-  int get selectorOffset;
+  String get selectorStr;
   @Id(3)
-  String get decoratedClassName;
+  int get selectorOffset;
   @Id(4)
   String get exportAs;
   @Id(5)
@@ -88,16 +102,8 @@ abstract class SummarizedDirective extends base.SummaryClass {
   @Id(11)
   List<SummarizedNgContent> get ngContents;
   @Id(12)
-  List<SummarizedBindable> get inputs;
-  @Id(13)
-  List<SummarizedBindable> get outputs;
-  @Id(14)
   List<SummarizedDirectiveUse> get subdirectives;
-  @Id(15)
-  List<SummarizedContentChildField> get contentChildFields;
-  @Id(16)
-  List<SummarizedContentChildField> get contentChildrenFields;
-  @Id(17)
+  @Id(13)
   List<SummarizedExportedIdentifier> get exports;
 }
 


### PR DESCRIPTION
Much of the code change is related to tracking annotations on
non-component/directive classes. Added a new member to DirectivesResult
to decrease likelihood of a non-directive being accepted as a directive
somewhere it shouldn't.

I don't currently resolve any conflicts between inherited members at
all. Waiting for confirmation of importance and strategy.

Also requires serializing non-directive angular metadata information,
and which in turn meant refactoring the serialization/deserialization a
bit.

Naming could still use some work.