### PR TITLE
Fix failures in focusin/out support that were missed due to solo_tests

### DIFF
--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -1167,8 +1167,10 @@ class TemplateCompleter {
 
   Element _createOutputElement(OutputElement outputElement, ElementKind kind) {
     final name = '(${ outputElement.name})';
+    // Note: We use `?? 0` below because focusin/out don't have ranges but we
+    // still want to suggest them.
     final location = new Location(outputElement.source.fullName,
-        outputElement.nameOffset, outputElement.nameLength, 0, 0);
+        outputElement.nameOffset ?? 0, outputElement.nameLength ?? 0, 0, 0);
     final flags = Element.makeFlags();
     return new Element(kind, name, flags,
         location: location, returnType: outputElement.eventType.toString());

--- a/angular_analyzer_plugin/lib/src/model.dart
+++ b/angular_analyzer_plugin/lib/src/model.dart
@@ -231,7 +231,7 @@ class AngularElementImpl implements AngularElement {
 
   @override
   int get hashCode => JenkinsSmiHash.hash4(
-      name.hashCode, nameOffset, nameLength, source.hashCode);
+      name.hashCode, nameOffset ?? -1, nameLength ?? -1, source.hashCode);
 
   @override
   bool operator ==(Object other) =>


### PR DESCRIPTION
I forgot to rebase #482 on top of #483 before merging, where the latter
removed solo_tests that were suppressing some test failures. This means
that I missed some test failures in #482.