### PR TITLE
Salt hashes for version updates of analysis/summary file formats

### DIFF
--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -501,7 +501,8 @@ class AngularDriver
 
   @override
   Future<List<NgContent>> getHtmlNgContent(String path) async {
-    final key = '${_fileTracker.getContentSignature(path).toHex()}.ngunlinked';
+    final baseKey = _fileTracker.getContentSignature(path).toHex();
+    final key = '$baseKey.ngunlinked';
     final bytes = byteStore.get(key);
     final source = getSource(path);
     if (bytes != null) {
@@ -703,7 +704,8 @@ class AngularDriver
       (await getDirectives(path)).directives;
 
   Future<DirectivesResult> getDirectives(String path) async {
-    final key = '${_fileTracker.getContentSignature(path).toHex()}.ngunlinked';
+    final baseKey = _fileTracker.getContentSignature(path).toHex();
+    final key = '$baseKey.ngunlinked';
     final bytes = byteStore.get(key);
     if (bytes != null) {
       final summary = new UnlinkedDartSummary.fromBuffer(bytes);

--- a/angular_analyzer_plugin/lib/src/file_tracker.dart
+++ b/angular_analyzer_plugin/lib/src/file_tracker.dart
@@ -8,6 +8,8 @@ abstract class FileHasher {
 }
 
 class FileTracker {
+  static const int salt = 1;
+
   final FileHasher _fileHasher;
 
   FileTracker(this._fileHasher);
@@ -17,17 +19,18 @@ class FileTracker {
 
   final _dartFilesWithDartTemplates = new HashSet<String>();
 
-  final htmlContentHashes = <String, List<int>>{};
+  final contentHashes = <String, List<int>>{};
 
-  void rehashHtmlContents(String path) {
-    htmlContentHashes[path] = _fileHasher.getContentHash(path).toByteList();
+  void rehashContents(String path) {
+    final signature = _fileHasher.getContentHash(path);
+    contentHashes[path] = signature.toByteList();
   }
 
-  List<int> getHtmlContentHash(String path) {
-    if (htmlContentHashes[path] == null) {
-      rehashHtmlContents(path);
+  List<int> _getContentHash(String path) {
+    if (contentHashes[path] == null) {
+      rehashContents(path);
     }
-    return htmlContentHashes[path];
+    return contentHashes[path];
   }
 
   void setDartHtmlTemplates(String dartPath, List<String> htmlPaths) =>
@@ -82,24 +85,39 @@ class FileTracker {
 
   ApiSignature getDartSignature(String dartPath) {
     final signature = new ApiSignature()
+      ..addInt(salt)
       ..addBytes(_fileHasher.getUnitElementHash(dartPath).toByteList());
     for (final htmlPath in getHtmlPathsAffectingDart(dartPath)) {
-      signature.addBytes(getHtmlContentHash(htmlPath));
+      signature.addBytes(_getContentHash(htmlPath));
     }
     return signature;
   }
 
   ApiSignature getHtmlSignature(String htmlPath) {
     final signature = new ApiSignature()
-      ..addBytes(getHtmlContentHash(htmlPath));
+      ..addInt(salt)
+      ..addBytes(_getContentHash(htmlPath));
     for (final dartPath in getDartPathsReferencingHtml(htmlPath)) {
       signature.addBytes(_fileHasher.getUnitElementHash(dartPath).toByteList());
       for (final subHtmlPath in getHtmlPathsAffectingDartContext(dartPath)) {
-        signature.addBytes(getHtmlContentHash(subHtmlPath));
+        signature.addBytes(_getContentHash(subHtmlPath));
       }
     }
     return signature;
   }
+
+  ApiSignature getContentSignature(String path) {
+    if (contentHashes[path] == null) {
+      rehashContents(path);
+    }
+    return new ApiSignature()
+      ..addInt(salt)
+      ..addBytes(_getContentHash(path));
+  }
+
+  ApiSignature getUnitElementSignature(String path) => new ApiSignature()
+    ..addInt(salt)
+    ..addBytes(_fileHasher.getUnitElementHash(path).toByteList());
 }
 
 class _RelationshipTracker {

--- a/angular_analyzer_plugin/test/file_tracker_test.dart
+++ b/angular_analyzer_plugin/test/file_tracker_test.dart
@@ -286,6 +286,7 @@ class FileTrackerTest {
         .thenReturn(fooDartElementSignature);
 
     final expectedSignature = new ApiSignature()
+      ..addInt(FileTracker.salt)
       ..addBytes(fooDartElementSignature.toByteList())
       ..addBytes(barHtmlSignature.toByteList());
 
@@ -314,6 +315,7 @@ class FileTrackerTest {
         .thenReturn(fooTestDartElementSignature);
 
     final expectedSignature = new ApiSignature()
+      ..addInt(FileTracker.salt)
       ..addBytes(fooHtmlSignature.toByteList())
       ..addBytes(fooDartElementSignature.toByteList())
       ..addBytes(barHtmlSignature.toByteList())
@@ -329,14 +331,39 @@ class FileTrackerTest {
     when(_fileHasher.getContentHash("foo.html")).thenReturn(fooHtmlSignature);
 
     for (var i = 0; i < 3; ++i) {
-      _fileTracker.getHtmlContentHash("foo.html");
+      _fileTracker.getContentSignature("foo.html");
       verify(_fileHasher.getContentHash("foo.html")).once();
     }
 
+    _fileTracker.rehashContents("foo.html");
+
     for (var i = 0; i < 3; ++i) {
-      _fileTracker.rehashHtmlContents("foo.html");
+      _fileTracker.getContentSignature("foo.html");
       verify(_fileHasher.getContentHash("foo.html")).times(2);
     }
+  }
+
+  // ignore: non_constant_identifier_names
+  void test_getContentHashIsSalted() {
+    final fooHtmlSignature = new ApiSignature()..addInt(1);
+    final expectedSignature = new ApiSignature()
+      ..addInt(FileTracker.salt)
+      ..addBytes(fooHtmlSignature.toByteList());
+    when(_fileHasher.getContentHash("foo.html")).thenReturn(fooHtmlSignature);
+    expect(_fileTracker.getContentSignature("foo.html").toHex(),
+        equals(expectedSignature.toHex()));
+  }
+
+  // ignore: non_constant_identifier_names
+  void test_getUnitElementSignatureIsSalted() {
+    final fooDartElementSignature = new ApiSignature()..addInt(1);
+    final expectedSignature = new ApiSignature()
+      ..addInt(FileTracker.salt)
+      ..addBytes(fooDartElementSignature.toByteList());
+    when(_fileHasher.getUnitElementHash("foo.dart"))
+        .thenReturn(fooDartElementSignature);
+    expect(_fileTracker.getUnitElementSignature("foo.dart").toHex(),
+        equals(expectedSignature.toHex()));
   }
 }
 

--- a/angular_analyzer_plugin/test/test_all.dart
+++ b/angular_analyzer_plugin/test/test_all.dart
@@ -2,6 +2,7 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import 'angular_driver_test.dart' as angular_driver_test;
 import 'completion_contributor_test.dart' as completion_contributor_test;
+import 'file_tracker_test.dart' as file_tracker_test;
 import 'navigation_test.dart' as navigation_test;
 import 'offsetting_constant_value_visitor_test.dart'
     as offsetting_constant_value_visitor_test;
@@ -20,5 +21,6 @@ void main() {
     offsetting_constant_value_visitor_test.main();
     navigation_test.main();
     completion_contributor_test.main();
+    file_tracker_test.main();
   }, name: 'Angular Plugin tests');
 }


### PR DESCRIPTION
Track file hashes the same for html/non-html, do all hashing through
FileTracker which has a salt it applies to everything. Tests that dart
signatures, html signatures, content signatures, and unit element
signatures are salted. Refactor angular driver to use file tracker's
APIs all the time.

Also looks like file tracker tests weren't running before via
test_all.dart; fixed. And it had a test that was failing (presumably,
since it wasn't running!). Fixed that too.

Salt is currently at 1 since we're on version 1. Well, two, but the
presence of the salt distinguishes that much by itself.