### PR TITLE
Create more robust synthetic tokens for completion integration.

### DIFF
--- a/angular_analyzer_plugin/lib/src/completion_request.dart
+++ b/angular_analyzer_plugin/lib/src/completion_request.dart
@@ -9,6 +9,10 @@ import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/standard_components.dart';
+import 'package:analyzer/src/dart/ast/token.dart' show TokenType;
+// TODO(mfairhurst): import these from package:analyzer once they're exported.
+import 'package:front_end/src/scanner/token.dart'
+    show SyntheticBeginToken, SyntheticToken;
 
 class AngularCompletionRequest extends CompletionRequest {
   final List<Template> templates;
@@ -67,8 +71,11 @@ class AngularCompletionRequest extends CompletionRequest {
         if (_dartSnippet is Expression) {
           // wrap dart snippet in a ParenthesizedExpression, because the dart
           // completion engine expects all expressions to have parents.
-          _dartSnippet =
-              astFactory.parenthesizedExpression(null, _dartSnippet, null);
+          _dartSnippet = astFactory.parenthesizedExpression(
+              new SyntheticBeginToken(TokenType.OPEN_PAREN, _dartSnippet.offset)
+                ..next = _dartSnippet.beginToken,
+              _dartSnippet,
+              new SyntheticToken(TokenType.CLOSE_PAREN, _dartSnippet.end));
         }
         _completionTarget = new CompletionTarget.forOffset(null, offset,
             entryPoint: _dartSnippet);

--- a/angular_analyzer_plugin/lib/src/completion_request.dart
+++ b/angular_analyzer_plugin/lib/src/completion_request.dart
@@ -9,7 +9,7 @@ import 'package:angular_analyzer_plugin/ast.dart';
 import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/standard_components.dart';
-import 'package:analyzer/src/dart/ast/token.dart' show TokenType;
+import 'package:analyzer/dart/ast/token.dart' show TokenType;
 // TODO(mfairhurst): import these from package:analyzer once they're exported.
 import 'package:front_end/src/scanner/token.dart'
     show SyntheticBeginToken, SyntheticToken;


### PR DESCRIPTION
This is not at all obvious, but because the branch name now has SDK_AT_HEAD, it will build in a different way that uses the latest of all dependencies. So the build should now succeed, and it should be safe to merge into the special fork branch without making me unable to publish externally in the meantime.

When autocompleting a dart snippet like "x" within "{{}}", there is no
parent node and that breaks some logic in the completion engine.
Therefore we add a synthetic parenthesized ast, but previously we had
been giving null begin and end tokens.

Create begin and end tokens via the front-end synthetic classes, and
ensure to link beginToken.next to the user's dart code's beginToken.