### PR TITLE
Fix the type of _convertStatementsBoundAttribute.

### DIFF
--- a/angular_analyzer_plugin/lib/src/converter.dart
+++ b/angular_analyzer_plugin/lib/src/converter.dart
@@ -392,7 +392,8 @@ class HtmlTreeConverter {
   }
 
   StatementsBoundAttribute _convertStatementsBoundAttribute(
-      ParsedEventAst ast) {
+      EventAst eventAst) {
+    final ast = eventAst as ParsedEventAst;
     final prefixToken = ast.prefixToken;
     final nameToken = ast.nameToken;
     final suffixToken = ast.suffixToken;


### PR DESCRIPTION
The use of _convertStatementsBoundAttribute in _convertAttributes has
a type error that the analyzer has been failing to detect due to
https://github.com/dart-lang/sdk/issues/32305.  In order to fix this
analyzer bug, we need to first fix any type errors that exist in the
wild.

This change fixes the type of _convertStatementsBoundAttribute to
match the type expected at the use site, and adds the necessary "as"
cast.