### PR TITLE
Handle quotes in attribute selector values.

### DIFF
--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -592,6 +592,37 @@ class SelectorParserTest {
   }
 
   // ignore: non_constant_identifier_names
+  void test_attribute_hasValueWithQuotes() {
+    final AndSelector selector =
+        new SelectorParser(source, 10, '''[single='quotes'][double="quotes"]''')
+            .parse();
+    expect(selector, const isInstanceOf<AndSelector>());
+    expect(selector.selectors, hasLength(2));
+    {
+      final AttributeSelector subSelector = selector.selectors[0];
+      expect(subSelector, const isInstanceOf<AttributeSelector>());
+      {
+        final nameElement = subSelector.nameElement;
+        expect(nameElement.source, source);
+        expect(nameElement.name, 'single');
+      }
+      // Ensure there are no quotes within the value
+      expect(subSelector.value, 'quotes');
+    }
+    {
+      final AttributeSelector subSelector = selector.selectors[1];
+      expect(subSelector, const isInstanceOf<AttributeSelector>());
+      {
+        final nameElement = subSelector.nameElement;
+        expect(nameElement.source, source);
+        expect(nameElement.name, 'double');
+      }
+      // Ensure there are no quotes within the value
+      expect(subSelector.value, 'quotes');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
   void test_attribute_hasWildcard() {
     final AttributeSelector selector =
         new SelectorParser(source, 10, '[kind*=pretty]').parse();


### PR DESCRIPTION
Previously, `[x="y"]` would look for `<... x='"y"'>`. That is to say,
it expected literal quotes rather than expecting merely the value `y`
for some attr `x` via some valid html.

Split the regex for attrs into three options: no quotes (and
potentially no attrs), single, and double quotes. This allows us to
mostly keep the same Map system for making match indexes a little bit
less awful to use.

Required using some offsets off of the match index, so track that, and
use that accordingly.