### PR TITLE
Fix #532 template URLs relative to parts' libraries rather than the part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unpublished Changes
 
+- Fixed a bug where parts' templateUrls should be relative to the parts' library
+  and not the part itself.
 - Added support for === operator.
 
 ## 0.0.14

--- a/angular_analyzer_plugin/lib/src/view_extraction.dart
+++ b/angular_analyzer_plugin/lib/src/view_extraction.dart
@@ -72,7 +72,8 @@ class ViewExtractor extends AnnotationProcessorMixin {
       final templateUrl = getExpressionString(templateUrlExpression);
       if (templateUrl != null) {
         final sourceFactory = context.sourceFactory;
-        templateUriSource = sourceFactory.resolveUri(source, templateUrl);
+        templateUriSource =
+            sourceFactory.resolveUri(classElement.library.source, templateUrl);
 
         if (templateUriSource == null || !templateUriSource.exists()) {
           errorReporter.reportErrorForNode(


### PR DESCRIPTION
Definitely possible that this solution is still a bit hairy, but this is
at least an initial step to support.