### PR TITLE
Use results stream to send error notifications.

### DIFF
--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/context/context_root.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/context/builder.dart';
 import 'package:analyzer/src/dart/analysis/driver.dart';
+import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/dart/analysis/performance_logger.dart';
 import 'package:analyzer_plugin/plugin/plugin.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart' as plugin;
@@ -14,6 +15,7 @@ import 'package:analyzer_plugin/protocol/protocol_constants.dart' as plugin;
 import 'package:analyzer_plugin/protocol/protocol_generated.dart' as plugin;
 import 'package:analyzer_plugin/plugin/completion_mixin.dart';
 import 'package:analyzer_plugin/plugin/navigation_mixin.dart';
+import 'package:analyzer_plugin/utilities/analyzer_converter.dart';
 import 'package:analyzer_plugin/utilities/completion/completion_core.dart';
 import 'package:analyzer_plugin/utilities/navigation/navigation.dart';
 import 'package:analyzer_plugin/src/utilities/navigation/navigation.dart';
@@ -75,7 +77,8 @@ class AngularAnalyzerPlugin extends ServerPlugin
     final sourceFactory = dartDriver.sourceFactory;
 
     final driver = new AngularDriver(
-        new ChannelNotificationManager(channel),
+        // TODO(mfairhurst) remove NotificationManager & old plugin loader.
+        new NoopNotificationManager(),
         dartDriver,
         analysisDriverScheduler,
         byteStore,
@@ -92,9 +95,30 @@ class AngularAnalyzerPlugin extends ServerPlugin
 
   void onResult(DirectivesResult result, AngularDriver driver,
       {@required bool isHtml}) {
+    _handleResultErrors(result, driver);
+    _handleResultNavigation(result, driver, isHtml: isHtml);
+  }
+
+  /// Send notifications for errors for this result
+  void _handleResultErrors(DirectivesResult result, AngularDriver driver) {
+    final converter = new AnalyzerConverter();
+    final lineInfo =
+        new LineInfo.fromContent(driver.getFileContent(result.filename));
+    // TODO(mfairhurst) Get the right analysis options.
+    final errors = converter.convertAnalysisErrors(
+      result.errors,
+      lineInfo: lineInfo,
+    );
+    channel.sendNotification(
+        new plugin.AnalysisErrorsParams(result.filename, errors)
+            .toNotification());
+  }
+
+  /// Send notifications for navigation for this result
+  void _handleResultNavigation(DirectivesResult result, AngularDriver driver,
+      {@required bool isHtml}) {
     final collector = new NavigationCollectorImpl();
     final filename = result.filename;
-
     if (filename == null ||
         !subscriptionManager.hasSubscriptionForFile(
             filename, plugin.AnalysisService.NAVIGATION)) {

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -37,6 +37,7 @@ class AngularDriver
         FilePipeProvider,
         DirectiveLinkerEnablement,
         FileHasher {
+  // TODO(mfairhurst) remove NotificationManager & old plugin loader.
   final NotificationManager notificationManager;
   final AnalysisDriverScheduler _scheduler;
   final AnalysisDriver dartDriver;
@@ -640,6 +641,7 @@ class AngularDriver
   Future pushHtmlErrors(String htmlPath) async {
     final errors = (await resolveHtml(htmlPath)).errors;
     final lineInfo = new LineInfo.fromContent(getFileContent(htmlPath));
+    // TODO(mfairhurst) remove this with old plugin loader
     notificationManager.recordAnalysisErrors(htmlPath, lineInfo, errors);
   }
 
@@ -654,6 +656,7 @@ class AngularDriver
     }
     final errors = result.errors;
     final lineInfo = new LineInfo.fromContent(getFileContent(path));
+    // TODO(mfairhurst) remove this with old plugin loader
     notificationManager.recordAnalysisErrors(path, lineInfo, errors);
   }
 

--- a/angular_analyzer_plugin/lib/src/notification_manager.dart
+++ b/angular_analyzer_plugin/lib/src/notification_manager.dart
@@ -6,21 +6,11 @@ import 'package:analyzer_plugin/protocol/protocol_generated.dart' as plugin;
 import 'package:analyzer_plugin/utilities/analyzer_converter.dart';
 import 'package:angular_analyzer_plugin/notification_manager.dart';
 
-class ChannelNotificationManager implements NotificationManager {
-  final PluginCommunicationChannel channel;
-
-  ChannelNotificationManager(this.channel);
+// TODO(mfairhurst) remove NotificationManager & old plugin loader.
+class NoopNotificationManager implements NotificationManager {
+  NoopNotificationManager();
 
   @override
   void recordAnalysisErrors(
-      String path, LineInfo lineInfo, List<AnalysisError> analysisErrors) {
-    final converter = new AnalyzerConverter();
-    // TODO(mfairhurst) Get the right analysis options.
-    final errors = converter.convertAnalysisErrors(
-      analysisErrors,
-      lineInfo: lineInfo,
-    );
-    channel.sendNotification(
-        new plugin.AnalysisErrorsParams(path, errors).toNotification());
-  }
+      String path, LineInfo lineInfo, List<AnalysisError> analysisErrors) {}
 }


### PR DESCRIPTION
This is cleaner, and closer to the end goal state of only having one
loader architecture. It also solves a bug on windows, wherein
autocompletion fires before error resolution, which prefills the summary
but doesn't send errors over the notification manager (but does emit the
DirectivesResult over the stream). Then when error resolution comes in,
the angular driver thinks its getting a repeat result and it doesn't
bother resending errors.