### PR TITLE
Use List instead of QueryList (though still support it, for now).

### DIFF
--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -48,6 +48,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.INVALID_TYPE_FOR_CHILD_QUERY,
   AngularWarningCode.UNKNOWN_CHILD_QUERY_TYPE,
   AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
+  AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_LIST,
   AngularWarningCode.MATCHED_LET_BINDING_HAS_WRONG_TYPE,
   AngularWarningCode.EXPORTS_MUST_BE_PLAIN_IDENTIFIERS,
   AngularWarningCode.DUPLICATE_EXPORT,
@@ -359,6 +360,16 @@ class AngularWarningCode extends ErrorCode {
 
   /// An error code indicating that @ContentChildren or @ViewChildren was used
   /// but the property wasn't a `QueryList`.
+  static const CONTENT_OR_VIEW_CHILDREN_REQUIRES_LIST =
+      const AngularWarningCode(
+          'CONTENT_OR_VIEW_CHILDREN_REQUIRES_LIST',
+          'The field {0} marked with @{1} expects a member of type List,'
+          ' but got {2}');
+
+  /// Here for backwards compatibility. Should not be used. Use
+  /// [CONTENT_OR_VIEW_CHILDREN_REQUIRES_LIST] instead. Note: we can remove this
+  /// the next time we tick the salt in `lib/src/file_tracker.dart`.
+  @deprecated
   static const CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST =
       const AngularWarningCode(
           'CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST',

--- a/angular_analyzer_plugin/lib/src/directive_linking.dart
+++ b/angular_analyzer_plugin/lib/src/directive_linking.dart
@@ -917,7 +917,8 @@ class ContentChildLinker {
         ?.instantiate([_context.typeProvider.bottomType]);
 
     final isList = setterType.isSupertypeOf(listBottom);
-    final isQueryList = setterType?.isSupertypeOf(queryListBottom) ?? false;
+    final isQueryList =
+        queryListBottom != null && setterType.isSupertypeOf(queryListBottom);
 
     if (!isList && !isQueryList) {
       _errorReporter.reportErrorForOffset(

--- a/angular_analyzer_plugin/lib/src/directive_linking.dart
+++ b/angular_analyzer_plugin/lib/src/directive_linking.dart
@@ -907,16 +907,21 @@ class ContentChildLinker {
 
   DartType transformSetterTypeMultiple(
       DartType setterType, ContentChildField field, String annotationName) {
-    // construct QueryList<Bottom>, which is a supertype of all QueryList<T>
-    // NOTE: In most languages, you'd need QueryList<Object>, but not dart.
-    final queryListBottom = _standardAngular.queryList.type
+    // construct List<Bottom>, which is a supertype of all List<T>
+    // NOTE: In most languages, you'd need List<Object>, but not dart.
+    final listBottom = _context.typeProvider.listType
         .instantiate([_context.typeProvider.bottomType]);
+    // Temporarily check QueryList, which is deprecated, but allowed.
+    // CAREFUL: QueryList may be NULL, handle that gracefully.
+    final queryListBottom = _standardAngular.queryList?.type
+        ?.instantiate([_context.typeProvider.bottomType]);
 
-    final isQueryList = setterType.isSupertypeOf(queryListBottom);
+    final isList = setterType.isSupertypeOf(listBottom);
+    final isQueryList = setterType?.isSupertypeOf(queryListBottom) ?? false;
 
-    if (!isQueryList) {
+    if (!isList && !isQueryList) {
       _errorReporter.reportErrorForOffset(
-          AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_QUERY_LIST,
+          AngularWarningCode.CONTENT_OR_VIEW_CHILDREN_REQUIRES_LIST,
           field.typeRange.offset,
           field.typeRange.length,
           [field.fieldName, annotationName, setterType]);

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -99,6 +99,13 @@ class AbstractAngularTest {
 
   GatheringErrorListener errorListener;
 
+  // flags specific to handling multiple versions of angular which may differ,
+  // but we still need to support.
+  final bool includeQueryList;
+
+  AbstractAngularTest() : includeQueryList = true;
+  AbstractAngularTest.future() : includeQueryList = false;
+
   Source newSource(String path, [String content = '']) {
     final file = resourceProvider.newFile(path, content);
     final source = file.createSource();
@@ -180,7 +187,9 @@ export 'src/core/change_detection.dart';
 library angular.security;
 export 'src/security/dom_sanitization_service.dart';
 ''');
-    newSource('/angular/src/core/metadata.dart', r'''
+    newSource(
+        '/angular/src/core/metadata.dart',
+        r'''
 import 'dart:async';
 
 abstract class Directive {
@@ -280,7 +289,13 @@ class DependencyMetadata {
 
 class TemplateRef {}
 class ElementRef {}
+''' +
+            (includeQueryList
+                ? r'''
 class QueryList<T> implements Iterable<T> {}
+'''
+                : '') +
+            r'''
 class ViewContainerRef {}
 class PipeTransform {}
 ''');

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -4684,7 +4684,7 @@ class TestPanel {
 @Component(selector: 'has-content-children-element-ref', template: '')
 class HasContentChildrenElementRef {
   @ContentChildren(ElementRef)
-  QueryList<ElementRef> theElement;
+  List<ElementRef> theElement;
 }
 ''');
     final code = r"""


### PR DESCRIPTION
A couple subtle things:

* deprecate the SHOULD_BE_QUERY_LIST error code but keep it. The cache
includes the message itself, so to fix it we'd have to bust the cache
which causes deep reanalysis. Next time we bust the cache we can drop
it.

* We have no testing infrastructure for different versions of our
angular version, so I can't test the case where QueryList is removed
from the source. However, its used in one place so I think that's OK.
Have a comment to help people avoid that trap.

And some basic things:
* Accept either QueryList or List
* Change all tests to use List (the preferred way now)
* Add one test to ensure QueryList still works and call it good