### PR TITLE
Allow custom events with custom types to be specified.

### DIFF
--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -49,8 +49,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
     if (optionsFilePath != null && optionsFilePath.isNotEmpty) {
       final file = resourceProvider.getFile(optionsFilePath);
       if (file.exists) {
-        final contents = file.readAsStringSync();
-        return new AngularOptions.from(contents);
+        return new AngularOptions.from(file.createSource());
       }
     }
     return new AngularOptions.defaults();

--- a/angular_analyzer_plugin/lib/src/file_tracker.dart
+++ b/angular_analyzer_plugin/lib/src/file_tracker.dart
@@ -101,6 +101,7 @@ class FileTracker {
     // Note, options which affect ng-content extraction should not be hashed
     // here. Those should be hashed into ContentSignature.
     addTags(signature);
+    addCustomEvents(signature);
 
     return signature;
   }
@@ -119,6 +120,7 @@ class FileTracker {
     // Note, options which affect directive/view extraction should not be hashed
     // here. Those should probably be hashed into ElementSignature.
     addTags(signature);
+    addCustomEvents(signature);
 
     return signature;
   }
@@ -129,6 +131,16 @@ class FileTracker {
   void addTags(ApiSignature signature) {
     for (final tagname in _options.customTagNames) {
       signature.addString('t:$tagname');
+    }
+  }
+
+  /// Add tag names to the signature. Note: in the future when there are more
+  /// lists of strings in options to add, we must be careful that they are
+  /// properly delimited/differentiated!
+  void addCustomEvents(ApiSignature signature) {
+    final hashString = _options.customEventsHashString;
+    if (hashString != null && hashString.isNotEmpty) {
+      signature.addString(hashString);
     }
   }
 

--- a/angular_analyzer_plugin/lib/src/options.dart
+++ b/angular_analyzer_plugin/lib/src/options.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:yaml/yaml.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/generated/source.dart';
@@ -6,9 +7,13 @@ class AngularOptions {
   AngularOptions({this.customTagNames, this.customEvents, this.source});
   factory AngularOptions.from(Source source) =>
       new _OptionsBuilder(null, source).build();
+  factory AngularOptions.defaults() => new _OptionsBuilder.empty().build();
+
+  /// For tests, its easier to pass the Source's contents directly rather than
+  /// creating mocks that returned mocked data that mocked contents.
+  @visibleForTesting
   factory AngularOptions.fromString(String content, Source source) =>
       new _OptionsBuilder(content, source).build();
-  factory AngularOptions.defaults() => new _OptionsBuilder.empty().build();
 
   final List<String> customTagNames;
   final Map<String, CustomEvent> customEvents;

--- a/angular_analyzer_plugin/lib/src/options.dart
+++ b/angular_analyzer_plugin/lib/src/options.dart
@@ -1,12 +1,60 @@
 import 'package:yaml/yaml.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/src/generated/source.dart';
 
 class AngularOptions {
-  AngularOptions({this.customTagNames});
-  factory AngularOptions.from(String contents) =>
-      new _OptionsBuilder(contents).build();
+  AngularOptions({this.customTagNames, this.customEvents, this.source});
+  factory AngularOptions.from(Source source) =>
+      new _OptionsBuilder(null, source).build();
+  factory AngularOptions.fromString(String content, Source source) =>
+      new _OptionsBuilder(content, source).build();
   factory AngularOptions.defaults() => new _OptionsBuilder.empty().build();
 
   final List<String> customTagNames;
+  final Map<String, CustomEvent> customEvents;
+  final Source source;
+
+  /// A unique signature based on the events for hashing the settings into the
+  /// resolution hashes.
+  String get customEventsHashString =>
+      _customEventsHashString ??= _computeCustomEventsHashString();
+  String _customEventsHashString;
+
+  /// When events are present, generate a string in the form of
+  /// 'e:name,type,path,name,type,path'. Take care we sort before emitting. And
+  /// in theory we could/should escape colon and comma, but the only one of
+  /// those that should appear in a valid config is the colon in 'package:',
+  /// and due to its position between the fixed placement of commas, it should
+  /// not be able to make one signature look like another.
+  String _computeCustomEventsHashString() {
+    if (customEvents.isEmpty) {
+      return '';
+    }
+
+    final buffer = new StringBuffer()..write('e:');
+    for (final key in customEvents.keys.toList()..sort()) {
+      final event = customEvents[key];
+      buffer
+        ..write(event.name ?? '')
+        ..write(',')
+        ..write(event.typeName ?? '')
+        ..write(',')
+        ..write(event.typePath ?? '')
+        ..write(',');
+    }
+    return buffer.toString();
+  }
+}
+
+class CustomEvent {
+  final String name;
+  final String typeName;
+  final String typePath;
+  final int nameOffset;
+
+  CustomEvent(this.name, this.typeName, this.typePath, this.nameOffset);
+
+  DartType resolvedType;
 }
 
 class _OptionsBuilder {
@@ -15,17 +63,32 @@ class _OptionsBuilder {
   dynamic angularPluginOptions;
 
   List<String> customTagNames = const [];
+  Map<String, CustomEvent> customEvents = {};
+  final Source source;
 
-  _OptionsBuilder.empty();
-  _OptionsBuilder(String contents) : analysisOptions = loadYaml(contents) {
+  _OptionsBuilder.empty() : source = null;
+  _OptionsBuilder(String content, Source source)
+      : source = source,
+        analysisOptions = loadYaml(content ?? source.contents.data) {
     load();
   }
 
   void resolve() {
     customTagNames = getOption('custom_tag_names', isListOfStrings) ?? [];
+    getOption('custom_events', isMapOfObjects)
+        ?.nodes
+        ?.forEach((nameNode, props) {
+      final name = (nameNode as YamlScalar).value as String;
+      final offset = nameNode.span.start.offset;
+      customEvents[nameNode.value] = props is YamlMap
+          ? new CustomEvent(name, props['type'], props['path'], offset)
+          // Handle `event:` with no value, a shortcut for dynamic.
+          : new CustomEvent(name, null, null, offset);
+    });
   }
 
-  AngularOptions build() => new AngularOptions(customTagNames: customTagNames);
+  AngularOptions build() => new AngularOptions(
+      customTagNames: customTagNames, customEvents: customEvents);
 
   void load() {
     if (analysisOptions['analyzer'] == null ||
@@ -63,4 +126,8 @@ class _OptionsBuilder {
 
   bool isListOfStrings(values) =>
       values is List && values.every((value) => value is String);
+
+  bool isMapOfObjects(values) =>
+      values is YamlMap &&
+      values.values.every((value) => value is YamlMap || value == null);
 }

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -9,8 +9,12 @@ import 'package:angular_analyzer_plugin/src/selector.dart';
 
 class StandardHtml {
   final Map<String, Component> components;
-  final Map<String, OutputElement> events;
   final Map<String, InputElement> attributes;
+  final Map<String, OutputElement> standardEvents;
+  final Map<String, OutputElement> customEvents;
+
+  Map<String, OutputElement> get events =>
+      new Map<String, OutputElement>.from(standardEvents)..addAll(customEvents);
 
   final ClassElement elementClass;
   final ClassElement htmlElementClass;
@@ -20,8 +24,8 @@ class StandardHtml {
   /// This will provide a static source of unique [InputElement]s.
   final Set<InputElement> uniqueAttributeElements;
 
-  StandardHtml(this.components, this.events, this.attributes, this.elementClass,
-      this.htmlElementClass)
+  StandardHtml(this.components, this.attributes, this.standardEvents,
+      this.customEvents, this.elementClass, this.htmlElementClass)
       : uniqueAttributeElements = new Set.from(attributes.values);
 }
 

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -99,6 +99,21 @@ class AbstractAngularTest {
 
   GatheringErrorListener errorListener;
 
+  AngularOptions ngOptions = new AngularOptions(
+      customTagNames: [
+        'my-first-custom-tag',
+        'my-second-custom-tag'
+      ],
+      customEvents: {
+        'custom-event': new CustomEvent('custom-event', 'CustomEvent',
+            'package:test_package/custom_event.dart', 10)
+      },
+      source: () {
+        final mock = new MockSource();
+        when(mock.fullName).thenReturn('/analysis_options.yaml');
+        return mock;
+      }());
+
   // flags specific to handling multiple versions of angular which may differ,
   // but we still need to support.
   final bool includeQueryList;
@@ -123,8 +138,9 @@ class AbstractAngularTest {
 
     sdk = new MockSdk(resourceProvider: resourceProvider);
     final packageMap = <String, List<Folder>>{
-      "angular2": [resourceProvider.getFolder("/angular2")],
-      "angular": [resourceProvider.getFolder("/angular")]
+      'angular2': [resourceProvider.getFolder('/angular2')],
+      'angular': [resourceProvider.getFolder('/angular')],
+      'test_package': [resourceProvider.getFolder('/')],
     };
     final packageResolver =
         new PackageMapUriResolver(resourceProvider, packageMap);
@@ -145,15 +161,8 @@ class AbstractAngularTest {
         contextRoot,
         sf,
         new AnalysisOptionsImpl());
-    angularDriver = new AngularDriver(
-        new MockNotificationManager(),
-        dartDriver,
-        scheduler,
-        byteStore,
-        sf,
-        new FileContentOverlay(),
-        new AngularOptions(
-            customTagNames: ['my-first-custom-tag', 'my-second-custom-tag']));
+    angularDriver = new AngularDriver(new MockNotificationManager(), dartDriver,
+        scheduler, byteStore, sf, new FileContentOverlay(), ngOptions);
 
     errorListener = new GatheringErrorListener();
     _addAngularSources();
@@ -537,3 +546,5 @@ class GatheringErrorListener implements AnalysisErrorListener {
 }
 
 class MockNotificationManager extends Mock implements NotificationManager {}
+
+class MockSource extends Mock implements Source {}

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_ast/angular_ast.dart';
 import 'package:angular_analyzer_plugin/src/from_file_prefixed_error.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
+import 'package:angular_analyzer_plugin/src/options.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:angular_analyzer_plugin/errors.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
@@ -22,6 +23,7 @@ void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(AngularParseHtmlTest);
     defineReflectiveTests(BuildStandardHtmlComponentsTest);
+    defineReflectiveTests(BuildStandardHtmlTest);
     defineReflectiveTests(BuildStandardAngularTest);
     defineReflectiveTests(GatherAnnotationsTest);
     defineReflectiveTests(GatherAnnotationsOnFutureAngularTest);
@@ -296,6 +298,348 @@ class BuildStandardHtmlComponentsTest extends AbstractAngularTest {
     expect(stdhtml.elementClass.name, 'Element');
     expect(stdhtml.htmlElementClass, isNotNull);
     expect(stdhtml.htmlElementClass.name, 'HtmlElement');
+  }
+}
+
+@reflectiveTest
+class BuildStandardHtmlTest extends AbstractAngularTest {
+  @override
+  void setUp() {
+    // Don't perform setup before tests. Tests will run `super.setUp()`.
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_perform() async {
+    super.setUp();
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.events, isNotNull);
+    expect(html.standardEvents, isNotNull);
+    expect(html.customEvents, isNotNull);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_untyped() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        foo:
+        bar:
+''', null);
+
+    super.setUp();
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(2));
+    {
+      final event = html.customEvents['foo'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'dynamic');
+    }
+    {
+      final event = html.customEvents['bar'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'dynamic');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_coreTypes() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        strEventImplicitCore:
+          type: String
+        strEventExplicitCore:
+          type: String
+          path: 'dart:core'
+        boolEventImplicitCore:
+          type: bool
+        boolEventExplicitCore:
+          type: bool
+          path: 'dart:core'
+''', null);
+
+    super.setUp();
+
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(4));
+    {
+      final event = html.customEvents['strEventImplicitCore'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'String');
+      expect(
+          event.eventType.element.source.fullName, '/sdk/lib/core/core.dart');
+    }
+    {
+      final event = html.customEvents['strEventExplicitCore'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'String');
+      expect(
+          event.eventType.element.source.fullName, '/sdk/lib/core/core.dart');
+    }
+    {
+      final event = html.customEvents['boolEventImplicitCore'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'bool');
+      expect(
+          event.eventType.element.source.fullName, '/sdk/lib/core/core.dart');
+    }
+    {
+      final event = html.customEvents['boolEventExplicitCore'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'bool');
+      expect(
+          event.eventType.element.source.fullName, '/sdk/lib/core/core.dart');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_noSource_dynamic() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        noSuchSource:
+          typePath: nonexist.dart
+''', null);
+
+    super.setUp();
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['noSuchSource'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'dynamic');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_noSuchIdentifier_dynamic() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        noSuchIdentifier:
+          type: NonExistEvent
+          path: 'package:test_package/customevent.dart'
+''', null);
+
+    super.setUp();
+
+    newSource('/customevent.dart', r'''
+class NotTheCorrectEvent {}
+''');
+
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['noSuchIdentifier'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'dynamic');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_typeIsNotAType_dynamic() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        notAType:
+          type: foo
+          path: 'package:test_package/customevent.dart'
+''', null);
+
+    super.setUp();
+
+    newSource('/customevent.dart', r'''
+int foo;
+''');
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['notAType'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'dynamic');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_resolved() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        bar:
+          type: BarEvent
+          path: 'package:test_package/bar.dart'
+''', null);
+
+    super.setUp();
+
+    newSource('/bar.dart', r'''
+class BarEvent {}
+''');
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['bar'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'BarEvent');
+      expect(event.eventType.element.source.fullName, '/bar.dart');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_enum() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        enumType:
+          type: EnumType
+          path: 'package:test_package/enum.dart'
+''', null);
+
+    super.setUp();
+
+    newSource('/enum.dart', r'''
+enum EnumType {}
+''');
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['enumType'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'EnumType');
+      expect(event.eventType.element.source.fullName, '/enum.dart');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_typedef() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        typedef:
+          type: TypeDef
+          path: 'package:test_package/typedef.dart'
+''', null);
+
+    super.setUp();
+
+    newSource('/typedef.dart', r'''
+typedef TypeDef = int Function<T>();
+''');
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['typedef'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), '() → int');
+      expect(event.eventType.element.source.fullName, '/typedef.dart');
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_customEvents_generic() async {
+    ngOptions = new AngularOptions.fromString(r'''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        generic:
+          type: Generic
+          path: 'package:test_package/generic.dart'
+''', null);
+
+    super.setUp();
+
+    newSource('/generic.dart', r'''
+class Generic<T> {}
+''');
+    final html = await angularDriver.getStandardHtml();
+    // validate
+    expect(html, isNotNull);
+    expect(html.customEvents, isNotNull);
+    expect(html.customEvents, hasLength(1));
+    {
+      final event = html.customEvents['generic'];
+      expect(event, isNotNull);
+      expect(event.getter, isNull);
+      expect(event.eventType, isNotNull);
+      expect(event.eventType.toString(), 'Generic<Object>');
+      expect(event.eventType.element.source.fullName, '/generic.dart');
+    }
   }
 }
 

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -637,7 +637,7 @@ class Generic<T> {}
       expect(event, isNotNull);
       expect(event.getter, isNull);
       expect(event.eventType, isNotNull);
-      expect(event.eventType.toString(), 'Generic<Object>');
+      expect(event.eventType.toString(), 'Generic<dynamic>');
       expect(event.eventType.element.source.fullName, '/generic.dart');
     }
   }

--- a/angular_analyzer_plugin/test/file_tracker_test.dart
+++ b/angular_analyzer_plugin/test/file_tracker_test.dart
@@ -289,6 +289,7 @@ class FileTrackerTest {
     when(_fileHasher.getContentHash("bar.html")).thenReturn(barHtmlSignature);
     when(_fileHasher.getUnitElementHash("foo.dart"))
         .thenReturn(fooDartElementSignature);
+    when(_options.customEventsHashString).thenReturn('');
 
     final expectedSignature = new ApiSignature()
       ..addInt(FileTracker.salt)
@@ -318,6 +319,7 @@ class FileTrackerTest {
         .thenReturn(fooDartElementSignature);
     when(_fileHasher.getUnitElementHash("foo_test.dart"))
         .thenReturn(fooTestDartElementSignature);
+    when(_options.customEventsHashString).thenReturn('');
 
     final expectedSignature = new ApiSignature()
       ..addInt(FileTracker.salt)
@@ -378,6 +380,8 @@ class FileTrackerTest {
     final fooDartElementSignature = new ApiSignature()..addInt(1);
     when(_fileHasher.getUnitElementHash("foo.dart"))
         .thenReturn(fooDartElementSignature);
+    when(_options.customTagNames).thenReturn(['foo', 'bar']);
+    when(_options.customEventsHashString).thenReturn('');
 
     final expectedSignature = new ApiSignature()
       ..addInt(FileTracker.salt)
@@ -385,14 +389,12 @@ class FileTrackerTest {
       ..addString('t:foo')
       ..addString('t:bar');
 
-    when(_options.customTagNames).thenReturn(['foo', 'bar']);
-
     expect(_fileTracker.getDartSignature("foo.dart").toHex(),
         equals(expectedSignature.toHex()));
   }
 
   // ignore: non_constant_identifier_names
-  void test_htmlSignature_includesCustomTagNames() {
+  void test_htmlSignature_includesCustomEvents() {
     _fileTracker.setDartHtmlTemplates("foo.dart", ["foo.html"]);
 
     final fooHtmlSignature = new ApiSignature()..addInt(1);
@@ -406,10 +408,9 @@ class FileTrackerTest {
       ..addInt(FileTracker.salt)
       ..addBytes(fooHtmlSignature.toByteList())
       ..addBytes(fooDartElementSignature.toByteList())
-      ..addString('t:foo')
-      ..addString('t:bar');
+      ..addString(r'$customEvents');
 
-    when(_options.customTagNames).thenReturn(['foo', 'bar']);
+    when(_options.customEventsHashString).thenReturn(r'$customEvents');
 
     expect(_fileTracker.getHtmlSignature("foo.html").toHex(),
         equals(expectedSignature.toHex()));

--- a/angular_analyzer_plugin/test/options_test.dart
+++ b/angular_analyzer_plugin/test/options_test.dart
@@ -26,19 +26,21 @@ class AngularOptionsTest {
 
   // ignore: non_constant_identifier_names
   void test_buildYaml_defaults() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
       enabled: true
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, isEmpty);
+    expect(options.customEvents, isNotNull);
+    expect(options.customEvents, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
   void test_buildYaml_simple_tags() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
@@ -47,14 +49,84 @@ analyzer:
         - foo
         - bar
         - baz
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
+  void test_buildYaml_dynamic_events() {
+    final code = '''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        foo:
+          type: String
+        bar:
+          type: BarEvent
+          path: 'package:foo/bar/baz.dart'
+        empty:
+
+''';
+    final options = new AngularOptions.fromString(code, null);
+    expect(options.customEvents, isNotNull);
+    expect(options.customEvents, hasLength(3));
+
+    {
+      final event = options.customEvents['foo'];
+      expect(event, isNotNull);
+      expect(event.name, 'foo');
+      expect(event.typeName, 'String');
+      expect(event.typePath, isNull);
+      expect(event.nameOffset, code.indexOf('foo'));
+    }
+
+    {
+      final event = options.customEvents['bar'];
+      expect(event, isNotNull);
+      expect(event.name, 'bar');
+      expect(event.typeName, 'BarEvent');
+      expect(event.typePath, 'package:foo/bar/baz.dart');
+      expect(event.nameOffset, code.indexOf('bar'));
+    }
+
+    {
+      final event = options.customEvents['empty'];
+      expect(event, isNotNull);
+      expect(event.name, 'empty');
+      expect(event.typeName, null);
+      expect(event.typePath, null);
+      expect(event.nameOffset, code.indexOf('empty'));
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  void test_buildYaml_events_hashString() {
+    final code = '''
+analyzer:
+  plugins:
+    angular:
+      enabled: true
+      custom_events:
+        foo:
+          type: String
+        bar:
+          type: BarEvent
+          path: 'package:foo/bar/baz.dart'
+        empty:
+
+''';
+    final options = new AngularOptions.fromString(code, null);
+    expect(options.customEvents, isNotNull);
+    expect(options.customEventsHashString,
+        'e:bar,BarEvent,package:foo/bar/baz.dart,empty,,,foo,String,,');
+  }
+
+  // ignore: non_constant_identifier_names
   void test_buildYaml_ignoresUnrelatedPlugin() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     craaangularrrrrk:
@@ -64,14 +136,14 @@ analyzer:
         - bar
         - baz
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
   void test_buildYaml_selfLoading() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular_analyzer_plugin:
@@ -81,14 +153,14 @@ analyzer:
         - bar
         - baz
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
 
   // ignore: non_constant_identifier_names
   void test_buildYaml_selfLoadingIgnoredIfNotEnabled() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
@@ -101,14 +173,14 @@ analyzer:
         - bar
         - baz
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
   void test_buildYaml_angularIgnoredIfNotEnabled() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
@@ -121,14 +193,14 @@ analyzer:
     angular_analyzer_plugin:
       enabled: true
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, isEmpty);
   }
 
   // ignore: non_constant_identifier_names
   void test_buildYaml_angularAndSelfLoadingMerged() {
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
@@ -141,7 +213,7 @@ analyzer:
         - bar
         - baz
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, equals(['foo', 'bar', 'baz']));
   }
@@ -151,7 +223,7 @@ analyzer:
     // TODO(mfairhurst) this should be an error/warning.
     // However, not critical.
     // For now, let's at least test this so it doesn't change willy-nilly.
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
@@ -168,7 +240,7 @@ analyzer:
         - should-not-appear
         - this-is-good
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames,
         equals(['tags-from-angular', 'should-appear', 'this-is-good']));
@@ -179,13 +251,13 @@ analyzer:
     // TODO(mfairhurst) this should be an error/warning.
     // However, the most important thing is that we don't propagate the mangled
     // values which can cause later crashes.
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
       enabled: true
       custom_tag_names: true
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, const isInstanceOf<List>());
     expect(options.customTagNames, isEmpty);
@@ -196,7 +268,7 @@ analyzer:
     // TODO(mfairhurst) this should be an error/warning.
     // However, not critical.
     // For now, let's at least test this so it doesn't change willy-nilly.
-    final options = new AngularOptions.from('''
+    final options = new AngularOptions.fromString('''
 analyzer:
   plugins:
     angular:
@@ -209,7 +281,7 @@ analyzer:
         - should-appear
         - this-is-good
 
-''');
+''', null);
     expect(options.customTagNames, isNotNull);
     expect(options.customTagNames, equals(['should-appear', 'this-is-good']));
   }

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -5233,6 +5233,51 @@ class TestPanel {
     ]);
   }
 
+  // ignore: non_constant_identifier_names
+  Future test_resolveTemplate_customEvent_valid() async {
+    newSource('/custom-event.dart', r'''
+class CustomEvent {
+  int foo;
+}
+''');
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html',
+    directives: const [])
+class TestPanel {
+  void acceptInt(int x) {}
+}
+''');
+    final code = r"""
+<div (custom-event)="acceptInt($event.foo)">
+</div>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_resolveTemplate_customEvent_invalid() async {
+    newSource('/custom_event.dart', r'''
+class CustomEvent {}
+''');
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html',
+    directives: const [])
+class TestPanel {
+  void acceptInt(int x) {}
+}
+''');
+    final code = r"""
+<div (custom-event)="acceptInt($event)">
+</div>
+    """;
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE, code, r'$event');
+  }
+
   void _addDartSource(final code) {
     dartCode = '''
 import 'package:angular2/angular2.dart';


### PR DESCRIPTION
```
analyzer:
  plugins:
    angular:
      enabled: true
      custom_events:
        doodle:
          type: DoodleEvent
          path: 'package:doodle/events.dart'
        poodle:
          type: PoodleEvent
          path: 'package:doodle/events.dart'
```

These don't yet correlate to tags, that could be next up, either
allowing a tag name in the custom_events section, or allowing
custom_events within a tag section, or both.

Still haven't fully decoupled [Options] from [FileTracker], but at
least the new hashes are *less* coupled, and I have some ideas to go
the rest of the way cleanly.

Gather the custom events inside the driver, and make it look like a
part of standard html. Track the source of the options file and the
name offsets of the custom events so that it they be supplied during
completion etc.

Currently doesn't re-resolve the custom event type. We'll see how many
people need it to react to change. I have a feeling that won't be
important, since this is mostly used for polymer users, where polymer
won't be under active development any more.

Also no errors reported yet for misconfigured analysis options. That
has to be a new pipeline unfortunately.