### PR TITLE
Revert change to plugin-get-version, which is only for API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.0.15
 
-- Fixed bug where the version pushed over the plugin API (available in the
-  analyzer diagnostics page) said 1.0.0-alpha.0 instead of the pub version.
 - Refactored attribute autocompletion
 - Fixed a bug where pipes that inherited transform() got flagged.
 - Fixed a bug where parts' templateUrls should be relative to the parts' library

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you have any issues, filing an issue with us is always a welcome option. Ther
 * Are you using angular 5 or newer? If not, are you loading a recent exact version of the plugin?
 * Are you using a bleeding edge SDK? The latest stable will not work correctly, and windows users require at least 2.0.0-dev-31.
 * Did you turn the plugin on correctly in your analysis options file?
-* From IntelliJ in the Dart Analysis panel, there's a gear icon that has "analyzer diagnostics," which opens a web page that has a section for loaded plugins. Does it show up? Which version are you on? Is it out of date? Are there any errors?
+* From IntelliJ in the Dart Analysis panel, there's a gear icon that has "analyzer diagnostics," which opens a web page that has a section for loaded plugins. Are there any errors?
 * Does your editor support html+dart analysis, or is it an old version? Some (such as VSCode, vim) may have special steps to show errors surfaced by dart analysis inside your html files.
 * Check the directory `~/.dartServer/.plugin_manager` (on Windows: `\Users\you\AppData\Local\.dartServer\.plugin_manager`). Does it have any subdirectories?
 * There should be a hash representing each plugin you've loaded. Can you run `pub get` from `HASH/analyzer_plugin`? (If you have multiple hashes, it should be safe to clear this directory & reload.)

--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -41,7 +41,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
   String get name => 'Angular Analysis Plugin';
 
   @override
-  String get version => '0.0.15';
+  String get version => '1.0.0-alpha.0';
 
   @override
   String get contactInfo =>

--- a/angular_analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular_analyzer_plugin
-version: 0.0.15
+version: 0.0.15+1
 description: Dart analyzer plugin for Angular 2+
 authors:
   - Konstantin Scheglov <scheglov@google.com>

--- a/angular_analyzer_plugin/tools/analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/tools/analyzer_plugin/pubspec.yaml
@@ -4,5 +4,5 @@ description: Self-loader of the plugin for people using an exact version.
 environment:
   sdk: '>=1.24.0-dev.1.0'
 dependencies:
-  angular_analyzer_plugin: '0.0.15'
+  angular_analyzer_plugin: '0.0.15+1'
 dev_dependencies:


### PR DESCRIPTION
I've already published this to fix the broken package. We may want to rename this getter and how it shows up in the dart analyzer diagnostic version. We also may want to add a "package plugin version" field which lets users see the info I thought it was showing