### PR TITLE
Properly report a hint (not error) for overly complicated templates

### DIFF
--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -39,7 +39,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.CUSTOM_DIRECTIVE_MAY_REQUIRE_TEMPLATE,
   AngularWarningCode.TEMPLATE_ATTR_NOT_USED,
   AngularWarningCode.NO_DIRECTIVE_EXPORTED_BY_SPECIFIED_NAME,
-  AngularWarningCode.OFFSETS_CANNOT_BE_CREATED,
+  AngularHintCode.OFFSETS_CANNOT_BE_CREATED,
   AngularWarningCode.CONTENT_NOT_TRANSCLUDED,
   AngularWarningCode.OUTPUT_STATEMENT_REQUIRES_EXPRESSION_STATEMENT,
   AngularWarningCode.DISALLOWED_EXPRESSION,
@@ -306,13 +306,6 @@ class AngularWarningCode extends ErrorCode {
   static const DISALLOWED_EXPRESSION = const AngularWarningCode(
       'DISALLOWED_EXPRESSION', "{0} not allowed in angular templates");
 
-  /// An error code indicating that an output-bound statement
-  /// must be an [ExpressionStatement].
-  static const OFFSETS_CANNOT_BE_CREATED = const AngularWarningCode(
-      'OFFSETS_CANNOT_BE_CREATED',
-      'Errors cannot be tracked for the constant expression because it is too'
-      ' complex for errors to be mapped to locations in the file');
-
   /// An error code indicating that dom inside a component won't be transcluded
   static const CONTENT_NOT_TRANSCLUDED = const AngularWarningCode(
       'CONTENT_NOT_TRANSCLUDED',
@@ -456,4 +449,26 @@ class AngularWarningCode extends ErrorCode {
 
   @override
   ErrorType get type => ErrorType.STATIC_WARNING;
+}
+
+class AngularHintCode extends AngularWarningCode {
+  /// An error code indicating that an output-bound statement
+  /// must be an [ExpressionStatement].
+  static const OFFSETS_CANNOT_BE_CREATED = const AngularHintCode(
+      'OFFSETS_CANNOT_BE_CREATED',
+      'Errors cannot be tracked for the constant expression because it is too'
+      ' complex for errors to be mapped to locations in the file');
+
+  /// Initialize a newly created error code to have the given [name].
+  /// The message associated with the error will be created from the given
+  /// [message] template. The correction associated with the error will be
+  /// created from the given [correction] template.
+  const AngularHintCode(String name, String message, [String correction])
+      : super(name, message, correction);
+
+  @override
+  ErrorSeverity get errorSeverity => ErrorSeverity.INFO;
+
+  @override
+  ErrorType get type => ErrorType.HINT;
 }

--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -452,8 +452,8 @@ class AngularWarningCode extends ErrorCode {
 }
 
 class AngularHintCode extends AngularWarningCode {
-  /// An error code indicating that an output-bound statement
-  /// must be an [ExpressionStatement].
+  /// When a user does for instance `template: 'foo$bar$baz`, we cannot analyze
+  /// the template because we cannot easily map errors to code offsets.
   static const OFFSETS_CANNOT_BE_CREATED = const AngularHintCode(
       'OFFSETS_CANNOT_BE_CREATED',
       'Errors cannot be tracked for the constant expression because it is too'

--- a/angular_analyzer_plugin/lib/src/tasks.dart
+++ b/angular_analyzer_plugin/lib/src/tasks.dart
@@ -160,16 +160,16 @@ class AnnotationProcessorMixin {
       final evaluator = new OffsettingConstantEvaluator();
       evaluator.value = expression.accept(evaluator);
 
-      if (evaluator.value is String) {
-        if (!evaluator.offsetsAreValid) {
-          errorReporter.reportErrorForNode(
-              AngularWarningCode.OFFSETS_CANNOT_BE_CREATED,
-              evaluator.lastUnoffsettableNode);
-        }
-        return evaluator;
+      if (!evaluator.offsetsAreValid) {
+        errorReporter.reportErrorForNode(
+            AngularHintCode.OFFSETS_CANNOT_BE_CREATED,
+            evaluator.lastUnoffsettableNode);
+      } else if (evaluator.value is! String &&
+          evaluator.value != utils.ConstantEvaluator.NOT_A_CONSTANT) {
+        errorReporter.reportErrorForNode(
+            AngularWarningCode.STRING_VALUE_EXPECTED, expression);
       }
-      errorReporter.reportErrorForNode(
-          AngularWarningCode.STRING_VALUE_EXPECTED, expression);
+      return evaluator;
     }
     return null;
   }

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -2048,7 +2048,7 @@ class ComponentA {
 ''');
     await getViews(source);
     errorListener.assertErrorsWithCodes(
-        <ErrorCode>[AngularWarningCode.STRING_VALUE_EXPECTED]);
+        <ErrorCode>[AngularHintCode.OFFSETS_CANNOT_BE_CREATED]);
   }
 
   // ignore: non_constant_identifier_names
@@ -4295,7 +4295,7 @@ class ComponentA {
     await getDirectives(source);
     expect(templates, hasLength(0));
     errorListener.assertErrorsWithCodes(
-        <ErrorCode>[AngularWarningCode.STRING_VALUE_EXPECTED]);
+        <ErrorCode>[AngularHintCode.OFFSETS_CANNOT_BE_CREATED]);
   }
 
   // ignore: non_constant_identifier_names


### PR DESCRIPTION
Should have been a hint all along, changed that.

Also, seems like I wrote tests for this but just expected the wrong
error. Solved.

Aaaand the implementation is fixed too, that helps. Basically, since
the OffsettingConstantEvaluator doesn't actually know everything
required to actually resolve the string value, some valid string
templates are not actually strings, but rather, "unknown." Don't report
its not a string just because of this.

The fact that we don't get the actual value in this case doesn't
matter; we won't analyze it.