### PR TITLE
Accept optional -- just no named -- parameters in pipe transform method

### DIFF
--- a/angular_analyzer_plugin/lib/src/pipe_extraction.dart
+++ b/angular_analyzer_plugin/lib/src/pipe_extraction.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/analyzer.dart' as analyzer;
 import 'package:analyzer/dart/ast/ast.dart' as ast;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/source.dart';
@@ -118,7 +119,7 @@ class PipeExtractor extends AnnotationProcessorMixin {
     }
     for (final parameter in parameters) {
       // If named or positional
-      if (parameter.parameterKind.ordinal > 0) {
+      if (parameter.parameterKind == analyzer.ParameterKind.NAMED) {
         errorReporter.reportErrorForElement(
             AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS, parameter);
         continue;

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -766,6 +766,43 @@ class PipeA extends PipeTransform{}
   }
 
   // ignore: non_constant_identifier_names
+  Future test_Pipe_error_named_args() async {
+    final source = newSource('/test.dart', r'''
+import 'package:angular2/angular2.dart';
+
+@Pipe('pipeA')
+class PipeA extends PipeTransform{
+  transform({named}) {}
+}
+''');
+    await getDirectives(source);
+    expect(pipes, hasLength(1));
+    final pipe = pipes[0];
+    expect(pipe, const isInstanceOf<Pipe>());
+
+    errorListener.assertErrorsWithCodes(
+        [AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_Pipe_allowedOptionalArgs() async {
+    final source = newSource('/test.dart', r'''
+import 'package:angular2/angular2.dart';
+
+@Pipe('pipeA')
+class PipeA extends PipeTransform{
+  transform([named]) {}
+}
+''');
+    await getDirectives(source);
+    expect(pipes, hasLength(1));
+    final pipe = pipes[0];
+    expect(pipe, const isInstanceOf<Pipe>());
+
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
   Future test_exportAs_Component() async {
     final code = r'''
 import 'package:angular2/angular2.dart';


### PR DESCRIPTION
And add tests (was missing them before). Very simple change.

Must import analyzer/analyzer.dart because it exports the ParameterKind
class which is otherwise inside src/. A bit late to start following
this convention, but, still important to follow when we can.