### PR TITLE
Support Functional Directives (in directive lists, autocomplete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Class decorators | Validation | Auto-Complete | Navigation | Refactoring
 -----------------|------------|---------------|------------|-------------
 `@Component(...) class MyComponent {}` | :white_check_mark: Validates directives list is all directives, that the template file exists, that a template is specified via string or URL but not both, requires a valid selector | :no_pedestrians: | :no_pedestrians: | :no_pedestrians:
 `@View(...) class MyComponent {}` | :warning: Supported, requires `@Directive` or `@Component`, but doesn't catch ambigous cases such as templates defined in the `@View` as well as `@Component` | :no_pedestrians: | :no_pedestrians: | :no_pedestrians:
-`@Directive(...) class MyDirective {}` | :white_check_mark: Validates directives list is all directives, that the template file exists, that a template is specified via string or URL but not both, requires a valid selector | :no_pedestrians: | :no_pedestrians: | :no_pedestrians:
+`@Directive(...) class MyDirective {}` | :white_check_mark: Validates directives list is all directives, requires a valid selector | :no_pedestrians: | :no_pedestrians: | :no_pedestrians:
+`@Directive(...) void directive(...) {}` | :white_check_mark: Validates directives list is all directives requires a valid selector, not exported | :no_pedestrians: | :no_pedestrians: | :no_pedestrians:
 `@Pipe(...) class MyPipe {}` | :x: | :no_pedestrians: | :no_pedestrians: | :x:
 `@Injectable() class MyService {}` | :x: | :no_pedestrians: | :no_pedestrians: | :x:
 

--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -15,6 +15,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.STRING_VALUE_EXPECTED,
   AngularWarningCode.TYPE_LITERAL_EXPECTED,
   AngularWarningCode.TYPE_IS_NOT_A_DIRECTIVE,
+  AngularWarningCode.FUNCTION_IS_NOT_A_DIRECTIVE,
   AngularWarningCode.UNRESOLVED_TAG,
   AngularWarningCode.UNTERMINATED_MUSTACHE,
   AngularWarningCode.UNOPENED_MUSTACHE,
@@ -60,6 +61,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG,
   AngularWarningCode.UNSAFE_BINDING,
   AngularWarningCode.EVENT_REDUCTION_NOT_ALLOWED,
+  AngularWarningCode.FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED,
   AngularHintCode.OFFSETS_CANNOT_BE_CREATED,
 ];
 
@@ -140,6 +142,13 @@ class AngularWarningCode extends ErrorCode {
       'TYPE_IS_NOT_A_DIRECTIVE',
       'The type "{0}" is included in the directives list, but is not a'
       ' directive');
