### PR TITLE
Update tests to use package:test and package:mockito

### DIFF
--- a/angular_analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/pubspec.yaml
@@ -22,6 +22,5 @@ dependency_overrides:
     path: ../deps/sdk/pkg/front_end
 dev_dependencies:
   test_reflective_loader: '^0.1.0'
-  typed_mock: '^0.0.4'
-  unittest: '^0.11.0'
   test: '^0.12.20'
+  mockito: '^2.0.2'

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -10,9 +10,9 @@ import 'package:angular_analyzer_plugin/notification_manager.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:angular_analyzer_plugin/src/angular_driver.dart';
-import 'package:typed_mock/typed_mock.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tuple/tuple.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'package:front_end/src/incremental/byte_store.dart';
 import 'package:front_end/src/base/performace_logger.dart';
@@ -493,5 +493,5 @@ class GatheringErrorListener implements AnalysisErrorListener {
   }
 }
 
-class MockNotificationManager extends TypedMock implements NotificationManager {
+class MockNotificationManager extends Mock implements NotificationManager {
 }

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -493,5 +493,4 @@ class GatheringErrorListener implements AnalysisErrorListener {
   }
 }
 
-class MockNotificationManager extends Mock implements NotificationManager {
-}
+class MockNotificationManager extends Mock implements NotificationManager {}

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -14,7 +14,7 @@ import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/view_extraction.dart';
 import 'package:angular_analyzer_plugin/src/directive_linking.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'abstract_angular.dart';
 

--- a/angular_analyzer_plugin/test/completion_contributor_test.dart
+++ b/angular_analyzer_plugin/test/completion_contributor_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:analyzer_plugin/utilities/completion/relevance.dart';
 import 'package:angular_analyzer_plugin/src/completion.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import 'completion_contributor_test_util.dart';

--- a/angular_analyzer_plugin/test/completion_contributor_test_util.dart
+++ b/angular_analyzer_plugin/test/completion_contributor_test_util.dart
@@ -15,7 +15,7 @@ import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/completion_request.dart';
 import 'package:angular_analyzer_plugin/src/completion.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'abstract_angular.dart';
 

