### PR TITLE
Match `selector: 'template[foo]` against `*foo`, `template="foo"`

### DIFF
--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -47,7 +47,8 @@ class ElementViewImpl implements ElementView {
   @override
   SourceRange openingNameSpan;
 
-  ElementViewImpl(List<AttributeInfo> attributeInfoList, ElementInfo element) {
+  ElementViewImpl(List<AttributeInfo> attributeInfoList,
+      {ElementInfo element, String elementName}) {
     for (final attribute in attributeInfoList) {
       if (attribute is TemplateAttribute) {
         continue;
@@ -67,6 +68,8 @@ class ElementViewImpl implements ElementView {
       closingSpan = element.closingSpan;
       openingNameSpan = element.openingNameSpan;
       closingNameSpan = element.closingNameSpan;
+    } else if (elementName != null) {
+      localName = elementName;
     }
   }
 }
@@ -774,7 +777,8 @@ class DirectiveResolver extends AngularAstVisitor {
       visitTemplateAttr(element.templateAttribute);
     }
 
-    final elementView = new ElementViewImpl(element.attributes, element);
+    final elementView =
+        new ElementViewImpl(element.attributes, element: element);
     final unmatchedDirectives = <AbstractDirective>[];
 
     final containingDirectivesCount = outerBindings.length;
@@ -834,7 +838,8 @@ class DirectiveResolver extends AngularAstVisitor {
 
   @override
   void visitTemplateAttr(TemplateAttribute attr) {
-    final elementView = new ElementViewImpl(attr.virtualAttributes, null);
+    final elementView =
+        new ElementViewImpl(attr.virtualAttributes, elementName: 'template');
     for (final directive in allDirectives) {
       if (directive.selector.match(elementView, template) !=
           SelectorMatch.NoMatch) {
@@ -979,7 +984,7 @@ class ComponentContentResolver extends AngularAstVisitor {
         _reportErrorForRange(new SourceRange(child.offset, child.length),
             AngularWarningCode.CONTENT_NOT_TRANSCLUDED);
       } else if (child is ElementInfo) {
-        final view = new ElementViewImpl(child.attributes, child);
+        final view = new ElementViewImpl(child.attributes, element: child);
 
         var matched = acceptAll;
         var matchedTag = false;

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -110,8 +110,11 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
       if (argument is ast.SimpleStringLiteral) {
         final tag = argument.value;
         final tagOffset = argument.contentsOffset;
-        final component = _buildComponent(tag, tagOffset);
-        components[tag] = component;
+        // don't track <template>, angular treats those specially.
+        if (tag != "template") {
+          final component = _buildComponent(tag, tagOffset);
+          components[tag] = component;
+        }
       }
     } else if (node.methodName.name == 'JS' &&
         argumentList != null &&
@@ -123,8 +126,11 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
           tagArgument is ast.SimpleStringLiteral) {
         final tag = tagArgument.value;
         final tagOffset = tagArgument.contentsOffset;
-        final component = _buildComponent(tag, tagOffset);
-        components[tag] = component;
+        // don't track <template>, angular treats those specially.
+        if (tag != "template") {
+          final component = _buildComponent(tag, tagOffset);
+          components[tag] = component;
+        }
       }
     }
   }

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -174,6 +174,8 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
     expect(map['h3'], isNotNull);
     // has no mention of 'option' in the source, is hardcoded
     expect(map['option'], isNotNull);
+    // <template> is special, not actually a TemplateElement
+    expect(map['template'], isNull);
   }
 
   // ignore: non_constant_identifier_names

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -3082,6 +3082,68 @@ class TestPanel {
   }
 
   // ignore: non_constant_identifier_names
+  Future test_templateTag_selectTemplateMatches() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel'
+    templateUrl: 'test_panel.html', directives: const [MyStarDirective])
+class TestPanel {
+}
+@Directive(selector: 'template[myStarDirective]')
+class MyStarDirective {
+  MyStarDirective(TemplateRef ref) {}
+  @Input()
+  String myStarDirective;
+}
+''');
+    final code = r'''
+<template myStarDirective="'foo'"></template>
+''';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_templateAttr() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel'
+    templateUrl: 'test_panel.html', directives: const [MyStarDirective])
+class TestPanel {
+}
+@Directive(selector: 'template[myStarDirective]')
+class MyStarDirective {
+  MyStarDirective(TemplateRef ref) {}
+}
+''');
+    final code = r'''
+<div template="myStarDirective"></div>
+''';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_star_selectTemplateMatches() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel'
+    templateUrl: 'test_panel.html', directives: const [MyStarDirective])
+class TestPanel {
+}
+@Directive(selector: 'template[myStarDirective]')
+class MyStarDirective {
+  MyStarDirective(TemplateRef ref) {}
+}
+''');
+    final code = r'''
+<span *myStarDirective></span>
+''';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
   Future test_standardHtmlComponent() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel')


### PR DESCRIPTION
Virtual template elements weren't treated as having a tag name, and
therefore weren't being matched against element name selectors of
template. Provide template tag name in this case, and a match occurs.

However, this also has the subtle effect of allowing you to bind to
`TemplateElement` properties in a star. Luckily, an `NgFor` test failed
for this reason.

Removed `TemplateElement` entirely from `StandardHtml`, so that won't
happen.