### PR TITLE
Handle major Angular security contexts; script & style pending.

### DIFF
--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -59,6 +59,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD,
   AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS,
   AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG,
+  AngularWarningCode.UNSAFE_BINDING,
 ];
 
 /// The lazy initialized map from [AngularWarningCode.uniqueName] to the
@@ -428,6 +429,13 @@ class AngularWarningCode extends ErrorCode {
   static const PIPE_TRANSFORM_REQ_ONE_ARG = const AngularWarningCode(
       'PIPE_TRANSFORM_REQ_ONE_ARG',
       "'transform' method requires at least one argument");
+
+  /// An error indicating that a security exception will be thrown by this input
+  /// binding
+  static const UNSAFE_BINDING = const AngularWarningCode(
+      'UNSAFE_BINDING',
+      'A security exception will be thrown by this binding. You must use the '
+      ' security service to get an instance of {0} and bind that result.');
 
   /// Initialize a newly created error code to have the given [name].
   /// The message associated with the error will be created from the given

--- a/angular_analyzer_plugin/lib/src/model.dart
+++ b/angular_analyzer_plugin/lib/src/model.dart
@@ -340,9 +340,16 @@ class InputElement extends AngularElementImpl {
   /// This should be null if there is no alternative name.
   final originalName;
 
+  /// Native inputs vulnerable to XSS (such as a.href and *.innerHTML) may have
+  /// a security context. The secure type of that context should be assignable
+  /// to this input, and if the security context does not allow sanitization
+  /// then it will always throw otherwise and thus should be treated as an
+  /// assignment error.
+  final SecurityContext securityContext;
+
   InputElement(String name, int nameOffset, int nameLength, Source source,
       this.setter, this.setterRange, this.setterType,
-      {this.originalName})
+      {this.originalName, this.securityContext})
       : super(name, nameOffset, nameLength, source);
 
   @override

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -79,7 +79,7 @@ class SecuritySchema {
       SecurityContext scriptSecurityContext,
       SecurityContext styleSecurityContext,
       SecurityContext resourceUrlSecurityContext}) {
-    // This written to be easily synced to angular's security
+    // This is written to be easily synced to angular's security
     _registerSecuritySchema(
         htmlSecurityContext, ['iframe|srcdoc', '*|innerHTML', '*|outerHTML']);
     _registerSecuritySchema(styleSecurityContext, ['*|style']);

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/ast/ast.dart' as ast;
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
@@ -25,9 +26,114 @@ class StandardAngular {
   final ClassElement elementRef;
   final ClassElement queryList;
   final ClassElement pipeTransform;
+  final SecuritySchema securitySchema;
 
   StandardAngular(
-      {this.templateRef, this.elementRef, this.queryList, this.pipeTransform});
+      {this.templateRef,
+      this.elementRef,
+      this.queryList,
+      this.pipeTransform,
+      this.securitySchema});
+
+  factory StandardAngular.fromAnalysis(
+      AnalysisResult ngResult, AnalysisResult securityResult) {
+    final ng = ngResult.unit.element.library.exportNamespace;
+    final security = securityResult.unit.element.library.exportNamespace;
+
+    SecurityContext makeSecurityContext(Element element,
+            {bool sanitizationAvailable: true}) =>
+        new SecurityContext((element as ClassElement)?.type,
+            sanitizationAvailable: sanitizationAvailable);
+
+    final securitySchema = new SecuritySchema(
+        htmlSecurityContext: makeSecurityContext(security.get('SafeHtml')),
+        urlSecurityContext: makeSecurityContext(security.get('SafeUrl')),
+        styleSecurityContext: makeSecurityContext(security.get('SafeStyle')),
+        scriptSecurityContext: makeSecurityContext(security.get('SafeScript'),
+            sanitizationAvailable: false),
+        resourceUrlSecurityContext: makeSecurityContext(
+            security.get('SafeResourceUrl'),
+            sanitizationAvailable: false));
+
+    return new StandardAngular(
+        queryList: ng.get("QueryList"),
+        elementRef: ng.get("ElementRef"),
+        templateRef: ng.get("TemplateRef"),
+        pipeTransform: ng.get("PipeTransform"),
+        securitySchema: securitySchema);
+  }
+}
+
+class SecuritySchema {
+  final Map<String, SecurityContext> schema = {};
+
+  void _registerSecuritySchema(SecurityContext context, List<String> specs) {
+    for (final spec in specs) {
+      schema[spec] = context;
+    }
+  }
+
+  SecuritySchema(
+      {SecurityContext htmlSecurityContext,
+      SecurityContext urlSecurityContext,
+      SecurityContext scriptSecurityContext,
+      SecurityContext styleSecurityContext,
+      SecurityContext resourceUrlSecurityContext}) {
+    // This written to be easily synced to angular's security
+    _registerSecuritySchema(
+        htmlSecurityContext, ['iframe|srcdoc', '*|innerHTML', '*|outerHTML']);
+    _registerSecuritySchema(styleSecurityContext, ['*|style']);
+    _registerSecuritySchema(urlSecurityContext, [
+      '*|formAction',
+      'area|href',
+      'area|ping',
+      'audio|src',
+      'a|href',
+      'a|ping',
+      'blockquote|cite',
+      'body|background',
+      'del|cite',
+      'form|action',
+      'img|src',
+      'img|srcset',
+      'input|src',
+      'ins|cite',
+      'q|cite',
+      'source|src',
+      'source|srcset',
+      'video|poster',
+      'video|src'
+    ]);
+    _registerSecuritySchema(resourceUrlSecurityContext, [
+      'applet|code',
+      'applet|codebase',
+      'base|href',
+      'embed|src',
+      'frame|src',
+      'head|profile',
+      'html|manifest',
+      'iframe|src',
+      'link|href',
+      'media|src',
+      'object|codebase',
+      'object|data',
+      'script|src',
+      'track|src'
+    ]);
+    // TODO where's script security?
+  }
+
+  SecurityContext lookup(String elementName, String name) =>
+      schema['$elementName|$name'];
+
+  SecurityContext lookupGlobal(String name) => schema['*|$name'];
+}
+
+class SecurityContext {
+  final DartType safeType;
+  final bool sanitizationAvailable;
+
+  SecurityContext(this.safeType, {this.sanitizationAvailable = true});
 }
 
 class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
