### PR TITLE
Publish 0.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,33 @@ analyzer:
 
 Then simply reboot your analysis server (inside IntelliJ this is done by clicking on the skull icon if it exists, or the refresh icon otherwise) and wait for the plugin to fully load, which can take a minute on the first run.
 
-## Building -- For hacking on this plugin, or using the latest
+## Loading an Exact Version
+
+This is much like the previous step. However, you should include this project in your pubspec:
+
+```
+dependencies:
+  angular_analyzer_plugin: 0.0.11
+```
+
+and then load the plugin as itself, rather than as a dependency of angular:
+
+```
+# forwards compatible (you need this)
+analyzer:
+  plugins:
+    angular_analyzer_plugin:
+      enabled: true
+
+# backwards compatible (you also need this, for the moment)
+plugins:
+  angular:
+    enabled: true
+```
+
+Like the previous installation option, you then just need to reboot your analysis server after running pub get.
+
+## Building -- For hacking on this plugin, or using the latest (unpublished)
 
 Download chrome depot tools, and clone this repository.
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,10 @@ dependencies:
 and then load the plugin as itself, rather than as a dependency of angular:
 
 ```
-# forwards compatible (you need this)
 analyzer:
   plugins:
     angular_analyzer_plugin:
       enabled: true
-
-# backwards compatible (you also need this, for the moment)
-plugins:
-  angular:
-    enabled: true
 ```
 
 Like the previous installation option, you then just need to reboot your analysis server after running pub get.

--- a/angular_analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular_analyzer_plugin
-version: 0.0.10
+version: 0.0.11
 description: Dart analyzer plugin for Angular 2+
 authors:
   - Konstantin Scheglov <scheglov@google.com>
@@ -14,7 +14,7 @@ dependencies:
   html: '^0.13.1'
   tuple: '^1.0.1'
   analyzer_plugin: '0.0.1-alpha.0'
-  angular_ast: '^0.4.0-alpha.0'
+  angular_ast: '0.4.0-alpha+1'
   meta: ^1.0.2
   yaml: ^2.1.2
   crypto: '>=1.1.1 <3.0.0'

--- a/angular_analyzer_plugin/tools/analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/tools/analyzer_plugin/pubspec.yaml
@@ -1,0 +1,8 @@
+name: analyzed_angular_plugin_loader
+version: 0.0.0
+description: Self-loader of the plugin for people using an exact version.
+environment:
+  sdk: '>=1.24.0-dev.1.0'
+dependencies:
+  angular_analyzer_plugin: '0.0.11'
+dev_dependencies:


### PR DESCRIPTION
Many many bugfixes since, even some in angular_ast. Definitely worth
publishing now.

Instructions for loading an exact version via the self-loader method,
which is updated here to load itself at the same version (0.0.11)