+
+  /// An error code indicating that a function not annotated with @Directive was
+  /// used as one.
+  static const FUNCTION_IS_NOT_A_DIRECTIVE = const AngularWarningCode(
+      'FUNCTION_IS_NOT_A_DIRECTIVE',
+      'The function "{0}" is included in the directives list, but is not a'
+      ' functional directive');
 
   /// An error code indicating that the value of type is not a Pipe.
   static const TYPE_IS_NOT_A_PIPE = const AngularWarningCode(
@@ -436,6 +445,14 @@ class AngularWarningCode extends ErrorCode {
   static const EVENT_REDUCTION_NOT_ALLOWED = const AngularWarningCode(
       'EVENT_REDUCTION_NOT_ALLOWED',
       'Event reductions are only allowed on keyup and keydown events');
+
+  /// An error indicating that functional directve had exportAs specified, which
+  /// is not allowed.
+  static const FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED =
+      const AngularWarningCode(
+          'FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED',
+          'Function directives cannot have an exportAs setting, because they'
+          " can't be exported");
 
   /// Initialize a newly created error code to have the given [name].
   /// The message associated with the error will be created from the given

--- a/angular_analyzer_plugin/lib/src/file_tracker.dart
+++ b/angular_analyzer_plugin/lib/src/file_tracker.dart
@@ -8,7 +8,7 @@ abstract class FileHasher {
 }
 
 class FileTracker {
-  static const int salt = 2;
+  static const int salt = 3;
 
   final FileHasher _fileHasher;
 

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -825,7 +825,7 @@ class DirectiveResolver extends AngularAstVisitor {
     }
 
     for (final directive in unmatchedDirectives) {
-      if (directive is Directive &&
+      if (directive is AbstractDirective &&
           directive.selector.availableTo(elementView) &&
           !directive.looksLikeTemplate) {
         element.availableDirectives[directive] =

--- a/angular_analyzer_plugin/lib/src/summary/format.dart
+++ b/angular_analyzer_plugin/lib/src/summary/format.dart
@@ -1076,6 +1076,7 @@ class SummarizedDirectiveBuilder extends Object
     with _SummarizedDirectiveMixin
     implements idl.SummarizedDirective {
   SummarizedClassAnnotationsBuilder _classAnnotations;
+  String _functionName;
   bool _isComponent;
   String _selectorStr;
   int _selectorOffset;
@@ -1096,6 +1097,13 @@ class SummarizedDirectiveBuilder extends Object
 
   void set classAnnotations(SummarizedClassAnnotationsBuilder value) {
     this._classAnnotations = value;
+  }
+
+  @override
+  String get functionName => _functionName ??= '';
+
+  void set functionName(String value) {
+    this._functionName = value;
   }
 
   @override
@@ -1207,6 +1215,7 @@ class SummarizedDirectiveBuilder extends Object
 
   SummarizedDirectiveBuilder(
       {SummarizedClassAnnotationsBuilder classAnnotations,
+      String functionName,
       bool isComponent,
       String selectorStr,
       int selectorOffset,
@@ -1222,6 +1231,7 @@ class SummarizedDirectiveBuilder extends Object
       List<SummarizedExportedIdentifierBuilder> exports,
       List<SummarizedPipesUseBuilder> pipesUse})
       : _classAnnotations = classAnnotations,
+        _functionName = functionName,
         _isComponent = isComponent,
         _selectorStr = selectorStr,
         _selectorOffset = selectorOffset,
@@ -1254,6 +1264,7 @@ class SummarizedDirectiveBuilder extends Object
   void collectApiSignature(api_sig.ApiSignature signature) {
     signature.addBool(this._classAnnotations != null);
     this._classAnnotations?.collectApiSignature(signature);
+    signature.addString(this._functionName ?? '');
     signature.addBool(this._isComponent == true);
     signature.addString(this._selectorStr ?? '');
     signature.addInt(this._selectorOffset ?? 0);
@@ -1300,6 +1311,7 @@ class SummarizedDirectiveBuilder extends Object
 
   fb.Offset finish(fb.Builder fbBuilder) {
     fb.Offset offset_classAnnotations;
+    fb.Offset offset_functionName;
     fb.Offset offset_selectorStr;
     fb.Offset offset_exportAs;
     fb.Offset offset_templateUrl;
@@ -1310,6 +1322,9 @@ class SummarizedDirectiveBuilder extends Object
     fb.Offset offset_pipesUse;
     if (_classAnnotations != null) {
       offset_classAnnotations = _classAnnotations.finish(fbBuilder);
+    }
+    if (_functionName != null) {
+      offset_functionName = fbBuilder.writeString(_functionName);
     }
     if (_selectorStr != null) {
       offset_selectorStr = fbBuilder.writeString(_selectorStr);
@@ -1343,47 +1358,50 @@ class SummarizedDirectiveBuilder extends Object
     if (offset_classAnnotations != null) {
       fbBuilder.addOffset(0, offset_classAnnotations);
     }
+    if (offset_functionName != null) {
+      fbBuilder.addOffset(1, offset_functionName);
+    }
     if (_isComponent == true) {
-      fbBuilder.addBool(1, true);
+      fbBuilder.addBool(2, true);
     }
     if (offset_selectorStr != null) {
-      fbBuilder.addOffset(2, offset_selectorStr);
+      fbBuilder.addOffset(3, offset_selectorStr);
     }
     if (_selectorOffset != null && _selectorOffset != 0) {
-      fbBuilder.addUint32(3, _selectorOffset);
+      fbBuilder.addUint32(4, _selectorOffset);
     }
     if (offset_exportAs != null) {
-      fbBuilder.addOffset(4, offset_exportAs);
+      fbBuilder.addOffset(5, offset_exportAs);
     }
     if (_exportAsOffset != null && _exportAsOffset != 0) {
-      fbBuilder.addUint32(5, _exportAsOffset);
+      fbBuilder.addUint32(6, _exportAsOffset);
     }
     if (offset_templateUrl != null) {
-      fbBuilder.addOffset(6, offset_templateUrl);
+      fbBuilder.addOffset(7, offset_templateUrl);
     }
     if (_templateUrlOffset != null && _templateUrlOffset != 0) {
-      fbBuilder.addUint32(7, _templateUrlOffset);
+      fbBuilder.addUint32(8, _templateUrlOffset);
     }
     if (_templateUrlLength != null && _templateUrlLength != 0) {
-      fbBuilder.addUint32(8, _templateUrlLength);
+      fbBuilder.addUint32(9, _templateUrlLength);
     }
     if (offset_templateText != null) {
-      fbBuilder.addOffset(9, offset_templateText);
+      fbBuilder.addOffset(10, offset_templateText);
     }
     if (_templateOffset != null && _templateOffset != 0) {
-      fbBuilder.addUint32(10, _templateOffset);
+      fbBuilder.addUint32(11, _templateOffset);
     }
     if (offset_ngContents != null) {
-      fbBuilder.addOffset(11, offset_ngContents);
+      fbBuilder.addOffset(12, offset_ngContents);
     }
     if (offset_subdirectives != null) {
-      fbBuilder.addOffset(12, offset_subdirectives);
+      fbBuilder.addOffset(13, offset_subdirectives);
     }
     if (offset_exports != null) {
-      fbBuilder.addOffset(13, offset_exports);
+      fbBuilder.addOffset(14, offset_exports);
     }
     if (offset_pipesUse != null) {
-      fbBuilder.addOffset(14, offset_pipesUse);
+      fbBuilder.addOffset(15, offset_pipesUse);
     }
     return fbBuilder.endTable();
   }
@@ -1407,6 +1425,7 @@ class _SummarizedDirectiveImpl extends Object
   _SummarizedDirectiveImpl(this._bc, this._bcOffset);
 
   idl.SummarizedClassAnnotations _classAnnotations;
+  String _functionName;
   bool _isComponent;
   String _selectorStr;
   int _selectorOffset;
@@ -1430,65 +1449,71 @@ class _SummarizedDirectiveImpl extends Object
   }
 
   @override
+  String get functionName {
+    _functionName ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 1, '');
+    return _functionName;
+  }
+
+  @override
   bool get isComponent {
-    _isComponent ??= const fb.BoolReader().vTableGet(_bc, _bcOffset, 1, false);
+    _isComponent ??= const fb.BoolReader().vTableGet(_bc, _bcOffset, 2, false);
     return _isComponent;
   }
 
   @override
   String get selectorStr {
-    _selectorStr ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 2, '');
+    _selectorStr ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 3, '');
     return _selectorStr;
   }
 
   @override
   int get selectorOffset {
-    _selectorOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 3, 0);
+    _selectorOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 4, 0);
     return _selectorOffset;
   }
 
   @override
   String get exportAs {
-    _exportAs ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 4, '');
+    _exportAs ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 5, '');
     return _exportAs;
   }
 
   @override
   int get exportAsOffset {
-    _exportAsOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 5, 0);
+    _exportAsOffset ??= const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 6, 0);
     return _exportAsOffset;
   }
 
   @override
   String get templateUrl {
-    _templateUrl ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 6, '');
+    _templateUrl ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 7, '');
     return _templateUrl;
   }
 
   @override
   int get templateUrlOffset {
     _templateUrlOffset ??=
-        const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 7, 0);
+        const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 8, 0);
     return _templateUrlOffset;
   }
 
   @override
   int get templateUrlLength {
     _templateUrlLength ??=
-        const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 8, 0);
+        const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 9, 0);
     return _templateUrlLength;
   }
 
   @override
   String get templateText {
-    _templateText ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 9, '');
+    _templateText ??= const fb.StringReader().vTableGet(_bc, _bcOffset, 10, '');
     return _templateText;
   }
 
   @override
   int get templateOffset {
     _templateOffset ??=
-        const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 10, 0);
+        const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 11, 0);
     return _templateOffset;
   }
 
