### PR TITLE
Make AngularDriver less prone to race conditions with smaller API.

### DIFF
--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -65,7 +65,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
 
     final logger = new PerformanceLog(new StringBuffer());
     final builder = new ContextBuilder(resourceProvider, sdkManager, null)
-      ..analysisDriverScheduler = analysisDriverScheduler
+      ..analysisDriverScheduler = (new AnalysisDriverScheduler(logger)..start())
       ..byteStore = byteStore
       ..performanceLog = logger
       ..fileContentOverlay = fileContentOverlay;
@@ -129,8 +129,8 @@ class AngularAnalyzerPlugin extends ServerPlugin
       // get a non-cached result, so we have an AST.
       // TODO(mfairhurst) make this assurance in a less hacky way
       isHtml
-          ? driver.resolveHtml(filename, ignoreCache: true)
-          : driver.resolveDart(filename);
+          ? driver.requestHtmlResult(filename)
+          : driver.requestDartResult(filename);
       return;
     }
 
@@ -152,9 +152,8 @@ class AngularAnalyzerPlugin extends ServerPlugin
     final AngularDriver driver = driverForPath(parameters.file);
     final isHtml = parameters.file.endsWith('.html');
     final result = isHtml
-        ? await driver.resolveHtml(parameters.file, ignoreCache: true)
-        : await driver.resolveDart(parameters.file,
-            onlyIfChangedSignature: false);
+        ? await driver.requestHtmlResult(parameters.file)
+        : await driver.requestDartResult(parameters.file);
     return new AngularNavigationRequest(
         parameters.file, parameters.offset, parameters.length, result);
   }

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -264,7 +264,6 @@ class AngularDriver
       } catch (e, st) {
         completers.forEach((completer) => completer.completeError(e));
       }
