### PR TITLE
Add new options for ContentChild(ren) in prep for deprecating ElementRef

### DIFF
--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -47,6 +47,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.STRING_STYLE_INPUT_BINDING_INVALID,
   AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
   AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE,
+  AngularWarningCode.CHILD_QUERY_TYPE_REQUIRES_READ,
   AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
   AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_LIST,
   AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
@@ -357,6 +358,13 @@ class AngularWarningCode extends ErrorCode {
       'UNKNOWN_CHILD_QUERY_TYPE',
       'The field {0} marked with @{1} must reference a directive, a string'
       ' let-binding name, TemplateRef, or ElementRef');
+
+  /// An error code indicating that a @ContentChild or @ContentChildren field
+  /// didn't have an expected value
+  static const CHILD_QUERY_TYPE_REQUIRES_READ = const AngularWarningCode(
+      'CHILD_QUERY_TYPE_REQUIRES_READ',
+      'The field {0} marked with @{1} cannot reference type {2} unless the @{1}'
+      ' annotation includes `read: {2}`');
 
   /// An error code indicating that @ContentChildren or @ViewChildren was used
   /// but the property wasn't a `QueryList`.

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -479,8 +479,8 @@ class AngularDriver
     final linkErrorListener = new IgnoringErrorListener();
     final linkErrorReporter = new ErrorReporter(linkErrorListener, dartSource);
 
-    final linker = new ChildDirectiveLinker(
-        this, this, await getStandardAngular(), linkErrorReporter);
+    final linker = new ChildDirectiveLinker(this, this,
+        await getStandardAngular(), await getStandardHtml(), linkErrorReporter);
     await linker.linkDirectivesAndPipes(directives, pipes, unit.library);
     final attrValidator = new AttributeAnnotationValidator(linkErrorReporter);
 
@@ -659,8 +659,8 @@ class AngularDriver
     final linkErrorListener = new RecordingErrorListener();
     final linkErrorReporter = new ErrorReporter(linkErrorListener, source);
 
-    final linker = new ChildDirectiveLinker(
-        this, this, await getStandardAngular(), linkErrorReporter);
+    final linker = new ChildDirectiveLinker(this, this,
+        await getStandardAngular(), await getStandardHtml(), linkErrorReporter);
     await linker.linkDirectivesAndPipes(directives, pipes, unit.library);
     final attrValidator = new AttributeAnnotationValidator(linkErrorReporter);
     directives

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -289,7 +289,12 @@ class AngularDriver
       result.unit.accept(new BuildStandardHtmlComponentsVisitor(
           components, events, attributes, source, securitySchema));
 
-      standardHtml = new StandardHtml(components, events, attributes);
+      standardHtml = new StandardHtml(
+          components,
+          events,
+          attributes,
+          result.libraryElement.exportNamespace.get('Element'),
+          result.libraryElement.exportNamespace.get('HtmlElement'));
     }
 
     return standardHtml;
@@ -512,6 +517,7 @@ class AngularDriver
                   standardHtml.events,
                   standardHtml.attributes,
                   await getStandardAngular(),
+                  await getStandardHtml(),
                   tplErrorListener,
                   options)
               .resolve(template);
@@ -694,6 +700,7 @@ class AngularDriver
                   standardHtml.events,
                   standardHtml.attributes,
                   await getStandardAngular(),
+                  await getStandardHtml(),
                   tplErrorListener,
                   options)
               .resolve(template);

--- a/angular_analyzer_plugin/lib/src/directive_linking.dart
+++ b/angular_analyzer_plugin/lib/src/directive_linking.dart
@@ -414,9 +414,10 @@ class ChildDirectiveLinker implements DirectiveMatcher {
   final FilePipeProvider _filePipeProvider;
   final ErrorReporter _errorReporter;
   final StandardAngular _standardAngular;
+  final StandardHtml _standardHtml;
 
   ChildDirectiveLinker(this._fileDirectiveProvider, this._filePipeProvider,
-      this._standardAngular, this._errorReporter);
+      this._standardAngular, this._standardHtml, this._errorReporter);
 
   Future linkDirectivesAndPipes(
     List<AbstractDirective> directivesToLink,
@@ -471,8 +472,8 @@ class ChildDirectiveLinker implements DirectiveMatcher {
         await new InheritedMetadataLinker(directive, _fileDirectiveProvider)
             .link();
 
-        await new ContentChildLinker(
-                directive, this, _standardAngular, _errorReporter)
+        await new ContentChildLinker(directive, this, _standardAngular,
+                _standardHtml, _errorReporter)
             .linkContentChildren();
       }
     }