@@ -1496,7 +1521,7 @@ class _SummarizedDirectiveImpl extends Object
   List<idl.SummarizedNgContent> get ngContents {
     _ngContents ??= const fb.ListReader<idl.SummarizedNgContent>(
             const _SummarizedNgContentReader())
-        .vTableGet(_bc, _bcOffset, 11, const <idl.SummarizedNgContent>[]);
+        .vTableGet(_bc, _bcOffset, 12, const <idl.SummarizedNgContent>[]);
     return _ngContents;
   }
 
@@ -1504,7 +1529,7 @@ class _SummarizedDirectiveImpl extends Object
   List<idl.SummarizedDirectiveUse> get subdirectives {
     _subdirectives ??= const fb.ListReader<idl.SummarizedDirectiveUse>(
             const _SummarizedDirectiveUseReader())
-        .vTableGet(_bc, _bcOffset, 12, const <idl.SummarizedDirectiveUse>[]);
+        .vTableGet(_bc, _bcOffset, 13, const <idl.SummarizedDirectiveUse>[]);
     return _subdirectives;
   }
 
@@ -1513,7 +1538,7 @@ class _SummarizedDirectiveImpl extends Object
     _exports ??= const fb.ListReader<idl.SummarizedExportedIdentifier>(
             const _SummarizedExportedIdentifierReader())
         .vTableGet(
-            _bc, _bcOffset, 13, const <idl.SummarizedExportedIdentifier>[]);
+            _bc, _bcOffset, 14, const <idl.SummarizedExportedIdentifier>[]);
     return _exports;
   }
 
