### PR TITLE
Fix #471 add status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Angular Dart Analysis Plugins
+# Angular Dart Analysis Plugin [![Build Status](https://travis-ci.org/dart-lang/angular_analyzer_plugin.svg?branch=master)](https://travis-ci.org/dart-lang/angular_analyzer_plugin)
 
 ## Integration with Dart Analysis Server
 


### PR DESCRIPTION
Also remove plurality from readme which is outdated (used to be server
plugin/analysis plugin, now its just a server plugin).

fix https://github.com/dart-lang/angular_analyzer_plugin/issues/471