### PR TITLE
Remove unnecessary dependency on front_end

### DIFF
--- a/angular_analyzer_plugin/lib/src/completion_request.dart
+++ b/angular_analyzer_plugin/lib/src/completion_request.dart
@@ -10,8 +10,7 @@ import 'package:angular_analyzer_plugin/src/converter.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/standard_components.dart';
 import 'package:analyzer/dart/ast/token.dart' show TokenType;
-// TODO(mfairhurst): import these from package:analyzer once they're exported.
-import 'package:front_end/src/scanner/token.dart'
+import 'package:analyzer/src/dart/ast/token.dart'
     show SyntheticBeginToken, SyntheticToken;
 
 class AngularCompletionRequest extends CompletionRequest {


### PR DESCRIPTION
SyntheticBeginToken and SyntheticToken are now exported by the analyzer.