@@ -1521,7 +1546,7 @@ class _SummarizedDirectiveImpl extends Object
   List<idl.SummarizedPipesUse> get pipesUse {
     _pipesUse ??= const fb.ListReader<idl.SummarizedPipesUse>(
             const _SummarizedPipesUseReader())
-        .vTableGet(_bc, _bcOffset, 14, const <idl.SummarizedPipesUse>[]);
+        .vTableGet(_bc, _bcOffset, 15, const <idl.SummarizedPipesUse>[]);
     return _pipesUse;
   }
 }
@@ -1532,6 +1557,7 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
     Map<String, Object> _result = <String, Object>{};
     if (classAnnotations != null)
       _result["classAnnotations"] = classAnnotations.toJson();
+    if (functionName != '') _result["functionName"] = functionName;
     if (isComponent != false) _result["isComponent"] = isComponent;
     if (selectorStr != '') _result["selectorStr"] = selectorStr;
     if (selectorOffset != 0) _result["selectorOffset"] = selectorOffset;
@@ -1560,6 +1586,7 @@ abstract class _SummarizedDirectiveMixin implements idl.SummarizedDirective {
   @override
   Map<String, Object> toMap() => {
         "classAnnotations": classAnnotations,
+        "functionName": functionName,
         "isComponent": isComponent,
         "selectorStr": selectorStr,
         "selectorOffset": selectorOffset,

--- a/angular_analyzer_plugin/lib/src/summary/format.fbs
+++ b/angular_analyzer_plugin/lib/src/summary/format.fbs
@@ -55,33 +55,35 @@ table SummarizedClassAnnotations {
 table SummarizedDirective {
   classAnnotations:SummarizedClassAnnotations (id: 0);
 
-  isComponent:bool (id: 1);
+  functionName:string (id: 1);
 
-  selectorStr:string (id: 2);
+  isComponent:bool (id: 2);
 
-  selectorOffset:uint (id: 3);
+  selectorStr:string (id: 3);
 
-  exportAs:string (id: 4);
+  selectorOffset:uint (id: 4);
 
-  exportAsOffset:uint (id: 5);
+  exportAs:string (id: 5);
 
-  templateUrl:string (id: 6);
+  exportAsOffset:uint (id: 6);
 
-  templateUrlOffset:uint (id: 7);
+  templateUrl:string (id: 7);
 
-  templateUrlLength:uint (id: 8);
+  templateUrlOffset:uint (id: 8);
 
-  templateText:string (id: 9);
+  templateUrlLength:uint (id: 9);
 
-  templateOffset:uint (id: 10);
+  templateText:string (id: 10);
 
-  ngContents:[SummarizedNgContent] (id: 11);
+  templateOffset:uint (id: 11);
 
-  subdirectives:[SummarizedDirectiveUse] (id: 12);
+  ngContents:[SummarizedNgContent] (id: 12);
 
-  exports:[SummarizedExportedIdentifier] (id: 13);
+  subdirectives:[SummarizedDirectiveUse] (id: 13);
 
-  pipesUse:[SummarizedPipesUse] (id: 14);
+  exports:[SummarizedExportedIdentifier] (id: 14);
+
+  pipesUse:[SummarizedPipesUse] (id: 15);
 }
 
 table SummarizedPipe {

--- a/angular_analyzer_plugin/lib/src/summary/idl.dart
+++ b/angular_analyzer_plugin/lib/src/summary/idl.dart
@@ -82,32 +82,34 @@ abstract class SummarizedDirective extends base.SummaryClass {
   @Id(0)
   SummarizedClassAnnotations get classAnnotations;
   @Id(1)
-  bool get isComponent;
+  String get functionName;
   @Id(2)
-  String get selectorStr;
+  bool get isComponent;
   @Id(3)
-  int get selectorOffset;
+  String get selectorStr;
   @Id(4)
-  String get exportAs;
+  int get selectorOffset;
   @Id(5)
-  int get exportAsOffset;
+  String get exportAs;
   @Id(6)
-  String get templateUrl;
+  int get exportAsOffset;
   @Id(7)
-  int get templateUrlOffset;
+  String get templateUrl;
   @Id(8)
-  int get templateUrlLength;
+  int get templateUrlOffset;
   @Id(9)
-  String get templateText;
+  int get templateUrlLength;
   @Id(10)
-  int get templateOffset;
+  String get templateText;
   @Id(11)
-  List<SummarizedNgContent> get ngContents;
+  int get templateOffset;
   @Id(12)
-  List<SummarizedDirectiveUse> get subdirectives;
+  List<SummarizedNgContent> get ngContents;
   @Id(13)
-  List<SummarizedExportedIdentifier> get exports;
+  List<SummarizedDirectiveUse> get subdirectives;
   @Id(14)
+  List<SummarizedExportedIdentifier> get exports;
+  @Id(15)
   List<SummarizedPipesUse> get pipesUse;
 }
 

--- a/angular_analyzer_plugin/lib/src/view_extraction.dart
+++ b/angular_analyzer_plugin/lib/src/view_extraction.dart
@@ -178,6 +178,7 @@ class ViewExtractor extends AnnotationProcessorMixin {
           final element = item.staticElement;
           // LIST_OF_DIRECTIVES or TypeLiteral
           if (element is ClassElement ||
+              element is FunctionElement ||
               element is PropertyAccessorElement &&
                   element.variable.constantValue != null) {
             directiveReferences.add(new DirectiveReference(

--- a/angular_analyzer_plugin/test/completion_contributor_test.dart
+++ b/angular_analyzer_plugin/test/completion_contributor_test.dart
@@ -2486,6 +2486,29 @@ class MyDirective {
   }
 
   // ignore: non_constant_identifier_names
+  Future test_availFunctionalDirective_attribute_begin() async {
+    final dartSource = newSource('/completionTest.dart', '''
+import 'package:angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a',
+    directives: const [MyTagComponent, myDirective])
+class MyComp {
+}
+@Component(selector: 'my-tag', template: '')
+class MyTagComponent{}
+@Directive(selector: '[myDirective]')
+void myDirective() {}
+    ''');
+
+    addTestSource('<my-tag ^></my-tag>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertSuggestSetter('myDirective');
+  }
+
+  // ignore: non_constant_identifier_names
   Future test_noCompleteEmptyTagContents() async {
     final dartSource = newSource('/completionTest.dart', '''
 import 'package:angular2/angular2.dart';
@@ -3115,8 +3138,8 @@ class NotTemplateDirective {
   Future test_completeStarAttrsOnlyStar() async {
     final dartSource = newSource('/completionTest.dart', '''
 import 'package:angular2/angular2.dart';
-@Component(templateUrl: 'completionTest.html', selector: 'a',
-    directives: const [NgFor, NgIf, CustomTemplateDirective])
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives:
+    const [NgFor, NgIf, CustomTemplateDirective, functionalTemplateDirective])
 class MyComp {
   List<String> items;
 }
@@ -3125,6 +3148,9 @@ class MyComp {
 class CustomTemplateDirective {
   CustomTemplateDirective(TemplateRef tpl);
 }
+
+@Directive(selector: '[functionalTemplateDirective]')
+void functionalTemplateDirective(TemplateRef tpl);
     ''');
 
     addTestSource('<div *^></div>');
@@ -3136,6 +3162,7 @@ class CustomTemplateDirective {
     assertSuggestStar("*ngFor");
     assertSuggestStar("*ngIf");
     assertSuggestStar("*customTemplateDirective");
+    assertSuggestStar("*functionalTemplateDirective");
     assertNotSuggested("*ngForOf");
     assertNotSuggested("[id]");
     assertNotSuggested("id");

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -3315,6 +3315,24 @@ class MyStarDirective {
   }
 
   // ignore: non_constant_identifier_names
+  Future test_star_selectTemplateFunctionalDirectiveMatches() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel'
+    templateUrl: 'test_panel.html', directives: const [myStarDirective])
+class TestPanel {
+}
+@Directive(selector: 'template[myStarDirective]')
+void myStarDirective(TemplateRef ref) {}
+''');
+    final code = r'''
+<span *myStarDirective></span>
+''';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
   Future test_standardHtmlComponent() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel')


### PR DESCRIPTION
Now part of the new AngularTopLevels construct. Find them at extraction
time, serialize them in summaries and deserialize (tick the salt to
invalidate old summaries), and link them in directives lists. Even
autocomplete them in attributes, and star attrs if its a template
directive.

Some potential clean ups possible after this:
- restructure the various summary types
- move pipes to angularTopLevels idea