### PR TITLE
Fix crash where we suggest something prefixed by itself, a range error.

### DIFF
--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -859,10 +859,17 @@ class TemplateCompleter {
         if (usedInputs.contains(input)) {
           continue;
         }
+
         // edge case. Don't think this comes up in standard.
         if (!input.name.startsWith(templateAttr.prefix)) {
           continue;
         }
+
+        // Unlick ngForTrackBy becoming trackBy, ngFor can't become anything.
+        if (input.name == templateAttr.prefix) {
+          continue;
+        }
+
         collector.addSuggestion(_createInputInTemplateSuggestion(
             templateAttr.prefix,
             input,

--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -865,7 +865,7 @@ class TemplateCompleter {
           continue;
         }
 
-        // Unlick ngForTrackBy becoming trackBy, ngFor can't become anything.
+        // Unlike ngForTrackBy becoming trackBy, ngFor can't become anything.
         if (input.name == templateAttr.prefix) {
           continue;
         }

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -338,6 +338,8 @@ import 'metadata.dart';
 @Directive(selector: "[ngIf]", inputs: const ["ngIf"])
 class NgIf {
   NgIf(TemplateRef tpl);
+
+  @Input()
   set ngIf(newCondition) {}
 }
 ''');

--- a/angular_analyzer_plugin/test/completion_contributor_test.dart
+++ b/angular_analyzer_plugin/test/completion_contributor_test.dart
@@ -641,6 +641,26 @@ class MyComp {
   }
 
   // ignore: non_constant_identifier_names
+  Future test_completeMemberInNgIfPartial() async {
+    final dartSource = newSource('/completionTest.dart', '''
+import 'package:angular2/angular2.dart';
+@Component(templateUrl: 'completionTest.html', selector: 'a', directives: const [NgIf])
+class MyComp {
+  String text;
+}
+    ''');
+
+    addTestSource('<div *ngIf="let ^" ></div>');
+
+    await resolveSingleTemplate(dartSource);
+    await computeSuggestions();
+    expect(replacementOffset, completionOffset);
+    expect(replacementLength, 0);
+    assertNotSuggested('text');
+    assertNotSuggested('ngIf');
+  }
+
+  // ignore: non_constant_identifier_names
   Future test_completeDotMemberInNgFor() async {
     final dartSource = newSource('/completionTest.dart', '''
 import 'package:angular2/angular2.dart';


### PR DESCRIPTION
Inside `<div *foo=" ... ">`, we look at the `Foo` directive for inputs
`fooBar`, `fooBaz`, and suggest `bar:`, and `baz:`. However, when `Foo`
has a `foo` input, we may try to suggest it at times. In these times,
it crashes because it gets the suffix (empty string) and attempts to
decapitalize the first character (there is no first character), and it
crashes.

We have no business suggesting it. That is to say, we *could* handle
the crash and suggest ':', but that would be a bogus suggestion anyway.

We already do a prefix check, simply a matter of adding an equality
check too.