--- a/angular_analyzer_plugin/test/element_assert.dart
+++ b/angular_analyzer_plugin/test/element_assert.dart
@@ -3,7 +3,7 @@ import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 class AngularElementAssert extends _AbstractElementAssert {
   final AngularElement element;

--- a/angular_analyzer_plugin/test/file_tracker_test.dart
+++ b/angular_analyzer_plugin/test/file_tracker_test.dart
@@ -332,7 +332,7 @@ class FileTrackerTest {
 
     for (var i = 0; i < 3; ++i) {
       _fileTracker.getContentSignature("foo.html");
-      verify(_fileHasher.getContentHash("foo.html")).called(0);
+      verify(_fileHasher.getContentHash("foo.html")).called(1);
     }
 
     _fileTracker.rehashContents("foo.html");

--- a/angular_analyzer_plugin/test/file_tracker_test.dart
+++ b/angular_analyzer_plugin/test/file_tracker_test.dart
@@ -332,15 +332,15 @@ class FileTrackerTest {
 
     for (var i = 0; i < 3; ++i) {
       _fileTracker.getContentSignature("foo.html");
-      verify(_fileHasher.getContentHash("foo.html")).called(1);
     }
+    verify(_fileHasher.getContentHash("foo.html")).called(1);
 
     _fileTracker.rehashContents("foo.html");
 
     for (var i = 0; i < 3; ++i) {
       _fileTracker.getContentSignature("foo.html");
-      verify(_fileHasher.getContentHash("foo.html")).called(2);
     }
+    verify(_fileHasher.getContentHash("foo.html")).called(1);
   }
 
   // ignore: non_constant_identifier_names

--- a/angular_analyzer_plugin/test/file_tracker_test.dart
+++ b/angular_analyzer_plugin/test/file_tracker_test.dart
@@ -1,8 +1,8 @@
 import 'package:angular_analyzer_plugin/src/file_tracker.dart';
 import 'package:front_end/src/base/api_signature.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
-import 'package:unittest/unittest.dart';
-import 'package:typed_mock/typed_mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 
 void main() {
   defineReflectiveSuite(() {
@@ -332,14 +332,14 @@ class FileTrackerTest {
 
     for (var i = 0; i < 3; ++i) {
       _fileTracker.getContentSignature("foo.html");
-      verify(_fileHasher.getContentHash("foo.html")).once();
+      verify(_fileHasher.getContentHash("foo.html")).called(0);
     }
 
     _fileTracker.rehashContents("foo.html");
 
     for (var i = 0; i < 3; ++i) {
       _fileTracker.getContentSignature("foo.html");
-      verify(_fileHasher.getContentHash("foo.html")).times(2);
+      verify(_fileHasher.getContentHash("foo.html")).called(2);
     }
   }
 
@@ -367,4 +367,4 @@ class FileTrackerTest {
   }
 }
 
-class _FileHasherMock extends TypedMock implements FileHasher {}
+class _FileHasherMock extends Mock implements FileHasher {}

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -42,8 +42,8 @@ class AngularNavigationContributorTest extends AbstractAngularTest {
   void setUp() {
     super.setUp();
     when(collector.addRegion(
-        argThat(new isInstanceOf<int>()),
-        typed(new isInstanceOf<int>()),
+        argThat(const isInstanceOf<int>()),
+        argThat(const isInstanceOf<int>()),
         typed(any),
         typed(any))).thenAnswer((invocation) {
       final offset = invocation.positionalArguments[0] as int;

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -41,7 +41,7 @@ class AngularNavigationContributorTest extends AbstractAngularTest {
   @override
   void setUp() {
     super.setUp();
-    when(collector.addRegion(typed(any), typed(any), typed(any), typed(any)))
+    when(collector.addRegion(argThat(new isInstanceOf<int>()), typed(new isInstanceOf<int>()), typed(any), typed(any)))
         .thenAnswer((invocation) {
           final offset = invocation.positionalArguments[0] as int;
           final length = invocation.positionalArguments[1] as int;

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -41,12 +41,15 @@ class AngularNavigationContributorTest extends AbstractAngularTest {
   @override
   void setUp() {
     super.setUp();
-    when(collector.addRegion(argThat(new isInstanceOf<int>()), typed(new isInstanceOf<int>()), typed(any), typed(any)))
-        .thenAnswer((invocation) {
-          final offset = invocation.positionalArguments[0] as int;
-          final length = invocation.positionalArguments[1] as int;
-          final targetKind = invocation.positionalArguments[2];
-          final targetLocation = invocation.positionalArguments[3];
+    when(collector.addRegion(
+        argThat(new isInstanceOf<int>()),
+        typed(new isInstanceOf<int>()),
+        typed(any),
+        typed(any))).thenAnswer((invocation) {
+      final offset = invocation.positionalArguments[0] as int;
+      final length = invocation.positionalArguments[1] as int;
+      final targetKind = invocation.positionalArguments[2];
+      final targetLocation = invocation.positionalArguments[3];
       regions.add(new _RecordedNavigationRegion(
           offset, length, targetKind, targetLocation));
     });
@@ -334,11 +337,9 @@ class GatheringErrorListener implements AnalysisErrorListener {
   }
 }
 
-class NavigationCollectorMock extends Mock implements NavigationCollector {
-}
+class NavigationCollectorMock extends Mock implements NavigationCollector {}
 
-class OccurrencesCollectorMock extends Mock
-    implements OccurrencesCollector {}
+class OccurrencesCollectorMock extends Mock implements OccurrencesCollector {}
 
 class SourceMock extends Mock implements Source {
   final String fullPath;

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -6,8 +6,8 @@ import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/navigation.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
-import 'package:typed_mock/typed_mock.dart';
-import 'package:unittest/unittest.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
 
 import 'abstract_angular.dart';
 
@@ -41,8 +41,12 @@ class AngularNavigationContributorTest extends AbstractAngularTest {
   @override
   void setUp() {
     super.setUp();
-    when(collector.addRegion(anyInt, anyInt, anyObject, anyObject))
-        .thenInvoke((offset, length, targetKind, targetLocation) {
+    when(collector.addRegion(typed(any), typed(any), typed(any), typed(any)))
+        .thenAnswer((invocation) {
+          final offset = invocation.positionalArguments[0] as int;
+          final length = invocation.positionalArguments[1] as int;
+          final targetKind = invocation.positionalArguments[2];
+          final targetLocation = invocation.positionalArguments[3];
       regions.add(new _RecordedNavigationRegion(
           offset, length, targetKind, targetLocation));
     });
@@ -233,7 +237,9 @@ class AngularOccurrencesContributorTest extends AbstractAngularTest {
   @override
   void setUp() {
     super.setUp();
-    when(collector.addOccurrences(anyObject)).thenInvoke(occurrencesList.add);
+    when(collector.addOccurrences(typed(any))).thenAnswer((invocation) {
+      occurrencesList.add(invocation.positionalArguments.first);
+    });
   }
 
   // ignore: non_constant_identifier_names
@@ -328,13 +334,13 @@ class GatheringErrorListener implements AnalysisErrorListener {
   }
 }
 
-class NavigationCollectorMock extends TypedMock implements NavigationCollector {
+class NavigationCollectorMock extends Mock implements NavigationCollector {
 }
 
-class OccurrencesCollectorMock extends TypedMock
+class OccurrencesCollectorMock extends Mock
     implements OccurrencesCollector {}
 
-class SourceMock extends TypedMock implements Source {
+class SourceMock extends Mock implements Source {
   final String fullPath;
 
   SourceMock([String name = 'mocked.dart']) : fullPath = name;

--- a/angular_analyzer_plugin/test/offsetting_constant_value_visitor_test.dart
+++ b/angular_analyzer_plugin/test/offsetting_constant_value_visitor_test.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/src/dart/scanner/scanner.dart';
 import 'package:analyzer/src/generated/parser.dart';
 import 'package:angular_analyzer_plugin/src/tasks.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 void main() {
   defineReflectiveSuite(() {

--- a/angular_analyzer_plugin/test/plugin_test.dart
+++ b/angular_analyzer_plugin/test/plugin_test.dart
@@ -7,8 +7,8 @@ import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:angular_analyzer_plugin/plugin.dart';
 import 'package:angular_analyzer_plugin/src/noop_driver.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
-import 'package:unittest/unittest.dart';
-import 'package:typed_mock/typed_mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 
 import 'mock_sdk.dart';
 
@@ -170,4 +170,4 @@ plugins:
   }
 }
 
-class MockResourceProvider extends TypedMock implements ResourceProvider {}
+class MockResourceProvider extends Mock implements ResourceProvider {}

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -10,7 +10,7 @@ import 'package:angular_analyzer_plugin/errors.dart';
 import 'package:angular_ast/angular_ast.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'package:tuple/tuple.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'abstract_angular.dart';
 import 'element_assert.dart';

--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -1340,9 +1340,9 @@ class _SelectorTest {
 
   void setUp() {
     when(template.addRange(typed(any), typed(any))).thenAnswer((invocation) {
-        final range = invocation.positionalArguments[0];
-        final element = invocation.positionalArguments[1];
-        resolvedRanges.add(new ResolvedRange(range, element));
+      final range = invocation.positionalArguments[0];
+      final element = invocation.positionalArguments[1];
+      resolvedRanges.add(new ResolvedRange(range, element));
     });
   }
 

--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -59,8 +59,8 @@ class AndSelectorTest extends _SelectorTest {
         .thenReturn(SelectorMatch.NoMatch);
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     verify(selector1.match(typed(any), typed(any))).called(1);
-    verify(selector2.match(typed(any), typed(any))).called(0);
-    verify(selector3.match(typed(any), typed(any))).called(0);
+    verifyNever(selector2.match(typed(any), typed(any)));
+    verifyNever(selector3.match(typed(any), typed(any)));
   }
 
   // ignore: non_constant_identifier_names
@@ -70,7 +70,7 @@ class AndSelectorTest extends _SelectorTest {
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     verify(selector1.match(typed(any), typed(any))).called(1);
     verify(selector2.match(typed(any), typed(any))).called(1);
-    verify(selector3.match(typed(any), typed(any))).called(0);
+    verifyNever(selector3.match(typed(any), typed(any)));
   }
 
   // ignore: non_constant_identifier_names
@@ -82,7 +82,7 @@ class AndSelectorTest extends _SelectorTest {
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     verify(selector1.match(typed(any), typed(any))).called(1);
     verify(selector2.match(typed(any), typed(any))).called(1);
-    verify(selector3.match(typed(any), typed(any))).called(0);
+    verifyNever(selector3.match(typed(any), typed(any)));
   }
 
   // ignore: non_constant_identifier_names
@@ -119,7 +119,7 @@ class AndSelectorTest extends _SelectorTest {
     expect(selector.availableTo(element), equals(false));
     verify(selector1.availableTo(typed(any))).called(1);
     verify(selector2.availableTo(typed(any))).called(1);
-    verify(selector3.availableTo(typed(any))).called(0);
+    verifyNever(selector3.availableTo(typed(any)));
   }
 
   // ignore: non_constant_identifier_names
@@ -470,13 +470,13 @@ class OrSelectorTest extends _SelectorTest {
     when(selector1.availableTo(typed(any))).thenReturn(true);
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
     verify(selector1.match(typed(any), typed(any))).called(1);
-    verify(selector2.match(typed(any), typed(any))).called(0);
-    verify(selector3.match(typed(any), typed(any))).called(0);
+    verifyNever(selector2.match(typed(any), typed(any)));
+    verifyNever(selector3.match(typed(any), typed(any)));
 
     expect(selector.availableTo(element), true);
     verify(selector1.availableTo(typed(any))).called(1);
-    verify(selector2.availableTo(typed(any))).called(0);
-    verify(selector3.availableTo(typed(any))).called(0);
+    verifyNever(selector2.availableTo(typed(any)));
+    verifyNever(selector3.availableTo(typed(any)));
   }
 
   // ignore: non_constant_identifier_names
@@ -498,12 +498,12 @@ class OrSelectorTest extends _SelectorTest {
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
     verify(selector1.match(typed(any), typed(any))).called(1);
     verify(selector2.match(typed(any), typed(any))).called(1);
-    verify(selector3.match(typed(any), typed(any))).called(0);
+    verifyNever(selector3.match(typed(any), typed(any)));
 
     expect(selector.availableTo(element), true);
     verify(selector1.availableTo(typed(any))).called(1);
     verify(selector2.availableTo(typed(any))).called(1);
-    verify(selector3.availableTo(typed(any))).called(0);
+    verifyNever(selector3.availableTo(typed(any)));
   }
 
   // ignore: non_constant_identifier_names
@@ -526,7 +526,7 @@ class OrSelectorTest extends _SelectorTest {
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
     verify(selector1.match(typed(any), typed(any))).called(1);
     verify(selector2.match(typed(any), typed(any))).called(1);
-    verify(selector3.match(typed(any), typed(any))).called(0);
+    verifyNever(selector3.match(typed(any), typed(any)));
   }
 
   // ignore: non_constant_identifier_names

--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -2,8 +2,8 @@ import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
-import 'package:typed_mock/typed_mock.dart';
-import 'package:unittest/unittest.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
 
 void main() {
   defineReflectiveSuite(() {
@@ -32,94 +32,94 @@ class AndSelectorTest extends _SelectorTest {
   void setUp() {
     super.setUp();
     selector = new AndSelector(<Selector>[selector1, selector2, selector3]);
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
-    when(selector3.match(anyObject, anyObject))
+    when(selector3.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
 
-    when(selector1.availableTo(anyObject)).thenReturn(true);
-    when(selector2.availableTo(anyObject)).thenReturn(true);
-    when(selector3.availableTo(anyObject)).thenReturn(true);
+    when(selector1.availableTo(typed(any))).thenReturn(true);
+    when(selector2.availableTo(typed(any))).thenReturn(true);
+    when(selector3.availableTo(typed(any))).thenReturn(true);
   }
 
   // ignore: non_constant_identifier_names
   void test_match() {
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(2);
-    verify(selector2.match(anyObject, anyObject)).times(2);
-    verify(selector3.match(anyObject, anyObject)).times(2);
+    verify(selector1.match(typed(any), typed(any))).called(2);
+    verify(selector2.match(typed(any), typed(any))).called(2);
+    verify(selector3.match(typed(any), typed(any))).called(2);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_false1() {
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(0);
-    verify(selector3.match(anyObject, anyObject)).times(0);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(0);
+    verify(selector3.match(typed(any), typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_false2() {
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(0);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_falseTagMatch() {
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(0);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_TagMatch1() {
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(2);
-    verify(selector2.match(anyObject, anyObject)).times(2);
-    verify(selector3.match(anyObject, anyObject)).times(2);
+    verify(selector1.match(typed(any), typed(any))).called(2);
+    verify(selector2.match(typed(any), typed(any))).called(2);
+    verify(selector3.match(typed(any), typed(any))).called(2);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_TagMatch2() {
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(2);
-    verify(selector2.match(anyObject, anyObject)).times(2);
-    verify(selector3.match(anyObject, anyObject)).times(2);
+    verify(selector1.match(typed(any), typed(any))).called(2);
+    verify(selector2.match(typed(any), typed(any))).called(2);
+    verify(selector3.match(typed(any), typed(any))).called(2);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_availableTo_allMatch() {
     expect(selector.availableTo(element), equals(true));
-    verify(selector1.availableTo(anyObject)).times(1);
-    verify(selector2.availableTo(anyObject)).times(1);
-    verify(selector3.availableTo(anyObject)).times(1);
+    verify(selector1.availableTo(typed(any))).called(1);
+    verify(selector2.availableTo(typed(any))).called(1);
+    verify(selector3.availableTo(typed(any))).called(1);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_availableTo_singleUnmatch() {
-    when(selector2.availableTo(anyObject)).thenReturn(false);
+    when(selector2.availableTo(typed(any))).thenReturn(false);
     expect(selector.availableTo(element), equals(false));
-    verify(selector1.availableTo(anyObject)).times(1);
-    verify(selector2.availableTo(anyObject)).times(1);
-    verify(selector3.availableTo(anyObject)).times(0);
+    verify(selector1.availableTo(typed(any))).called(1);
+    verify(selector2.availableTo(typed(any))).called(1);
+    verify(selector3.availableTo(typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
@@ -389,9 +389,9 @@ class NotSelectorTest extends _SelectorTest {
 
   // ignore: non_constant_identifier_names
   void test_notFalse() {
-    when(condition.match(anyObject, anyObject))
+    when(condition.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
-    when(condition.availableTo(anyObject)).thenReturn(false);
+    when(condition.availableTo(typed(any))).thenReturn(false);
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     expect(selector.availableTo(element), equals(true));
@@ -399,18 +399,18 @@ class NotSelectorTest extends _SelectorTest {
 
   // ignore: non_constant_identifier_names
   void test_notTagMatch() {
-    when(condition.match(anyObject, anyObject))
+    when(condition.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
-    when(condition.availableTo(anyObject)).thenReturn(true);
+    when(condition.availableTo(typed(any))).thenReturn(true);
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     expect(selector.availableTo(element), equals(false));
   }
 
   // ignore: non_constant_identifier_names
   void test_notNonTagMatch() {
-    when(condition.match(anyObject, anyObject))
+    when(condition.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
-    when(condition.availableTo(anyObject)).thenReturn(true);
+    when(condition.availableTo(typed(any))).thenReturn(true);
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     expect(selector.availableTo(element), equals(false));
   }
@@ -452,94 +452,94 @@ class OrSelectorTest extends _SelectorTest {
   void setUp() {
     super.setUp();
     selector = new OrSelector(<Selector>[selector1, selector2, selector3]);
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
-    when(selector1.availableTo(anyObject)).thenReturn(false);
-    when(selector2.match(anyObject, anyObject))
+    when(selector1.availableTo(typed(any))).thenReturn(false);
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
-    when(selector2.availableTo(anyObject)).thenReturn(false);
-    when(selector3.match(anyObject, anyObject))
+    when(selector2.availableTo(typed(any))).thenReturn(false);
+    when(selector3.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NoMatch);
-    when(selector3.availableTo(anyObject)).thenReturn(false);
+    when(selector3.availableTo(typed(any))).thenReturn(false);
   }
 
   // ignore: non_constant_identifier_names
   void test_matchFirstIsTagMatch() {
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
-    when(selector1.availableTo(anyObject)).thenReturn(true);
+    when(selector1.availableTo(typed(any))).thenReturn(true);
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(0);
-    verify(selector3.match(anyObject, anyObject)).times(0);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(0);
+    verify(selector3.match(typed(any), typed(any))).called(0);
 
     expect(selector.availableTo(element), equals(true));
-    verify(selector1.availableTo(anyObject)).times(1);
-    verify(selector2.availableTo(anyObject)).times(0);
-    verify(selector3.availableTo(anyObject)).times(0);
+    verify(selector1.availableTo(typed(any))).called(1);
+    verify(selector2.availableTo(typed(any))).called(0);
+    verify(selector3.availableTo(typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
   void test_matchFirstIsNonTagMatch() {
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(1);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(1);
   }
 
   // ignore: non_constant_identifier_names
   void test_match2TagMatch() {
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
-    when(selector2.availableTo(anyObject)).thenReturn(true);
+    when(selector2.availableTo(typed(any))).thenReturn(true);
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(0);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(0);
 
     expect(selector.availableTo(element), equals(true));
-    verify(selector1.availableTo(anyObject)).times(1);
-    verify(selector2.availableTo(anyObject)).times(1);
-    verify(selector3.availableTo(anyObject)).times(0);
+    verify(selector1.availableTo(typed(any))).called(1);
+    verify(selector2.availableTo(typed(any))).called(1);
+    verify(selector3.availableTo(typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
   void test_match2NonTagMatch() {
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(1);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(1);
   }
 
   // ignore: non_constant_identifier_names
   void test_match2TagAndNonTagMatch() {
-    when(selector1.match(anyObject, anyObject))
+    when(selector1.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.NonTagMatch);
-    when(selector2.match(anyObject, anyObject))
+    when(selector2.match(typed(any), typed(any)))
         .thenReturn(SelectorMatch.TagMatch);
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(0);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(0);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_false() {
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    verify(selector1.match(anyObject, anyObject)).times(1);
-    verify(selector2.match(anyObject, anyObject)).times(1);
-    verify(selector3.match(anyObject, anyObject)).times(1);
+    verify(selector1.match(typed(any), typed(any))).called(1);
+    verify(selector2.match(typed(any), typed(any))).called(1);
+    verify(selector3.match(typed(any), typed(any))).called(1);
 
     expect(selector.availableTo(element), equals(false));
-    verify(selector1.availableTo(anyObject)).times(1);
-    verify(selector2.availableTo(anyObject)).times(1);
-    verify(selector3.availableTo(anyObject)).times(1);
+    verify(selector1.availableTo(typed(any))).called(1);
+    verify(selector2.availableTo(typed(any))).called(1);
+    verify(selector3.availableTo(typed(any))).called(1);
   }
 
   // ignore: non_constant_identifier_names
@@ -1321,9 +1321,9 @@ class HtmlTagForSelectorTest {
   }
 }
 
-class _ElementViewMock extends TypedMock implements ElementView {}
+class _ElementViewMock extends Mock implements ElementView {}
 
-class _SelectorMock extends TypedMock implements Selector {
+class _SelectorMock extends Mock implements Selector {
   final String text;
 
   _SelectorMock(this.text);
@@ -1339,8 +1339,11 @@ class _SelectorTest {
   List<ResolvedRange> resolvedRanges = <ResolvedRange>[];
 
   void setUp() {
-    when(template.addRange(anyObject, anyObject)).thenInvoke((range, element) =>
-        resolvedRanges.add(new ResolvedRange(range, element)));
+    when(template.addRange(typed(any), typed(any))).thenAnswer((invocation) {
+        final range = invocation.positionalArguments[0];
+        final element = invocation.positionalArguments[1];
+        resolvedRanges.add(new ResolvedRange(range, element));
+    });
   }
 
   void _assertRange(ResolvedRange resolvedRange, int offset, int length,
@@ -1355,6 +1358,6 @@ class _SelectorTest {
       new SourceRange(offset, value.length);
 }
 
-class _SourceMock extends TypedMock implements Source {}
+class _SourceMock extends Mock implements Source {}
 
-class _TemplateMock extends TypedMock implements Template {}
+class _TemplateMock extends Mock implements Template {}

--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -107,7 +107,7 @@ class AndSelectorTest extends _SelectorTest {
 
   // ignore: non_constant_identifier_names
   void test_match_availableTo_allMatch() {
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     verify(selector1.availableTo(typed(any))).called(1);
     verify(selector2.availableTo(typed(any))).called(1);
     verify(selector3.availableTo(typed(any))).called(1);
@@ -139,7 +139,7 @@ class AttributeSelectorTest extends _SelectorTest {
         new AttributeSelector(nameElement, null, isWildcard: false);
     when(element.attributes).thenReturn({'not-kind': 'no-matter'});
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -163,7 +163,7 @@ class AttributeSelectorTest extends _SelectorTest {
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     _assertRange(resolvedRanges[0], 100, 4, selector.nameElement);
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -177,7 +177,7 @@ class AttributeSelectorTest extends _SelectorTest {
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     _assertRange(resolvedRanges[0], 100, 4, selector.nameElement);
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -190,7 +190,7 @@ class AttributeSelectorTest extends _SelectorTest {
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     _assertRange(resolvedRanges[0], 100, 9, selector.nameElement);
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -204,7 +204,7 @@ class AttributeSelectorTest extends _SelectorTest {
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
     _assertRange(resolvedRanges[0], 100, 9, selector.nameElement);
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -215,7 +215,7 @@ class AttributeSelectorTest extends _SelectorTest {
         .thenReturn({'indatrue': _newStringSpan(100, "indatrue")});
     // verify
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -248,14 +248,14 @@ class ClassSelectorTest extends _SelectorTest {
   void test_match_false_noClass() {
     when(element.attributes).thenReturn({'not-class': 'no-matter'});
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
   void test_match_false_noSuchClass() {
     when(element.attributes).thenReturn({'class': 'not-nice'});
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -266,7 +266,7 @@ class ClassSelectorTest extends _SelectorTest {
         .thenReturn({'class': _newStringSpan(100, classValue)});
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     expect(resolvedRanges, hasLength(1));
     _assertRange(resolvedRanges[0], 100, 4, selector.nameElement);
   }
@@ -279,7 +279,7 @@ class ClassSelectorTest extends _SelectorTest {
         .thenReturn({'class': _newStringSpan(100, classValue)});
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     expect(resolvedRanges, hasLength(1));
     _assertRange(resolvedRanges[0], 111, 4, selector.nameElement);
   }
@@ -292,7 +292,7 @@ class ClassSelectorTest extends _SelectorTest {
         .thenReturn({'class': _newStringSpan(100, classValue)});
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     expect(resolvedRanges, hasLength(1));
     _assertRange(resolvedRanges[0], 105, 4, selector.nameElement);
   }
@@ -320,7 +320,7 @@ class ElementNameSelectorTest extends _SelectorTest {
     when(element.openingNameSpan).thenReturn(_newStringSpan(100, 'panel'));
     when(element.closingNameSpan).thenReturn(_newStringSpan(200, 'panel'));
     expect(selector.match(element, template), equals(SelectorMatch.TagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     _assertRange(resolvedRanges[0], 100, 5, selector.nameElement);
     _assertRange(resolvedRanges[1], 200, 5, selector.nameElement);
   }
@@ -362,7 +362,7 @@ class AttributeValueRegexSelectorTest extends _SelectorTest {
     when(element.attributes).thenReturn({'kind': '0abcd'});
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -371,7 +371,7 @@ class AttributeValueRegexSelectorTest extends _SelectorTest {
         .thenReturn({'kind': 'bcd', 'plop': 'zabcz', 'klark': 'efg'});
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 }
 
@@ -394,7 +394,7 @@ class NotSelectorTest extends _SelectorTest {
     when(condition.availableTo(typed(any))).thenReturn(false);
     expect(
         selector.match(element, template), equals(SelectorMatch.NonTagMatch));
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -424,7 +424,7 @@ class NotSelectorTest extends _SelectorTest {
     when(element.attributeNameSpans)
         .thenReturn({'not-kind': _newStringSpan(100, 'not-kind')});
     selector = new NotSelector(attributeSelector);
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
   }
 
   // ignore: non_constant_identifier_names
@@ -473,7 +473,7 @@ class OrSelectorTest extends _SelectorTest {
     verify(selector2.match(typed(any), typed(any))).called(0);
     verify(selector3.match(typed(any), typed(any))).called(0);
 
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     verify(selector1.availableTo(typed(any))).called(1);
     verify(selector2.availableTo(typed(any))).called(0);
     verify(selector3.availableTo(typed(any))).called(0);
@@ -500,7 +500,7 @@ class OrSelectorTest extends _SelectorTest {
     verify(selector2.match(typed(any), typed(any))).called(1);
     verify(selector3.match(typed(any), typed(any))).called(0);
 
-    expect(selector.availableTo(element), equals(true));
+    expect(selector.availableTo(element), true);
     verify(selector1.availableTo(typed(any))).called(1);
     verify(selector2.availableTo(typed(any))).called(1);
     verify(selector3.availableTo(typed(any))).called(0);


### PR DESCRIPTION
Note: some tests which checked for the exact type have been replaced with typed(any).

Most changes are just API names, however `.thenInvoke` was replaced with `.thenAnswer` which has a slightly different API.

anyObject -> typed(any)
anyInt -> typed(any).  I don't think there is a way to express anyInt in 'package:test' since they assume you are using strong mode.

EDIT:


Note that .verify seems to work much differently now.  Each time you call `called(n)` or similar it will reset the count.  This only affects one test in file_tracker_test where verify was used in a loop.


EDIT:

I am wrong about the typed api, the pattern to test for an instance of a type is

`argThat(new isInstanceOf<TypeIExpect>())`