### PR TITLE
Add a hard cap on slicing dart in template attributes.

### DIFF
--- a/angular_analyzer_plugin/lib/src/converter.dart
+++ b/angular_analyzer_plugin/lib/src/converter.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
@@ -831,7 +832,8 @@ class EmbeddedDartParser {
         final start = token.offset - offset;
 
         token = expression.endToken.next;
-        final end = token.offset - offset;
+        // The tokenizer isn't perfect always. Ensure [end] <= [code.length].
+        final end = min(token.offset - offset, code.length);
         final exprCode = code.substring(start, end);
         attributes.add(new ExpressionBoundAttribute(
             key,

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -8,6 +8,7 @@ import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:angular_analyzer_plugin/errors.dart';
 import 'package:angular_ast/angular_ast.dart';
+import 'package:front_end/src/scanner/errors.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'package:tuple/tuple.dart';
 import 'package:test/test.dart';
@@ -4804,6 +4805,25 @@ class TestPanel {
     expect(ranges, hasLength(0));
     errorListener.assertErrorsWithCodes([
       StaticWarningCode.UNDEFINED_IDENTIFIER,
+    ]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_nanTokenizationRangeError() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel',
+    templateUrl: 'test_panel.html', directives: const [NgIf])
+class TestPanel {
+  int i;
+}
+''');
+    final code = r'''
+<div *ngIf="i > 0e"></div>
+''';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertErrorsWithCodes([
+      ScannerErrorCode.MISSING_DIGIT,
     ]);
   }
 


### PR DESCRIPTION
There's at least one condition which currently causes a range error due
to an SDK bug: #30321. Should have a hard cap.