### PR TITLE
Correctness/Performance fix: Use FileContentOverlay in navigation

### DIFF
--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -140,7 +140,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
   /// analysis [driver].
   @override
   List<NavigationContributor> getNavigationContributors(String path) =>
-      [new AngularNavigation()];
+      [new AngularNavigation(angularDriverForPath(path).contentOverlay)];
 
   void sendNotificationForSubscription(
       String fileName, plugin.AnalysisService service, AnalysisResult result) {

--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -110,7 +110,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
       return;
     }
 
-    new AngularNavigation()
+    new AngularNavigation(driver.contentOverlay)
       ..computeNavigation(
           new AngularNavigationRequest(filename, null, null, result),
           collector);

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -40,7 +40,7 @@ class AngularDriver
   final NotificationManager notificationManager;
   final AnalysisDriverScheduler _scheduler;
   final AnalysisDriver dartDriver;
-  final FileContentOverlay _contentOverlay;
+  final FileContentOverlay contentOverlay;
   final AngularOptions options;
   StandardHtml standardHtml;
   StandardAngular standardAngular;
@@ -65,7 +65,7 @@ class AngularDriver
       this._scheduler,
       this.byteStore,
       SourceFactory sourceFactory,
-      this._contentOverlay,
+      this.contentOverlay,
       this.options) {
     _sourceFactory = sourceFactory.clone();
     _scheduler.add(this);
@@ -430,7 +430,7 @@ class AngularDriver
   }
 
   String getFileContent(String path) =>
-      _contentOverlay[path] ??
+      contentOverlay[path] ??
       ((source) =>
           source.exists() ? source.contents.data : "")(getSource(path));
 

--- a/angular_analyzer_plugin/lib/src/navigation.dart
+++ b/angular_analyzer_plugin/lib/src/navigation.dart
@@ -6,8 +6,13 @@ import 'package:analyzer/dart/element/element.dart' as engine;
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/navigation_request.dart';
+import 'package:analyzer/src/dart/analysis/file_state.dart';
 
 class AngularNavigation implements NavigationContributor {
+  final FileContentOverlay _contentOverlay;
+
+  AngularNavigation(this._contentOverlay);
+
   @override
   void computeNavigation(
       NavigationRequest baseRequest, NavigationCollector collector,
@@ -93,7 +98,8 @@ class AngularNavigation implements NavigationContributor {
       }
 
       final lineInfo = element.compilationElement?.lineInfo ??
-          new LineInfo.fromContent(element.source.contents.data);
+          new LineInfo.fromContent(
+              _contentOverlay[element.source.fullName] ?? "");
 
       if (lineInfo == null) {
         continue;

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -95,7 +95,7 @@ class User {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(null, null, null, result), collector,
         templatesOnly: false);
     // input references setter
@@ -161,7 +161,7 @@ class TextPanel {}
     final dartSource = newSource('/test.dart', code);
     newSource('/text_panel.html', "");
     final result = await resolveDart(dartSource);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(null, null, null, result), collector,
         templatesOnly: false);
     // input references setter
@@ -191,7 +191,7 @@ class TextPanel {
     final dartSource = newSource('/test.dart', dartCode);
     newSource('/text_panel.html', htmlCode);
     final result = await resolveLinkedHtml(dartSource);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(null, null, null, result), collector,
         templatesOnly: false);
     // template references field
@@ -218,7 +218,7 @@ class TestComponent {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(
             null, 'fieldOne'.length, code.indexOf('fieldOne}}'), result),
         collector,
@@ -246,7 +246,7 @@ class TestComponent {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(
             null, '}}{{'.length, code.indexOf('}}{{'), result),
         collector,
@@ -269,7 +269,7 @@ class TestComponent {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(
             null, 'e}}{{f'.length, code.indexOf('e}}{{f'), result),
         collector,
@@ -305,7 +305,7 @@ class TestComponent {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(null, 'fieldOne}}{{fieldTwo'.length,
             code.indexOf('fieldOne}}{{fieldTwo'), result),
         collector,
@@ -341,7 +341,7 @@ class TestComponent {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(
             null, ' {{fieldOne}} '.length, code.indexOf(' {{'), result),
         collector,
@@ -368,7 +368,7 @@ class TestComponent {
     final source = newSource('/test.dart', code);
     // compute navigation regions
     final result = await resolveDart(source);
-    new AngularNavigation().computeNavigation(
+    new AngularNavigation(angularDriver.contentOverlay).computeNavigation(
         new AngularNavigationRequest(
             null, 'focusin'.length, code.indexOf('focusin'), result),
         collector,


### PR DESCRIPTION
This is a big performance regression in IntelliJ when inside HTML (where
content info isn't as nicely cached for us by the driver). Before
serving completions, for instance, the navigation would be reading in
large files and computing their line infos which was like 90%+ of CPU
time.

By sharing the overlay, navigation is now 0.16% of CPU time and
completions are much snappier.