### PR TITLE
Refactor getAttributeSelectors -> getAttributes, and return element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unpublished Changes
 
+- Refactored attribute autocompletion
 - Fixed a bug where pipes that inherited transform() got flagged.
 - Fixed a bug where parts' templateUrls should be relative to the parts' library
   and not the part itself.

--- a/angular_analyzer_plugin/lib/ast.dart
+++ b/angular_analyzer_plugin/lib/ast.dart
@@ -108,7 +108,7 @@ class TemplateAttribute extends BoundAttributeInfo implements HasDirectives {
   @override
   final boundStandardInputs = <InputBinding>[];
   @override
-  final availableDirectives = <AbstractDirective, List<AttributeSelector>>{};
+  final availableDirectives = <AbstractDirective, List<AngularElement>>{};
 
   List<AbstractDirective> get directives =>
       boundDirectives.map((bd) => bd.boundDirective).toList();
@@ -268,7 +268,7 @@ abstract class NodeInfo extends AngularAstNode {
 /// contain more info than just the bound directive.
 abstract class HasDirectives extends AngularAstNode {
   List<DirectiveBinding> get boundDirectives;
-  Map<AbstractDirective, List<AttributeSelector>> get availableDirectives;
+  Map<AbstractDirective, List<AngularElement>> get availableDirectives;
   List<OutputBinding> get boundStandardOutputs;
   List<InputBinding> get boundStandardInputs;
 }
@@ -408,7 +408,7 @@ class ElementInfo extends NodeInfo implements HasDirectives {
   @override
   final boundStandardInputs = <InputBinding>[];
   @override
-  final availableDirectives = <AbstractDirective, List<AttributeSelector>>{};
+  final availableDirectives = <AbstractDirective, List<AngularElement>>{};
 
   List<AbstractDirective> get directives =>
       boundDirectives.map((bd) => bd.boundDirective).toList();

--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -1011,18 +1011,18 @@ class TemplateCompleter {
   /// and extracts non-violating plain-text attribute-directives
   /// and inputs (if name overlaps with attribute-directive).
   void suggestFromAvailableDirectives(
-    Map<AbstractDirective, List<AttributeSelector>> availableDirectives,
+    Map<AbstractDirective, List<AngularElement>> availableDirectives,
     CompletionCollector collector, {
     bool suggestInputs: false,
     bool suggestBananas: false,
     bool suggestPlainAttributes: false,
   }) {
     availableDirectives.forEach((directive, selectors) {
-      final attributeSelectors = <String, AttributeSelector>{};
+      final attributeSelectors = <String, AngularElement>{};
       final validInputs = <InputElement>[];
 
-      for (final aSelector in selectors) {
-        attributeSelectors[aSelector.nameElement.name] = aSelector;
+      for (final attribute in selectors) {
+        attributeSelectors[attribute.name] = attribute;
       }
 
       for (final input in directive.inputs) {
@@ -1053,8 +1053,8 @@ class TemplateCompleter {
 
       if (suggestPlainAttributes) {
         attributeSelectors.forEach((name, selector) {
-          final nameOffset = selector.nameElement.nameOffset;
-          final locationSource = selector.nameElement.source.fullName;
+          final nameOffset = selector.nameOffset;
+          final locationSource = selector.source.fullName;
           collector.addSuggestion(_createPlainAttributeSuggestions(
               name,
               DART_RELEVANCE_DEFAULT,

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -854,7 +854,7 @@ class DirectiveResolver extends AngularAstVisitor {
           directive.selector.availableTo(elementView) &&
           !directive.looksLikeTemplate) {
         element.availableDirectives[directive] =
-            directive.selector.getAttributeSelectors(elementView);
+            directive.selector.getAttributes(elementView);
       }
     }
 

--- a/angular_analyzer_plugin/lib/src/selector.dart
+++ b/angular_analyzer_plugin/lib/src/selector.dart
@@ -42,10 +42,8 @@ class AndSelector extends Selector {
       selectors.every((selector) => selector.availableTo(element));
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) =>
-      selectors
-          .expand((selector) => selector.getAttributeSelectors(element))
-          .toList();
+  List<AngularElement> getAttributes(ElementView element) =>
+      selectors.expand((selector) => selector.getAttributes(element)).toList();
 
   @override
   String toString() => selectors.join(' && ');
@@ -125,10 +123,10 @@ class AttributeSelector extends Selector {
       value == null ? true : match(element, null) == SelectorMatch.NonTagMatch;
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) =>
+  List<AngularElement> getAttributes(ElementView element) =>
       (isWildcard || match(element, null) == SelectorMatch.NonTagMatch)
           ? []
-          : [this];
+          : [nameElement];
 
   @override
   String toString() {
@@ -177,7 +175,7 @@ class AttributeValueRegexSelector extends Selector {
       match(element, null) == SelectorMatch.NonTagMatch;
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) => [];
+  List<AngularElement> getAttributes(ElementView element) => [];
 
   @override
   String toString() => '[*=$regexpStr]';
@@ -233,7 +231,7 @@ class ClassSelector extends Selector {
   bool availableTo(ElementView element) => true;
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) => [];
+  List<AngularElement> getAttributes(ElementView element) => [];
 
   @override
   String toString() => '.${nameElement.name}';
@@ -285,7 +283,7 @@ class ElementNameSelector extends Selector {
       nameElement.name == element.localName;
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) => [];
+  List<AngularElement> getAttributes(ElementView element) => [];
 
   @override
   String toString() => nameElement.name;
@@ -341,10 +339,8 @@ class OrSelector extends Selector {
       selectors.any((selector) => selector.availableTo(element));
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) =>
-      selectors
-          .expand((selector) => selector.getAttributeSelectors(element))
-          .toList();
+  List<AngularElement> getAttributes(ElementView element) =>
+      selectors.expand((selector) => selector.getAttributes(element)).toList();
 
   @override
   String toString() => selectors.join(' || ');
@@ -385,7 +381,7 @@ class NotSelector extends Selector {
       condition.match(element, null) == SelectorMatch.NoMatch;
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) => [];
+  List<AngularElement> getAttributes(ElementView element) => [];
 
   @override
   String toString() => ":not($condition)";
@@ -425,7 +421,7 @@ class ContainsSelector extends Selector {
   bool availableTo(ElementView element) => false;
 
   @override
-  List<AttributeSelector> getAttributeSelectors(ElementView element) => [];
+  List<AngularElement> getAttributes(ElementView element) => [];
 
   @override
   String toString() => ":contains($regex)";
@@ -459,9 +455,10 @@ abstract class Selector {
   /// without having to change/remove existing decorator.
   bool availableTo(ElementView element);
 
-  /// Returns a list of all [AttributeSelector]s that does not
-  /// violate the current selector's rules as defined by [availableTo].
-  List<AttributeSelector> getAttributeSelectors(ElementView element);
+  /// Returns a list of all [AngularElement]s where each is an attribute name,
+  /// and each attribute could be added to [element] and the selector would
+  /// still be [availableTo] it.
+  List<AngularElement> getAttributes(ElementView element);
 
   /// See [HtmlTagForSelector] for info on what this does.
   List<HtmlTagForSelector> refineTagSuggestions(


### PR DESCRIPTION
Rather than returning AttributeSelector, which we don't use, return just
the AngularElement, which we do.

This makes us able to split up the type of AttributeSelector's/things
which can lead to attributes, without having to make a subclass
relationship between all tags that mean attribute names could be
autocompleted.