### PR TITLE
Fix rejection of innerHTML as an input due to missing dart:html annotation

### DIFF
--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -142,6 +142,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   }
 
   /// dart:html is missing an annotation to fix this casing. Compensate.
+  /// TODO(mfairhurst) remove this fix once dart:html is fixed
   String fixName(String name) => name == 'innerHtml' ? 'innerHTML' : name;
 
   List<InputElement> _buildInputs(bool skipHtmlElement) =>

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -141,9 +141,12 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
         isHtml: true);
   }
 
+  /// dart:html is missing an annotation to fix this casing. Compensate.
+  String fixName(String name) => name == 'innerHtml' ? 'innerHTML' : name;
+
   List<InputElement> _buildInputs(bool skipHtmlElement) =>
       _captureAspects((inputMap, accessor) {
-        final name = accessor.displayName;
+        final name = fixName(accessor.displayName);
         final prettyName = alternativeInputs[name];
         final originalName = prettyName == null ? null : name;
         if (!inputMap.containsKey(name)) {

--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -353,12 +353,19 @@ class HtmlElement extends Element {
   
   @DomName('HTMLElement.className')
   void set className(String s){}
-  @DomName('HTMLElement.innerHtml')
-  void set innerHtml(String s){}
   @DomName('HTMLElement.readOnly')
   void set readOnly(bool b){}
   @DomName('HTMLElement.tabIndex')
   void set tabIndex(int i){}
+
+  @DomName('HTMLElement.innerHTML')
+  String _innerHtml;
+  String get innerHtml {
+    throw 'not the real implementation';
+  }
+  set innerHtml(String value) {
+    // stuff
+  }
   
 }
 

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -449,7 +449,7 @@ class TestPanel {
 }
 ''');
     final code = r"""
-<span [class]='text'></span>
+<span [class]='text' [innerHtml]='text'></span>
 """;
     await angularDriver.getStandardHtml();
     _addHtmlSource(code);
@@ -466,7 +466,7 @@ class TestPanel {
 }
 ''');
     final code = r"""
-<span [className]='text'></span>
+<span [className]='text' [innerHTML]='text'></span>
 """;
     await angularDriver.getStandardHtml();
     _addHtmlSource(code);


### PR DESCRIPTION
The public setter (as well as the private member, which realistically
means nothing for most people) should be annotated, but it isn't. As
such, we can't get the DomName() for innerHTML as such (capitalized)
and then apply angular's map to it.

To ensure that we still _suggest_ `innerHtml`, the angular way, while
accepting `innerHTML`, the DOM way, reuse all existing methodologies
after doing a little switcharoo up front.

Luckily this is harmless for in the future when that annotation gets
fixed, but I hear it may be months and months away.