### PR TITLE
Upgrade to 0.0.15. New instructions too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.0.15
 
-- Fixed bug where version pushed over the plugin API (available in the analyzer
-  diagnostics page) said 1.0.0-alpha.0 instead of the pub version.
+- Fixed bug where the version pushed over the plugin API (available in the
+  analyzer diagnostics page) said 1.0.0-alpha.0 instead of the pub version.
 - Refactored attribute autocompletion
 - Fixed a bug where pipes that inherited transform() got flagged.
 - Fixed a bug where parts' templateUrls should be relative to the parts' library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unpublished Changes
 
+## 0.0.15
+
+- Fixed bug where version pushed over the plugin API (available in the analyzer
+  diagnostics page) said 1.0.0-alpha.0 instead of the pub version.
 - Refactored attribute autocompletion
 - Fixed a bug where pipes that inherited transform() got flagged.
 - Fixed a bug where parts' templateUrls should be relative to the parts' library
@@ -11,9 +15,7 @@ Some larger items:
 ### Newer options config
 
 The required config has been changed in a backwards-compatible way. However,
-setup documentation will be changed later, since the *new setup instructions*
-won't work *with older plugins*. After publish + a delay, the setup instructions
-will be updated accordingly.
+note that while 0.0.14's config works for 0.0.15 users, the reverse is not true.
 
 Specifically, we no longer require `enabled: true`, and we are moving from
 configuring the plugin inside `analyzer`, to having its own top level. This

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Simply add to your [analysis_options.yaml file](https://www.dartlang.org/guides/
 ```yaml
 analyzer:
   plugins:
-    angular:
-      enabled: true
+    - angular
 ```
 
 Then simply reboot your analysis server (inside IntelliJ this is done by clicking on the skull icon if it exists, or the refresh icon otherwise) and wait for the plugin to fully load, which can take a minute on the first run.
@@ -45,8 +44,7 @@ and then load the plugin as itself, rather than as a dependency of angular:
 ```yaml
 analyzer:
   plugins:
-    angular_analyzer_plugin:
-      enabled: true
+    - angular_analyzer_plugin
 ```
 
 Like the previous installation option, you then just need to reboot your analysis server after running pub get.
@@ -58,14 +56,17 @@ If you have any issues, filing an issue with us is always a welcome option. Ther
 * Are you using angular 5 or newer? If not, are you loading a recent exact version of the plugin?
 * Are you using a bleeding edge SDK? The latest stable will not work correctly, and windows users require at least 2.0.0-dev-31.
 * Did you turn the plugin on correctly in your analysis options file?
+* From IntelliJ in the Dart Analysis panel, there's a gear icon that has "analyzer diagnostics," which opens a web page that has a section for loaded plugins. Does it show up? Which version are you on? Is it out of date? Are there any errors?
 * Does your editor support html+dart analysis, or is it an old version? Some (such as VSCode, vim) may have special steps to show errors surfaced by dart analysis inside your html files.
-* From IntelliJ in the Dart Analysis panel, there's a gear icon that has "analyzer diagnostics," which opens a web page that has a section for loaded plugins. Are there any errors?
 * Check the directory `~/.dartServer/.plugin_manager` (on Windows: `\Users\you\AppData\Local\.dartServer\.plugin_manager`). Does it have any subdirectories?
 * There should be a hash representing each plugin you've loaded. Can you run `pub get` from `HASH/analyzer_plugin`? (If you have multiple hashes, it should be safe to clear this directory & reload.)
 * If you run `bin/plugin.dart` from `.plugin_manager/HASH/analyzer_plugin`, do you get any import errors? (Note: this is expected to crash when launched in this way, but without import-related errors)
 
 We may ask you any or all of these questions if you open an issue, so feel free to go run through these checks on your own to get a hint what might be wrong.
 
+## Upgrading
+
+Any dart users on 2.0.0-dev.48 or newer will get updates on every restart of the analysis server. If you are on an older dart version than that, check the Troubleshooting section.
 
 ## Building -- For hacking on this plugin, or using the latest unpublished.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ We may ask you any or all of these questions if you open an issue, so feel free 
 
 ## Upgrading
 
-Any dart users on 2.0.0-dev.48 or newer will get updates on every restart of the analysis server. If you are on an older dart version than that, check the Troubleshooting section.
+Any Dart users on 2.0.0-dev.48 or newer will get updates on every restart of the analysis server. If you are on an older Dart version than that, check the Troubleshooting section.
 
 ## Building -- For hacking on this plugin, or using the latest unpublished.
 

--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -41,7 +41,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
   String get name => 'Angular Analysis Plugin';
 
   @override
-  String get version => '1.0.0-alpha.0';
+  String get version => '0.0.15';
 
   @override
   String get contactInfo =>

--- a/angular_analyzer_plugin/tools/analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/tools/analyzer_plugin/pubspec.yaml
@@ -4,5 +4,5 @@ description: Self-loader of the plugin for people using an exact version.
 environment:
   sdk: '>=1.24.0-dev.1.0'
 dependencies:
-  angular_analyzer_plugin: '0.0.14'
+  angular_analyzer_plugin: '0.0.15'
 dev_dependencies:


### PR DESCRIPTION
Good time to publish; we have some bugfixes for users, and once this is published we can update the setup instructions.

The changes to analysis server to reload on start will go out in the next dev release, so this is slightly ahead of that.