### PR TITLE
Support (focusin) and (focusout), taking care of its nonexist getter

### DIFF
--- a/angular_analyzer_plugin/lib/src/navigation.dart
+++ b/angular_analyzer_plugin/lib/src/navigation.dart
@@ -88,6 +88,10 @@ class AngularNavigation implements NavigationContributor {
       final offset = resolvedRange.range.offset;
       final element = resolvedRange.element;
 
+      if (element.nameOffset == null) {
+        continue;
+      }
+
       final lineInfo = element.compilationElement?.lineInfo ??
           new LineInfo.fromContent(element.source.contents.data);
 

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -169,10 +169,27 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
     'tabIndex': 'tabindex',
   };
 
+  static const missingOutputs = const {
+    'focusin': 'FocusEvent',
+    'focusout': 'FocusEvent',
+  };
+
   ClassElement classElement;
 
   BuildStandardHtmlComponentsVisitor(this.components, this.events,
       this.attributes, this.source, this.securitySchema);
+
+  @override
+  void visitCompilationUnit(ast.CompilationUnit unit) {
+    super.visitCompilationUnit(unit);
+
+    missingOutputs.forEach((name, type) {
+      final namespace = unit.element.library.publicNamespace;
+      final ClassElement eventClass = namespace.get(type);
+      events[name] = new OutputElement(
+          name, null, null, unit.element.source, null, null, eventClass.type);
+    });
+  }
 
   @override
   void visitClassDeclaration(ast.ClassDeclaration node) {

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -227,7 +227,7 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
       expect(outputElement, isNotNull);
       expect(outputElement.getter, isNotNull);
       expect(outputElement.eventType, isNotNull);
-      expect(outputElement.eventType.toString(), equals('MouseEvent'));
+      expect(outputElement.eventType.toString(), 'MouseEvent');
     }
     {
       final outputElement = outputElements['change'];
@@ -250,14 +250,14 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
       final outputElement = outputElements['focusin'];
       expect(outputElement, isNotNull);
       expect(outputElement.eventType, isNotNull);
-      expect(outputElement.eventType.toString(), equals('FocusEvent'));
+      expect(outputElement.eventType.toString(), 'FocusEvent');
     }
     {
       // missing from dart:html, and supplied manually (with no getter)
       final outputElement = outputElements['focusout'];
       expect(outputElement, isNotNull);
       expect(outputElement.eventType, isNotNull);
-      expect(outputElement.eventType.toString(), equals('FocusEvent'));
+      expect(outputElement.eventType.toString(), 'FocusEvent');
     }
   }
 

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -245,6 +245,20 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
       final outputElement = outputElements['dden'];
       expect(outputElement, isNull);
     }
+    {
+      // missing from dart:html, and supplied manually (with no getter)
+      final outputElement = outputElements['focusin'];
+      expect(outputElement, isNotNull);
+      expect(outputElement.eventType, isNotNull);
+      expect(outputElement.eventType.toString(), equals('FocusEvent'));
+    }
+    {
+      // missing from dart:html, and supplied manually (with no getter)
+      final outputElement = outputElements['focusout'];
+      expect(outputElement, isNotNull);
+      expect(outputElement.eventType, isNotNull);
+      expect(outputElement.eventType.toString(), equals('FocusEvent'));
+    }
   }
 
   // ignore: non_constant_identifier_names

--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -317,6 +317,7 @@ import 'dart:async';
 
 class Event {}
 class MouseEvent extends Event {}
+class FocusEvent extends Event {}
 class KeyEvent extends Event {}
 
 class DomName {

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -356,6 +356,27 @@ class TestComponent {
     expect(regions, hasLength(1));
   }
 
+  // ignore: non_constant_identifier_names
+  Future test_navigateOnfocusin() async {
+    code = r'''
+import 'package:angular/src/core/metadata.dart';
+
+@Component(selector: 'test-comp', template: '<div (focusin)=""></div>')
+class TestComponent {
+}
+''';
+    final source = newSource('/test.dart', code);
+    // compute navigation regions
+    final result = await resolveDart(source);
+    new AngularNavigation().computeNavigation(
+        new AngularNavigationRequest(
+            null, 'focusin'.length, code.indexOf('focusin'), result),
+        collector,
+        templatesOnly: false);
+
+    expect(regions, hasLength(0));
+  }
+
   void _findRegion(int offset, int length) {
     for (final region in regions) {
       if (region.offset == offset && region.length == length) {


### PR DESCRIPTION
It's not a part of dart:html, but it works inside angular by binding to
events by name. Find its event type (FocusEvent) manually, after
performing the usual standard html resolution.

Since it doesn't have a getter, it doesn't have a range. Test that
navigation won't crash.