### PR TITLE
Disable empty *starAttr validation, with tests

### DIFF
--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -1309,6 +1309,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
     // catch *ngIf without a value
     if (binding.parent.boundDirectives
         .map((binding) => binding.boundDirective)
+        // TODO enable this again for all directives, not just NgIf
+        .where((directive) => directive.classElement.name == "NgIf")
         .any((directive) =>
             directive.inputs.any((input) => input.name == binding.name))) {
       errorListener.onError(new AnalysisError(

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -3136,9 +3136,11 @@ class TestPanel {
   // ignore: non_constant_identifier_names
   Future test_template_attribute_withoutValue() async {
     _addDartSource(r'''
-@Directive(selector: '[deferred-content]')
+@Directive(selector: '[deferred]')
 class DeferredContentDirective {
   DeferredContentDirective(TemplateRef tpl);
+  @Input()
+  String deferred;
 }
 
 @Component(selector: 'test-panel')
@@ -3148,10 +3150,10 @@ class DeferredContentDirective {
 class TestPanel {}
 ''');
     _addHtmlSource(r"""
-<div *deferred-content>Deferred content</div>
+<div *deferred>Deferred content</div>
 """);
     await _resolveSingleTemplate(dartSource);
-    _assertElement('deferred-content>').selector.at("deferred-content]')");
+    _assertElement('deferred>').selector.at("deferred]')");
     errorListener.assertNoErrors();
   }
 


### PR DESCRIPTION
Our example `*deferredContent` directive has an input, which fails the
test if we add it. Also, change it to `*deferred` for better
consistency.

Adding that aspect to the test, seems we can still pass our test suite
by limiting validation to NgIf. Left a comment to reenable it...likely
we can do this if the input is marked required, in the future, or we
can decide that the usage of `*deferred` in that test *is* invalid, and
change the definition/API so we can reenable this check.