### PR TITLE
Change NgContentRecorder to operate on AngularAst.

### DIFF
--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -96,6 +96,12 @@ class AngularWarningCode extends ErrorCode {
   static const ARGUMENT_SELECTOR_MISSING = const AngularWarningCode(
       'ARGUMENT_SELECTOR_MISSING', 'Argument "selector" missing');
 
+  /// An error code indicating that an ng-content tag's selector attribute does
+  /// not actually contain a selector.
+  static const SELECTOR_ATTRIBUTE_VALUE_MISSING = const AngularWarningCode(
+      'SELECTOR_ATTRIBUTE_VALUE_MISSING',
+      'This selector attribute must be deleted or have a value specified');
+
   /// An error code indicating that the provided selector cannot be parsed.
   static const CANNOT_PARSE_SELECTOR = const AngularWarningCode(
       'CANNOT_PARSE_SELECTOR', 'Cannot parse the given selector ({0})');

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -563,7 +563,8 @@ class AngularDriver
           template.ast =
               new HtmlTreeConverter(parser, htmlSource, tplErrorListener)
                   .convertFromAstList(tplParser.rawAst);
-          template.ast.accept(new NgContentRecorder(directive, errorReporter));
+          new NgContentRecorder(directive, errorReporter)
+              .visitAll(tplParser.rawAst);
           setIgnoredErrors(template, document);
           new TemplateResolver(
                   context.typeProvider,
@@ -627,7 +628,8 @@ class AngularDriver
     final ast = new HtmlTreeConverter(parser, source, tplErrorListener)
         .convertFromAstList(tplParser.rawAst);
     final contents = <NgContent>[];
-    ast.accept(new NgContentRecorder.forFile(contents, source, errorReporter));
+    new NgContentRecorder.forFile(contents, source, errorReporter)
+        .visitAll(tplParser.rawAst);
 
     final summary = new UnlinkedHtmlSummaryBuilder()
       ..ngContents = serializeNgContents(contents);
@@ -747,7 +749,8 @@ class AngularDriver
 
           template.ast = new HtmlTreeConverter(parser, source, tplErrorListener)
               .convertFromAstList(tplParser.rawAst);
-          template.ast.accept(new NgContentRecorder(directive, errorReporter));
+          new NgContentRecorder(directive, errorReporter)
+              .visitAll(tplParser.rawAst);
           setIgnoredErrors(template, document);
           new TemplateResolver(
                   context.typeProvider,
@@ -896,7 +899,8 @@ class AngularDriver
 
           template.ast = new HtmlTreeConverter(parser, source, tplErrorListener)
               .convertFromAstList(tplParser.rawAst);
-          template.ast.accept(new NgContentRecorder(directive, errorReporter));
+          new NgContentRecorder(directive, errorReporter)
+              .visitAll(tplParser.rawAst);
         }
       }
     }

--- a/angular_analyzer_plugin/lib/src/model.dart
+++ b/angular_analyzer_plugin/lib/src/model.dart
@@ -13,6 +13,7 @@ import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:angular_analyzer_plugin/src/standard_components.dart';
 import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/errors.dart';
+import 'package:angular_ast/angular_ast.dart';
 
 /// Might be a directive, or a component, or neither. It might simply have
 /// annotated @Inputs, @Outputs() intended to be inherited.

--- a/angular_analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   html: '^0.13.1'
   tuple: '^1.0.1'
   analyzer_plugin: '0.0.1-alpha.0'
-  angular_ast: '0.4.2'
+  angular_ast: '0.4.5'
   meta: ^1.0.2
   yaml: ^2.1.2
   crypto: '>=1.1.1 <3.0.0'

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -3491,7 +3491,7 @@ class TestPanel {
     await _resolveSingleTemplate(dartSource);
     expect(template.view.component.ngContents, hasLength(0));
     assertErrorInCodeAtPosition(
-        AngularWarningCode.CANNOT_PARSE_SELECTOR, code, "\"\"");
+        AngularWarningCode.SELECTOR_ATTRIBUTE_VALUE_MISSING, code, "\"\"");
   }
 
   // ignore: non_constant_identifier_names
@@ -3510,7 +3510,7 @@ class TestPanel {
     await _resolveSingleTemplate(dartSource);
     expect(template.view.component.ngContents, hasLength(0));
     assertErrorInCodeAtPosition(
-        AngularWarningCode.CANNOT_PARSE_SELECTOR, code, "select");
+        AngularWarningCode.SELECTOR_ATTRIBUTE_VALUE_MISSING, code, "select");
   }
 
   // ignore: non_constant_identifier_names


### PR DESCRIPTION
Started moving some of the visitors over to use AngularAst.

This was fairly difficult, giving me the impression that it may be easier, as a prototype, to copy angular_ast into my ast, resolve it, and then copy it back into angular_ast again....

Depends upon usability improvements contributed upstream to angular_ast,
which are not yet published, so this build will fail for now.