### PR TITLE
Lexically and unintelligently accept `===` by replacing it with `== `.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unpublished Changes
 
+- Added support for === operator.
+
 ## 0.0.14
 
 - Fixed issues with locating sources in Windows

--- a/angular_analyzer_plugin/lib/src/converter.dart
+++ b/angular_analyzer_plugin/lib/src/converter.dart
@@ -629,8 +629,14 @@ class EmbeddedDartParser {
 
   /// Scan the given Dart [code] that starts at [offset].
   Token _scanDartCode(int offset, String code) {
+    // Warning: we lexically and unintelligently "accept" `===` for now by
+    // replacing it with `==`. This is actually OK for us since we can butcher
+    // string literal contents fine, and it won't affect analysis.
+    final noTripleEquals =
+        code.replaceAll('===', '== ').replaceAll('!==', '!= ');
+
     // ignore: prefer_interpolation_to_compose_strings
-    final text = ' ' * offset + code;
+    final text = ' ' * offset + noTripleEquals;
     final reader = new CharSequenceReader(text);
     final scanner = new Scanner(templateSource, reader, errorListener);
     return scanner.tokenize();

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -5319,7 +5319,7 @@ class FutureOrApis {
   }
 
   // ignore: non_constant_identifier_names
-  Future solo_test_tripleEq() async {
+  Future test_tripleEq() async {
     _addDartSource(r'''
 import 'dart:async';
 @Component(selector: 'a', templateUrl: 'test_panel.html')

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -5318,6 +5318,22 @@ class FutureOrApis {
     errorListener.assertNoErrors();
   }
 
+  // ignore: non_constant_identifier_names
+  Future solo_test_tripleEq() async {
+    _addDartSource(r'''
+import 'dart:async';
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class UseTripleEq {
+  bool a;
+  int b;
+}
+''');
+    final code = r'{{a === b}}';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
   void _addDartSource(final code) {
     dartCode = '''
 import 'package:angular2/angular2.dart';


### PR DESCRIPTION
This is not the cleanest solution from a "language theory" perspective.
I did try extending [parseEqualityExpression] to accept the new
operator, but it isn't particularly clean since equality operators have
a few micro details (allowing super==, disallowing x == y == z). Also,
since === has the same precedence as ==, they must share a loop which
means copying the lower implementation, which seemed like too much
coupling, on top of the fact that its already extending something that
will have a limited lifetime.

By replacing === with ==, we may see some strange behavior. For
instance, 'x === y === z' will highlight two characters of the second
'===' when it complains about doing equality with an equality.

But the important thing is that it doesn't matter if we butcher string
literals, and there is no other type of token we can be replacing here.
And the semantics of == vs === should be the same statically for users.