### PR TITLE
Suppress many (but not all) errors when they occur on custom tags.

### DIFF
--- a/angular_analyzer_plugin/lib/ast.dart
+++ b/angular_analyzer_plugin/lib/ast.dart
@@ -417,6 +417,7 @@ class ElementInfo extends NodeInfo implements HasDirectives {
   bool tagMatchedAsTransclusion = false;
   bool tagMatchedAsDirective = false;
   bool tagMatchedAsImmediateContentChild = false;
+  bool tagMatchedAsCustomTag = false;
 
   ElementInfo(
       this.localName,

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -511,7 +511,8 @@ class AngularDriver
                   standardHtml.events,
                   standardHtml.attributes,
                   await getStandardAngular(),
-                  tplErrorListener)
+                  tplErrorListener,
+                  options)
               .resolve(template);
 
           bool rightErrorType(AnalysisError e) =>
@@ -692,7 +693,8 @@ class AngularDriver
                   standardHtml.events,
                   standardHtml.attributes,
                   await getStandardAngular(),
-                  tplErrorListener)
+                  tplErrorListener,
+                  options)
               .resolve(template);
           errors
             ..addAll(tplParser.parseErrors.where(

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -133,7 +133,7 @@ class TemplateResolver {
         standardAngular,
         errorReporter,
         errorListener,
-        new Set<String>.from(options.unknownTagNames));
+        new Set<String>.from(options.customTagNames));
     root.accept(directiveResolver);
     final contentResolver =
         new ComponentContentResolver(templateSource, template, errorListener);
@@ -1639,7 +1639,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
 }
 
 /// Custom tags shouldn't report things like unbound inputs/outputs
-bool isOnCustomTag(AngularAstNode node) {
+bool isOnCustomTag(AttributeInfo node) {
   if (node.parent == null) {
     return false;
   }

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -146,7 +146,7 @@ class AbstractAngularTest {
         sf,
         new FileContentOverlay(),
         new AngularOptions(
-            unknownTagNames: ['my-first-custom-tag', 'my-second-custom-tag']));
+            customTagNames: ['my-first-custom-tag', 'my-second-custom-tag']));
 
     errorListener = new GatheringErrorListener();
     _addAngularSources();

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -145,7 +145,8 @@ class AbstractAngularTest {
         byteStore,
         sf,
         new FileContentOverlay(),
-        new AngularOptions.defaults());
+        new AngularOptions(
+            unknownTagNames: ['my-first-custom-tag', 'my-second-custom-tag']));
 
     errorListener = new GatheringErrorListener();
     _addAngularSources();


### PR DESCRIPTION
Inputs and outputs may be because of web components, ignore those
warnings on a tag that was entered as a custom tag.

Ensure we stil get all the rest.