### PR TITLE
Fix tests running in checked mode, and make that default on travis

### DIFF
--- a/angular_analyzer_plugin/lib/src/completion_request.dart
+++ b/angular_analyzer_plugin/lib/src/completion_request.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer_plugin/utilities/completion/completion_core.dart';
 import 'package:analyzer_plugin/src/utilities/completion/completion_target.dart';
@@ -63,6 +64,12 @@ class AngularCompletionRequest extends CompletionRequest {
       _dartSnippet = extractor.dartSnippet;
       _angularTarget = extractor.target;
       if (_dartSnippet != null) {
+        if (_dartSnippet is Expression) {
+          // wrap dart snippet in a ParenthesizedExpression, because the dart
+          // completion engine expects all expressions to have parents.
+          _dartSnippet =
+              astFactory.parenthesizedExpression(null, _dartSnippet, null);
+        }
         _completionTarget = new CompletionTarget.forOffset(null, offset,
             entryPoint: _dartSnippet);
       }

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -4538,7 +4538,8 @@ class ResolveHtmlTemplateTest extends AbstractAngularTest {
     fillErrorListener(result2.errors);
     views = result2.directives
         .map((d) => d is Component ? d.view : null)
-        .where((v) => v != null);
+        .where((v) => v != null)
+        .toList();
   }
 
   // ignore: non_constant_identifier_names

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -10,5 +10,5 @@ cd $PACKAGE
 dartanalyzer lib test
 
 # Run the actual tests
-dart test/test_all.dart
+dart --checked test/test_all.dart
 


### PR DESCRIPTION
Had one type error, that had to be fixed.

Also was tripping an assertion in the analyzer's autocomplete that
expressions must have parents. The solution here is perhaps too hacky,
but perhaps not. Just wrap in a virtual parenthesized expression.
Doesn't seem like a problem to pass in null for the open and close
paren tokens.