@@ -35,6 +141,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   final Map<String, OutputElement> events;
   final Map<String, InputElement> attributes;
   final Source source;
+  final SecuritySchema securitySchema;
 
   static const Map<String, String> specialElementClasses =
       const <String, String>{
@@ -56,19 +163,19 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
 
   ClassElement classElement;
 
-  BuildStandardHtmlComponentsVisitor(
-      this.components, this.events, this.attributes, this.source);
+  BuildStandardHtmlComponentsVisitor(this.components, this.events,
+      this.attributes, this.source, this.securitySchema);
 
   @override
   void visitClassDeclaration(ast.ClassDeclaration node) {
     classElement = node.element;
     super.visitClassDeclaration(node);
     if (classElement.name == 'HtmlElement') {
-      final outputElements = _buildOutputs(false);
+      final outputElements = _buildOutputs(true);
       for (final outputElement in outputElements) {
         events[outputElement.name] = outputElement;
       }
-      final inputElements = _buildInputs(false);
+      final inputElements = _buildInputs();
       for (final inputElement in inputElements) {
         attributes[inputElement.name] = inputElement;
         final originalName = inputElement.originalName;
@@ -137,8 +244,8 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
 
   /// Return a new [Component] for the current [classElement].
   Component _buildComponent(String tag, int tagOffset) {
-    final inputElements = _buildInputs(true);
-    final outputElements = _buildOutputs(true);
+    final inputElements = _buildInputs(tagname: tag);
+    final outputElements = _buildOutputs(false);
     return new Component(classElement,
         inputs: inputElements,
         outputs: outputElements,
@@ -151,7 +258,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
   /// TODO(mfairhurst) remove this fix once dart:html is fixed
   String fixName(String name) => name == 'innerHtml' ? 'innerHTML' : name;
 
-  List<InputElement> _buildInputs(bool skipHtmlElement) =>
+  List<InputElement> _buildInputs({String tagname}) =>
       _captureAspects((inputMap, accessor) {
         final name = fixName(accessor.displayName);
         final prettyName = alternativeInputs[name];
@@ -159,20 +266,22 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
         if (!inputMap.containsKey(name)) {
           if (accessor.isSetter) {
             inputMap[name] = new InputElement(
-              prettyName ?? name,
-              accessor.nameOffset,
-              accessor.nameLength,
-              accessor.source,
-              accessor,
-              new SourceRange(accessor.nameOffset, accessor.nameLength),
-              accessor.variable.type,
-              originalName: originalName,
-            );
+                prettyName ?? name,
+                accessor.nameOffset,
+                accessor.nameLength,
+                accessor.source,
+                accessor,
+                new SourceRange(accessor.nameOffset, accessor.nameLength),
+                accessor.variable.type,
+                originalName: originalName,
+                securityContext: tagname == null
+                    ? securitySchema.lookupGlobal(name)
+                    : securitySchema.lookup(tagname, name));
           }
         }
-      }, skipHtmlElement); // Either grabbing HtmlElement attrs or skipping them
+      }, tagname == null); // Either grabbing HtmlElement attrs or skipping them
 
-  List<OutputElement> _buildOutputs(bool skipHtmlElement) =>
+  List<OutputElement> _buildOutputs(bool globalOutputs) =>
       _captureAspects((outputMap, accessor) {
         final domName = _getDomName(accessor);
         if (domName == null) {
@@ -205,7 +314,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
             }
           }
         }
-      }, skipHtmlElement); // Either grabbing HtmlElement events or skipping them
+      }, globalOutputs); // Either grabbing HtmlElement events or skipping them
 
   String _getDomName(Element element) {
     for (final annotation in element.metadata) {
@@ -221,8 +330,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
     return null;
   }
 
-  List<T> _captureAspects<T>(
-      CaptureAspectFn<T> addAspect, bool skipHtmlElement) {
+  List<T> _captureAspects<T>(CaptureAspectFn<T> addAspect, bool globalAspects) {
     final aspectMap = <String, T>{};
     final visitedTypes = new Set<InterfaceType>();
 
@@ -232,7 +340,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
         // (even directives) can use them. Note, this leaves only a few
         // special elements with outputs such as BodyElement, everything else
         // relies on standardHtmlEvents checked after the outputs.
-        if (!skipHtmlElement || type.name != 'HtmlElement') {
+        if (globalAspects || type.name != 'HtmlElement') {
           type.accessors
               .where((elem) => !elem.isPrivate)
               .forEach((elem) => addAspect(aspectMap, elem));

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -156,6 +156,11 @@ library angular2;
 
 export 'package:angular/angular.dart';
 ''');
+    newSource('/angular2/security.dart', r'''
+library angular2.security;
+
+export 'package:angular/security.dart';
+''');
     newSource('/angular/angular.dart', r'''
 library angular;
 
@@ -164,6 +169,10 @@ export 'src/core/metadata.dart';
 export 'src/core/ng_if.dart';
 export 'src/core/ng_for.dart';
 export 'src/core/change_detection.dart';
+''');
+    newSource('/angular/security.dart', r'''
+library angular.security;
+export 'src/security/dom_sanitization_service.dart';
 ''');
     newSource('/angular/src/core/metadata.dart', r'''
 import 'dart:async';
@@ -335,6 +344,19 @@ class NgFor {
 }
 
 typedef dynamic TrackByFn(num index, dynamic item);
+''');
+    newSource('/angular/src/security/dom_sanitization_service.dart', r'''
+class SafeValue {}
+
+abstract class SafeHtml extends SafeValue {}
+
+abstract class SafeStyle extends SafeValue {}
+
+abstract class SafeScript extends SafeValue {}
+
+abstract class SafeUrl extends SafeValue {}
+
+abstract class SafeResourceUrl extends SafeValue {}
 ''');
   }
 

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -22,6 +22,7 @@ void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(AngularParseHtmlTest);
     defineReflectiveTests(BuildStandardHtmlComponentsTest);
+    defineReflectiveTests(BuildStandardAngularTest);
     defineReflectiveTests(GatherAnnotationsTest);
     defineReflectiveTests(BuildUnitViewsTest);
     defineReflectiveTests(ResolveDartTemplatesTest);
@@ -124,6 +125,9 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
         expect(input, isNotNull);
         expect(input.setter, isNotNull);
         expect(input.setterType.toString(), equals("String"));
+        expect(input.securityContext, isNotNull);
+        expect(input.securityContext.safeType.toString(), equals('SafeUrl'));
+        expect(input.securityContext.sanitizationAvailable, equals(true));
       }
       expect(outputElements, hasLength(0));
       expect(inputs.where((i) => i.name == '_privateField'), hasLength(0));
@@ -141,8 +145,27 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
         expect(input, isNotNull);
         expect(input.setter, isNotNull);
         expect(input.setterType.toString(), equals("bool"));
+        expect(input.securityContext, isNull);
       }
       expect(outputElements, hasLength(0));
+    }
+    // iframe
+    {
+      final component = map['iframe'];
+      expect(component, isNotNull);
+      expect(component.classElement.displayName, 'IFrameElement');
+      expect(component.selector.toString(), 'iframe');
+      final inputs = component.inputs;
+      {
+        final input = inputs.singleWhere((i) => i.name == 'src');
+        expect(input, isNotNull);
+        expect(input.setter, isNotNull);
+        expect(input.setterType.toString(), equals("String"));
+        expect(input.securityContext, isNotNull);
+        expect(input.securityContext.safeType.toString(),
+            equals('SafeResourceUrl'));
+        expect(input.securityContext.sanitizationAvailable, equals(false));
+      }
     }
     // input
     {
@@ -237,6 +260,73 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
       expect(input.setter, isNotNull);
       expect(input.setterType.toString(), equals("bool"));
     }
+    {
+      final input = inputElements['innerHtml'];
+      expect(input, isNotNull);
+      expect(identical(input, inputElements['innerHTML']), true);
+      expect(input.setter, isNotNull);
+      expect(input.setterType.toString(), equals('String'));
+      expect(input.securityContext, isNotNull);
+      expect(input.securityContext.safeType.toString(), equals('SafeHtml'));
+      expect(input.securityContext.sanitizationAvailable, equals(true));
+    }
+  }
+}
+
+@reflectiveTest
+class BuildStandardAngularTest extends AbstractAngularTest {
+  // ignore: non_constant_identifier_names
+  Future test_perform() async {
+    final ng = await angularDriver.getStandardAngular();
+    // validate
+    expect(ng, isNotNull);
+    expect(ng.templateRef, isNotNull);
+    expect(ng.elementRef, isNotNull);
+    expect(ng.queryList, isNotNull);
+    expect(ng.pipeTransform, isNotNull);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_securitySchema() async {
+    final ng = await angularDriver.getStandardAngular();
+    // validate
+    expect(ng, isNotNull);
+    expect(ng.securitySchema, isNotNull);
+
+    final imgSrcSecurity = ng.securitySchema.lookup('img', 'src');
+    expect(imgSrcSecurity, isNotNull);
+    expect(imgSrcSecurity.safeType.toString(), 'SafeUrl');
+    expect(imgSrcSecurity.sanitizationAvailable, true);
+
+    final aHrefSecurity = ng.securitySchema.lookup('a', 'href');
+    expect(aHrefSecurity, isNotNull);
+    expect(aHrefSecurity.safeType.toString(), 'SafeUrl');
+    expect(aHrefSecurity.sanitizationAvailable, true);
+
+    final innerHtmlSecurity = ng.securitySchema.lookupGlobal('innerHTML');
+    expect(innerHtmlSecurity, isNotNull);
+    expect(innerHtmlSecurity.safeType.toString(), 'SafeHtml');
+    expect(innerHtmlSecurity.sanitizationAvailable, true);
+
+    final iframeSrcdocSecurity = ng.securitySchema.lookup('iframe', 'srcdoc');
+    expect(iframeSrcdocSecurity, isNotNull);
+    expect(iframeSrcdocSecurity.safeType.toString(), 'SafeHtml');
+    expect(iframeSrcdocSecurity.sanitizationAvailable, true);
+
+    final styleSecurity = ng.securitySchema.lookupGlobal('style');
+    expect(styleSecurity, isNotNull);
+    expect(styleSecurity.safeType.toString(), 'SafeStyle');
+    expect(styleSecurity.sanitizationAvailable, true);
+
+    final iframeSrcSecurity = ng.securitySchema.lookup('iframe', 'src');
+    expect(iframeSrcSecurity, isNotNull);
+    expect(iframeSrcSecurity.safeType.toString(), 'SafeResourceUrl');
+    expect(iframeSrcSecurity.sanitizationAvailable, false);
+
+    final scriptSrcSecurity = ng.securitySchema.lookup('script', 'src');
+    expect(scriptSrcSecurity, isNotNull);
+    expect(scriptSrcSecurity.safeType.toString(), 'SafeResourceUrl');
+    expect(scriptSrcSecurity.sanitizationAvailable, false);
   }
 }
 

--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -410,6 +410,17 @@ class InputElement extends HtmlElement {
   String validationMessage;
 }
 
+class IFrameElement extends HtmlElement {
+  factory IFrameElement._() { throw new UnsupportedError("Not supported"); }
+  factory IFrameElement() => JS(
+      'returns:IFrameElement;creates:IFrameElement;new:true',
+      '#.createElement(#)',
+      document,
+      "iframe");
+  @DomName('HTMLIFrameElement.src')
+  String src;
+}
+
 class OptionElement extends HtmlElement {                                        
   factory OptionElement({String data: '', String value : '', bool selected: false}) {
   }                                                                              


### PR DESCRIPTION
For an input with a security context, allow binding to that security
context's safe type instead of the input type. For security contexts
with no sanitization available (resource urls ie iframe.src, scripts),
report an error if bound with anything but the safe type.

Style sanitization started but not completed. Looks like we don't allow
binding to [style] at all currently. Need to look into why its not part
of dart:html and what other exceptions we need to handle and how we
need to handle them. Security will likely "just work" then...some new
tests will need to be written and some comments in other tests will
need to be uncommented.

Script sanitization seems to be something entirely different?

Store security context classes on StandardAngular, and then use them to
create StandardHtml. That does mean we need to flip the order that we
get them. I also put in extra blocks to make sure that when our plugin
runs without any package:angular to resolve, it will not try to get
standard angular forever and ever by forcing 'no priority' as a driver.