### PR TITLE
Create more robust synthetic tokens for completion integration.

### DIFF
--- a/angular_analyzer_plugin/lib/src/completion_request.dart
+++ b/angular_analyzer_plugin/lib/src/completion_request.dart
@@ -9,6 +9,8 @@ import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/standard_components.dart';
+import 'package:front_end/src/scanner/token.dart'
+    show SyntheticBeginToken, TokenType, SyntheticToken;
 
 class AngularCompletionRequest extends CompletionRequest {
   final List<Template> templates;
@@ -67,8 +69,11 @@ class AngularCompletionRequest extends CompletionRequest {
         if (_dartSnippet is Expression) {
           // wrap dart snippet in a ParenthesizedExpression, because the dart
           // completion engine expects all expressions to have parents.
-          _dartSnippet =
-              astFactory.parenthesizedExpression(null, _dartSnippet, null);
+          _dartSnippet = astFactory.parenthesizedExpression(
+              new SyntheticBeginToken(TokenType.OPEN_PAREN, _dartSnippet.offset)
+                ..next = _dartSnippet.beginToken,
+              _dartSnippet,
+              new SyntheticToken(TokenType.CLOSE_PAREN, _dartSnippet.end));
         }
         _completionTarget = new CompletionTarget.forOffset(null, offset,
             entryPoint: _dartSnippet);


### PR DESCRIPTION
This won't solve the problem by itself without updating the SDK (PR incoming)...but I'm also curious if this passes on travis, in which case we can commit it to master without issue and support both versions (internal/external) without branching.

When autocompleting a dart snippet like "x" within "{{}}", there is no
parent node and that breaks some logic in the completion engine.
Therefore we add a synthetic parenthesized ast, but previously we had
been giving null begin and end tokens.

Create begin and end tokens via the front-end synthetic classes, and
ensure to link beginToken.next to the user's dart code's beginToken.