-      ;
 
       return;
     }

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -150,7 +150,7 @@ class AbstractAngularTest {
     final contextRoot = new ContextRoot(testPath, []);
 
     dartDriver = new AnalysisDriver(
-        scheduler,
+        new AnalysisDriverScheduler(logger)..start(),
         logger,
         resourceProvider,
         byteStore,

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -3939,7 +3939,7 @@ class LinkDirectivesTest extends AbstractAngularTest {
   Future getDirectives(final source) async {
     final dartResult = await dartDriver.getResult(source.fullName);
     fillErrorListener(dartResult.errors);
-    final ngResult = await angularDriver.resolveDart(source.fullName);
+    final ngResult = await angularDriver.requestDartResult(source.fullName);
     directives = ngResult.directives;
     errors = ngResult.errors;
     fillErrorListener(errors);
@@ -4403,7 +4403,7 @@ class ResolveDartTemplatesTest extends AbstractAngularTest {
   Future getDirectives(final source) async {
     final dartResult = await dartDriver.getResult(source.fullName);
     fillErrorListener(dartResult.errors);
-    final ngResult = await angularDriver.resolveDart(source.fullName);
+    final ngResult = await angularDriver.requestDartResult(source.fullName);
     directives = ngResult.directives;
     errors = ngResult.errors;
     fillErrorListener(errors);
@@ -5199,10 +5199,10 @@ class ResolveHtmlTemplatesTest extends AbstractAngularTest {
   List<Template> templates;
   Future getDirectives(Source htmlSource, List<Source> dartSources) async {
     for (final dartSource in dartSources) {
-      final result = await angularDriver.resolveDart(dartSource.fullName);
+      final result = await angularDriver.requestDartResult(dartSource.fullName);
       fillErrorListener(result.errors);
     }
-    final result2 = await angularDriver.resolveHtml(htmlSource.fullName);
+    final result2 = await angularDriver.requestHtmlResult(htmlSource.fullName);
     fillErrorListener(result2.errors);
     templates = result2.directives
         .map((d) => d is Component ? d.view?.template : null)
@@ -5271,9 +5271,9 @@ class TextPanelB {
 class ResolveHtmlTemplateTest extends AbstractAngularTest {
   List<View> views;
   Future getDirectives(Source htmlSource, Source dartSource) async {
-    final result = await angularDriver.resolveDart(dartSource.fullName);
+    final result = await angularDriver.requestDartResult(dartSource.fullName);
     fillErrorListener(result.errors);
-    final result2 = await angularDriver.resolveHtml(htmlSource.fullName);
+    final result2 = await angularDriver.requestHtmlResult(htmlSource.fullName);
     fillErrorListener(result2.errors);
     views = result2.directives
         .map((d) => d is Component ? d.view : null)

--- a/angular_analyzer_plugin/test/completion_contributor_test_util.dart
+++ b/angular_analyzer_plugin/test/completion_contributor_test_util.dart
@@ -69,11 +69,11 @@ abstract class AbstractCompletionContributorTest
   /// Compute all the views declared in the given [dartSource], and resolve the
   /// external template of all the views.
   Future resolveSingleTemplate(Source dartSource) async {
-    final result = await angularDriver.resolveDart(dartSource.fullName);
+    final result = await angularDriver.requestDartResult(dartSource.fullName);
     for (var d in result.directives) {
       if (d is Component && d.view.templateUriSource != null) {
         final htmlPath = d.view.templateUriSource.fullName;
-        await angularDriver.resolveHtml(htmlPath);
+        await angularDriver.requestHtmlResult(htmlPath);
       }
     }
   }

--- a/angular_analyzer_plugin/test/fuzz_test.dart
+++ b/angular_analyzer_plugin/test/fuzz_test.dart
@@ -605,12 +605,12 @@ class CounterComponent {
       newSource('/test.dart', dart);
       newSource('/test.html', html);
       final resultFuture =
-          angularDriver.resolveDart('/test.dart').then((result) {
+          angularDriver.requestDartResult('/test.dart').then((result) {
         if (result.directives.isNotEmpty) {
           final directive = result.directives.first;
           if (directive is Component &&
               directive.view?.templateUriSource?.fullName == '/test.html') {
-            return angularDriver.resolveHtml('/test.html');
+            return angularDriver.requestHtmlResult('/test.html');
           }
         }
       });

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -28,11 +28,11 @@ class AngularNavigationTest extends AbstractAngularTest {
   /// Compute all the views declared in the given [dartSource], and resolve the
   /// external template of all the views.
   Future<DirectivesResult> resolveLinkedHtml(Source dartSource) async {
-    final result = await angularDriver.resolveDart(dartSource.fullName);
+    final result = await angularDriver.requestDartResult(dartSource.fullName);
     for (var d in result.directives) {
       if (d is Component && d.view.templateUriSource != null) {
         final htmlPath = d.view.templateUriSource.fullName;
-        return await angularDriver.resolveHtml(htmlPath);
+        return await angularDriver.requestHtmlResult(htmlPath);
       }
     }
 
@@ -42,7 +42,7 @@ class AngularNavigationTest extends AbstractAngularTest {
   /// Compute all the views declared in the given [dartSource], and return its
   /// result
   Future<DirectivesResult> resolveDart(Source dartSource) async =>
-      await angularDriver.resolveDart(dartSource.fullName);
+      await angularDriver.requestDartResult(dartSource.fullName);
 
   List<_RecordedNavigationRegion> regions = <_RecordedNavigationRegion>[];
   NavigationCollector collector = new NavigationCollectorMock();

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -5354,7 +5354,7 @@ $code
   /// Compute all the views declared in the given [dartSource], and resolve the
   /// external template of the last one.
   Future _resolveSingleTemplate(Source dartSource) async {
-    final result = await angularDriver.resolveDart(dartSource.fullName);
+    final result = await angularDriver.requestDartResult(dartSource.fullName);
     bool finder(AbstractDirective d) =>
         d is Component && d.view.templateUriSource != null;
     fillErrorListener(result.errors);
@@ -5362,7 +5362,7 @@ $code
     directives = result.directives;
     final directive = result.directives.singleWhere(finder);
     final htmlPath = (directive as Component).view.templateUriSource.fullName;
-    final result2 = await angularDriver.resolveHtml(htmlPath);
+    final result2 = await angularDriver.requestHtmlResult(htmlPath);
     fillErrorListener(result2.errors);
     final view = (result2.directives.singleWhere(finder) as Component).view;
 


### PR DESCRIPTION
Public members resolveHtml, resolveDart have to be atomic to be
guaranteed to work well and at the very least easy to read, reason
about, and debug. In addition, resolveHtml has an order-of-operations
requirement that it comes after all dart has been fully analyzed.

Change the requestErrors APIs (which we only used in the old API) to
request full [DirectiveResult]s, and use that everywhere that we used to
use resolve(Dart|Html), because that was made free of race conditions.
One caveat here is that everywhere resolve(Dart|Html) was used, it
required cache busting. This means that the deprecated [requestErrors]
APIs will be slower as those didn't used to, and don't need to, cache
bust. Since they're deprecated this isn't a problem.

Another note, is that we can't share a scheduler with the lower-level
driver if we want [performWork] to be atomic (which we do). That's
because we request data from the underlying driver which won't be
complete until that driver can [performWork], which will never happen if
the scheduler is waiting for the angular driver to finish. Therefore,
rather than giving up on having [performWork] being atomic inside
[AngularDriver], create a new [AnalysisDriverScheduler] for the dart
driver so that we don't have this problem. This does mean we have two
"competing" schedulers, but I think that's fine for now anyway.

This was causing issues on windows because order-of-operations there was
different and so it was behaving in weird ways in response to workflows
that were previously unexercized. Should be fixed now, and more reliable
in response to *all* different workflows.