### PR TITLE
Fix travis branch detection; git branch doesn't seem to work.

### DIFF
--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -3,6 +3,11 @@
 # Fast fail the script on failures.
 set -e
 
+if [[ -z "$TRAVIS_BRANCH" ]]
+then
+  TRAVIS_BRANCH="$(git branch)"
+fi
+
 # Go to the respective package directory
 cd $PACKAGE
 
@@ -10,7 +15,7 @@ cd $PACKAGE
 # depot tools.
 if [[ "$PACKAGE" != old_plugin_loader ]]
 then
-  if [[ -z "$(git branch | grep 'SDK_AT_HEAD')" ]]
+  if [[ -z "$(echo $TRAVIS_BRANCH | grep 'SDK_AT_HEAD')" ]]
   then
     echo Using pub for the SDK dependencies.
     echo


### PR DESCRIPTION
Use the travis environment variable instead -- but still fall back to
git branch for local runs.

This only affects branches running with SDK_AT_HEAD.