@@ -731,7 +732,7 @@ class ChildDirectiveLinker implements DirectiveMatcher {
       final errorIgnorer =
           new ErrorReporter(new IgnoringErrorListener(), directive.source);
       await new ContentChildLinker(
-              directive, this, _standardAngular, errorIgnorer)
+              directive, this, _standardAngular, _standardHtml, errorIgnorer)
           .linkContentChildren();
     }
 
@@ -750,11 +751,12 @@ class ContentChildLinker {
   final AbstractClassDirective _directive;
   final DirectiveMatcher _directiveMatcher;
   final StandardAngular _standardAngular;
+  final StandardHtml _standardHtml;
 
   final htmlTypes = new Set.from(['ElementRef', 'Element', 'HtmlElement']);
 
   ContentChildLinker(AbstractClassDirective directive, this._directiveMatcher,
-      this._standardAngular, this._errorReporter)
+      this._standardAngular, this._standardHtml, this._errorReporter)
       : _context =
             directive.classElement.enclosingElement.enclosingElement.context,
         _directive = directive;
@@ -846,11 +848,30 @@ class ContentChildLinker {
     final read = getReadWithInheritance(annotationValue);
 
     if (value?.toStringValue() != null) {
+      final transformedType = transformSetterTypeFn(
+          bindingSynthesizer.getSetterType(member), field, annotationName);
+
+      if (transformedType == _standardHtml.elementClass.type ||
+          transformedType == _standardHtml.htmlElementClass.type) {
+        if (read != transformedType.name) {
+          _errorReporter.reportErrorForOffset(
+              AngularWarningCode.CHILD_QUERY_TYPE_REQUIRES_READ,
+              field.nameRange.offset,
+              field.nameRange.length,
+              [field.fieldName, annotationName, transformedType.name]);
+        } else {
+          destinationArray.add(new ContentChild(
+              field,
+              new LetBoundQueriedChildType(
+                  value.toStringValue(), transformedType),
+              read: read));
+          return;
+        }
+      }
+
       // Take the type -- except, we can't validate DI symbols via `read`.
-      final setterType = read == null
-          ? transformSetterTypeFn(
-              bindingSynthesizer.getSetterType(member), field, annotationName)
-          : _context.typeProvider.dynamicType;
+      final setterType =
+          read == null ? transformedType : _context.typeProvider.dynamicType;
 
       destinationArray.add(new ContentChild(field,
           new LetBoundQueriedChildType(value.toStringValue(), setterType),

--- a/angular_analyzer_plugin/lib/src/directive_linking.dart
+++ b/angular_analyzer_plugin/lib/src/directive_linking.dart
@@ -751,6 +751,8 @@ class ContentChildLinker {
   final DirectiveMatcher _directiveMatcher;
   final StandardAngular _standardAngular;
 
+  final htmlTypes = new Set.from(['ElementRef', 'Element', 'HtmlElement']);
+
   ContentChildLinker(AbstractClassDirective directive, this._directiveMatcher,
       this._standardAngular, this._errorReporter)
       : _context =
@@ -861,8 +863,8 @@ class ContentChildLinker {
       AbstractQueriedChildType query;
       if (referencedDirective != null) {
         query = new DirectiveQueriedChildType(referencedDirective);
-      } else if (type.element.name == 'ElementRef') {
-        query = new ElementRefQueriedChildType();
+      } else if (htmlTypes.contains(type.element.name)) {
+        query = new ElementQueriedChildType();
       } else if (type.element.name == 'TemplateRef') {
         query = new TemplateRefQueriedChildType();
       } else {

--- a/angular_analyzer_plugin/lib/src/model.dart
+++ b/angular_analyzer_plugin/lib/src/model.dart
@@ -367,7 +367,7 @@ class ContentChild {
   final AbstractQueriedChildType query;
 
   /// Look up a symbol from the injector. We don't track the injector yet.
-  final String read;
+  final dart.DartType read;
 
   ContentChild(this.field, this.query, {this.read});
 }

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -93,6 +93,7 @@ class TemplateResolver {
   final AngularOptions options;
   final AnalysisErrorListener errorListener;
   final StandardAngular standardAngular;
+  final StandardHtml standardHtml;
 
   Template template;
   View view;
@@ -111,6 +112,7 @@ class TemplateResolver {
       this.standardHtmlEvents,
       this.standardHtmlAttributes,
       this.standardAngular,
+      this.standardHtml,
       this.errorListener,
       this.options);
 
@@ -131,6 +133,7 @@ class TemplateResolver {
         templateSource,
         template,
         standardAngular,
+        standardHtml,
         errorReporter,
         errorListener,
         new Set<String>.from(options.customTagNames));
@@ -779,6 +782,7 @@ class DirectiveResolver extends AngularAstVisitor {
   final AnalysisErrorListener errorListener;
   final ErrorReporter _errorReporter;
   final StandardAngular _standardAngular;
+  final StandardHtml _standardHtml;
   final outerBindings = <DirectiveBinding>[];
   final outerElements = <ElementInfo>[];
   final Set<String> customTagNames;
@@ -788,6 +792,7 @@ class DirectiveResolver extends AngularAstVisitor {
       this.templateSource,
       this.template,
       this._standardAngular,
+      this._standardHtml,
       this._errorReporter,
       this.errorListener,
       this.customTagNames);
@@ -907,7 +912,7 @@ class DirectiveResolver extends AngularAstVisitor {
         }
 
         if (contentChild.query
-            .match(element, _standardAngular, _errorReporter)) {
+            .match(element, _standardAngular, _standardHtml, _errorReporter)) {
           binding.contentChildBindings.putIfAbsent(
               contentChild,
               () => new ContentChildBinding(
@@ -931,7 +936,7 @@ class DirectiveResolver extends AngularAstVisitor {
 
       for (var contentChildren in binding.boundDirective.contentChildren) {
         if (contentChildren.query
-            .match(element, _standardAngular, _errorReporter)) {
+            .match(element, _standardAngular, _standardHtml, _errorReporter)) {
           binding.contentChildrenBindings.putIfAbsent(
               contentChildren,
               () => new ContentChildBinding(

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -12,12 +12,16 @@ class StandardHtml {
   final Map<String, OutputElement> events;
   final Map<String, InputElement> attributes;
 
+  final ClassElement elementClass;
+  final ClassElement htmlElementClass;
+
   /// In attributes, there can be multiple strings that point to the
   /// same [InputElement] generated from [alternativeInputs] (below).
   /// This will provide a static source of unique [InputElement]s.
   final Set<InputElement> uniqueAttributeElements;
 
-  StandardHtml(this.components, this.events, this.attributes)
+  StandardHtml(this.components, this.events, this.attributes, this.elementClass,
+      this.htmlElementClass)
       : uniqueAttributeElements = new Set.from(attributes.values);
 }
 

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -2708,8 +2708,7 @@ class ContentChildComp {}
     final component = directives.first;
     final childs = component.contentChilds;
     expect(childs, hasLength(1));
-    expect(
-        childs.first.query, const isInstanceOf<ElementRefQueriedChildType>());
+    expect(childs.first.query, const isInstanceOf<ElementQueriedChildType>());
 
     // validate
     errorListener.assertNoErrors();
@@ -2731,8 +2730,8 @@ class ComponentA {
     final component = directives.first;
     final childrens = component.contentChildren;
     expect(childrens, hasLength(1));
-    expect(childrens.first.query,
-        const isInstanceOf<ElementRefQueriedChildType>());
+    expect(
+        childrens.first.query, const isInstanceOf<ElementQueriedChildType>());
 
     // validate
     errorListener.assertNoErrors();

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -274,6 +274,15 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
       expect(input.securityContext.sanitizationAvailable, equals(true));
     }
   }
+
+  // ignore: non_constant_identifier_names
+  Future test_buildStandardHtmlClasses() async {
+    final stdhtml = await angularDriver.getStandardHtml();
+    expect(stdhtml.elementClass, isNotNull);
+    expect(stdhtml.elementClass.name, 'Element');
+    expect(stdhtml.htmlElementClass, isNotNull);
+    expect(stdhtml.htmlElementClass.name, 'HtmlElement');
+  }
 }
 
 @reflectiveTest

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -3911,6 +3911,30 @@ class TranscludeSome {
 
   Future
       // ignore: non_constant_identifier_names
+      test_resolveTemplate_provideContentNotMatchingSelectorsButMatchesContentChildHtmlElement() async {
+    _addDartSource(r'''
+import 'dart:html';
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html',
+    directives: const [TranscludeSome])
+class TestPanel {
+}
+@Component(selector: 'transclude-some',
+    template: '<ng-content select="transclude-me"></ng-content>')
+class TranscludeSome {
+  @ContentChild(HtmlElement)
+  HtmlElement foo;
+}
+''');
+    final code = r"""
+<transclude-some><div></div></transclude-some>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  Future
+      // ignore: non_constant_identifier_names
       test_resolveTemplate_provideContentNotMatchingSelectorsButMatchesContentChildTemplateRef() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html',
@@ -3990,7 +4014,7 @@ class TestPanel {
 }
 @Component(selector: 'transclude-none', template: '')
 class TranscludeNone {
-  @ContentChild('contentChild')
+  @ContentChild('contentChild', read: Element)
   Element foo;
   @ContentChild('contentChild')
   ElementRef foo; // to be deprecated, but ok
@@ -4284,7 +4308,7 @@ class TranscludeNone {
 @Component(selector: 'transclude-all-with-content-child',
     template: '<ng-content></ng-content>')
 class TranscludeAllWithContentChild {
-  @ContentChild("contentChildOfHigherComponent")
+  @ContentChild("contentChildOfHigherComponent", read: Element)
   Element foo;
 }
 ''');
@@ -4337,7 +4361,7 @@ class TestPanel {
 }
 @Component(selector: 'has-content-child', template: '<ng-content></ng-content>')
 class HasContentChild {
-  @ContentChild('contentChild')
+  @ContentChild('contentChild', read: Element)
   Element foo;
 }
 ''');
@@ -4391,7 +4415,7 @@ class TestPanel {
 }
 @Component(selector: 'has-content-child', template: '<ng-content></ng-content>')
 class HasContentChild {
-  @ContentChild('contentChild')
+  @ContentChild('contentChild', read: Element)
   Element foo;
 }
 @Component(selector: 'some-component', template: '')
@@ -4448,7 +4472,7 @@ class TestPanel {
 }
 @Component(selector: 'has-content-child', template: '<ng-content></ng-content>')
 class HasContentChild {
-  @ContentChild('contentChild')
+  @ContentChild('contentChild', read: Element)
   Element foo;
 }
 @Directive(selector: '[some-directive]', template: '', exportAs: "theDirective")
@@ -4783,7 +4807,7 @@ class TestPanel {
 }
 @Component(selector: 'has-content-child', template: '<ng-content></ng-content>')
 class HasContentChild {
-  @ContentChild('contentChild')
+  @ContentChild('contentChild', read: Element)
   Element foo;
 }
 @Directive(selector: '[some-directive]', template: '', exportAs: "theDirective")


### PR DESCRIPTION
Accept (for the moment) ElementRef, Element, and HtmlElement (the
latter two being from dart:html).

Update most tests specific to ElementRef to have a copy that uses
Element. Tests that use ElementRef to check general
transclusion/content child/content children behavior which use
ElementRef have been changed to use Element.

We currently don't differentiate SVG and HTML, so we accept either type
for either case at the moment.