### PR TITLE
Remove dependencies on deprecated server code

### DIFF
--- a/angular_analyzer_plugin/lib/src/navigation.dart
+++ b/angular_analyzer_plugin/lib/src/navigation.dart
@@ -5,14 +5,15 @@ import 'package:analysis_server/plugin/protocol/protocol_dart.dart' as protocol;
 import 'package:analyzer_plugin/protocol/protocol_common.dart' as protocol;
 import 'package:analyzer/dart/element/element.dart' as engine;
 import 'package:analyzer/src/dart/element/member.dart';
-import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 
-class AngularNavigationContributor implements NavigationContributor {
-  @override
-  void computeNavigation(NavigationCollector collector, AnalysisContext context,
+class AngularNavigationContributor {
+  void computeNavigation(NavigationCollector collector,
       Source source, int offset, int length) {
+    // In the code below, `context` used to be a parameter defined to be an
+    // `AnalysisContext`.
+    //
     //LineInfo lineInfo = context.computeResult(source, LINE_INFO);
     //// in Dart
     //{
@@ -106,10 +107,12 @@ class AngularNavigationContributor implements NavigationContributor {
   }
 }
 
-class AngularOccurrencesContributor implements OccurrencesContributor {
-  @override
+class AngularOccurrencesContributor {
   void computeOccurrences(
-      OccurrencesCollector collector, AnalysisContext context, Source source) {
+      OccurrencesCollector collector, Source source) {
+    // In the code below, `context` used to be a parameter defined to be an
+    // `AnalysisContext`.
+    //
     //List<Source> librarySources = context.getLibrariesContaining(source);
     //for (Source librarySource in librarySources) {
     //  // directives

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -86,7 +86,7 @@ class User {
     //computeResult(target, DART_TEMPLATES);
     // compute navigation regions
     new AngularNavigationContributor()
-        .computeNavigation(collector, null, source, null, null);
+        .computeNavigation(collector, source, null, null);
     // input references setter
     {
       _findRegionString('text', ': my-text');
@@ -159,7 +159,7 @@ class TextPanel {}
     //computeResult(htmlSource, HTML_TEMPLATES);
     // compute navigation regions
     new AngularNavigationContributor()
-        .computeNavigation(collector, null, dartSource, null, null);
+        .computeNavigation(collector, dartSource, null, null);
     // input references setter
     {
       _findRegionString("'text_panel.html'", ')');
@@ -197,7 +197,7 @@ class TextPanel {
     //computeResult(htmlSource, HTML_TEMPLATES);
     // compute navigation regions
     new AngularNavigationContributor()
-        .computeNavigation(collector, null, htmlSource, null, null);
+        .computeNavigation(collector, htmlSource, null, null);
     // template references field
     {
       _findRegionString('text', "}}", codeOverride: htmlCode);
@@ -275,7 +275,7 @@ class ObjectContainer<T> {
     //computeResult(target, DART_TEMPLATES);
     // compute navigation regions
     new AngularOccurrencesContributor()
-        .computeOccurrences(collector, null, source);
+        .computeOccurrences(collector, source);
     // "text" field
     {
       _findOccurrences(code.indexOf('text: my-text'));


### PR DESCRIPTION
I'd like to remove `NavigationContributor` and `OccurrencesContributor` from the analysis_server package, and `AnalysisContext` is being replaced soon.