### PR TITLE
Incorporate custom_tag_names into unit signatures for summaries.

### DIFF
--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -68,7 +68,7 @@ class AngularDriver
       this.options) {
     _sourceFactory = sourceFactory.clone();
     _scheduler.add(this);
-    _fileTracker = new FileTracker(this);
+    _fileTracker = new FileTracker(this, options);
     // TODO only support package:angular once we all move to that
     _hasAngularImported =
         _sourceFactory.resolveUri(null, "package:angular/angular.dart") != null;

--- a/angular_analyzer_plugin/lib/src/options.dart
+++ b/angular_analyzer_plugin/lib/src/options.dart
@@ -1,12 +1,12 @@
 import 'package:yaml/yaml.dart';
 
 class AngularOptions {
-  AngularOptions({this.unknownTagNames});
+  AngularOptions({this.customTagNames});
   factory AngularOptions.from(String contents) =>
       new _OptionsBuilder(contents).build();
   factory AngularOptions.defaults() => new _OptionsBuilder.empty().build();
 
-  final List<String> unknownTagNames;
+  final List<String> customTagNames;
 }
 
 class _OptionsBuilder {
@@ -14,7 +14,7 @@ class _OptionsBuilder {
   dynamic angularOptions;
   dynamic angularPluginOptions;
 
-  List<String> unknownTagNames = const [];
+  List<String> customTagNames = const [];
 
   _OptionsBuilder.empty();
   _OptionsBuilder(String contents) : analysisOptions = loadYaml(contents) {
@@ -22,11 +22,10 @@ class _OptionsBuilder {
   }
 
   void resolve() {
-    unknownTagNames = getOption('custom_tag_names', isListOfStrings) ?? [];
+    customTagNames = getOption('custom_tag_names', isListOfStrings) ?? [];
   }
 
-  AngularOptions build() =>
-      new AngularOptions(unknownTagNames: unknownTagNames);
+  AngularOptions build() => new AngularOptions(customTagNames: customTagNames);
 
   void load() {
     if (analysisOptions['analyzer'] == null ||

--- a/angular_analyzer_plugin/test/options_test.dart
+++ b/angular_analyzer_plugin/test/options_test.dart
@@ -13,15 +13,15 @@ class AngularOptionsTest {
   // ignore: non_constant_identifier_names
   void test_buildEmpty() {
     final options = new AngularOptions.defaults();
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, isEmpty);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
   void test_buildExact() {
-    final options = new AngularOptions(unknownTagNames: ['foo']);
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, equals(['foo']));
+    final options = new AngularOptions(customTagNames: ['foo']);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, equals(['foo']));
   }
 
   // ignore: non_constant_identifier_names
@@ -32,8 +32,8 @@ analyzer:
     angular:
       enabled: true
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, isEmpty);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -48,8 +48,8 @@ analyzer:
         - bar
         - baz
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, equals(['foo', 'bar', 'baz']));
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
@@ -65,8 +65,8 @@ analyzer:
         - baz
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, isEmpty);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -82,8 +82,8 @@ analyzer:
         - baz
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, equals(['foo', 'bar', 'baz']));
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
@@ -102,8 +102,8 @@ analyzer:
         - baz
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, isEmpty);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -122,8 +122,8 @@ analyzer:
       enabled: true
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, isEmpty);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -142,8 +142,8 @@ analyzer:
         - baz
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, equals(['foo', 'bar', 'baz']));
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
@@ -169,8 +169,8 @@ analyzer:
         - this-is-good
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames,
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames,
         equals(['tags-from-angular', 'should-appear', 'this-is-good']));
   }
 
@@ -186,9 +186,9 @@ analyzer:
       enabled: true
       custom_tag_names: true
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, const isInstanceOf<List>());
-    expect(options.unknownTagNames, isEmpty);
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, const isInstanceOf<List>());
+    expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -210,7 +210,7 @@ analyzer:
         - this-is-good
 
 ''');
-    expect(options.unknownTagNames, isNotNull);
-    expect(options.unknownTagNames, equals(['should-appear', 'this-is-good']));
+    expect(options.customTagNames, isNotNull);
+    expect(options.customTagNames, equals(['should-appear', 'this-is-good']));
   }
 }

--- a/angular_analyzer_plugin/test/plugin_test.dart
+++ b/angular_analyzer_plugin/test/plugin_test.dart
@@ -49,8 +49,8 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
-    expect(driver.options.unknownTagNames, isNotNull);
-    expect(driver.options.unknownTagNames, isEmpty);
+    expect(driver.options.customTagNames, isNotNull);
+    expect(driver.options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -65,8 +65,8 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
-    expect(driver.options.unknownTagNames, isNotNull);
-    expect(driver.options.unknownTagNames, equals(['foo', 'bar', 'baz']));
+    expect(driver.options.customTagNames, isNotNull);
+    expect(driver.options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
@@ -81,8 +81,8 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
-    expect(driver.options.unknownTagNames, isNotNull);
-    expect(driver.options.unknownTagNames, equals(['foo', 'bar', 'baz']));
+    expect(driver.options.customTagNames, isNotNull);
+    expect(driver.options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
@@ -100,8 +100,8 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
-    expect(driver.options.unknownTagNames, isNotNull);
-    expect(driver.options.unknownTagNames, isEmpty);
+    expect(driver.options.customTagNames, isNotNull);
+    expect(driver.options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
@@ -119,8 +119,8 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
-    expect(driver.options.unknownTagNames, isNotNull);
-    expect(driver.options.unknownTagNames, equals(['foo', 'bar', 'baz']));
+    expect(driver.options.customTagNames, isNotNull);
+    expect(driver.options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 }
 


### PR DESCRIPTION
No analysis yet dependent on them, but this ensures the analysis won't
be stale once that analysis is added.

Also change 'unknownTagNames' to 'customTagNames' to reflect the
setting name in the yaml file, 'custom_tag_names' which is the better
term for what it does.

Comments about how summaries will be affected by future analysis
options and making sure they are in the right locations/are adequately
differentiable.