### PR TITLE
After syncing SDK_AT_HEAD, it needs an update to angular_ast version.

### DIFF
--- a/deps/pubspec.yaml
+++ b/deps/pubspec.yaml
@@ -3,10 +3,7 @@ version: 0.0.0
 description: What we need that the sdk doesn't provide
 dependencies:
   tuple: '^1.0.1'
-  angular_ast:
-    git:
-      url: https://github.com/dart-lang/angular_ast
-      ref: master
+  angular_ast: '^0.4.2'
 dev_dependencies:
   test_reflective_loader: '^0.1.0'
   typed_mock: '^0.0.4'


### PR DESCRIPTION
After syncing SDK_AT_HEAD, it needs an update to angular_ast version.

The master branch uses the package pubspec.yaml, and, after an upgrade of angular_ast, had to change an expectation.

That new expectation is now in SDK_AT_HEAD, but, in order to get the SDK at HEAD, it ignores that pubspec yaml in favor of this specialized one which wasn't updated and therefore its getting a version of angular_ast that fails that test which was changed before.