### PR TITLE
Split wildcards into a separate class of selector, share base class

### DIFF
--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -138,6 +138,7 @@ class AttributeSelectorTest extends _SelectorTest {
   void test_match_notName() {
     final selector = new AttributeSelector(nameElement, null);
     when(element.attributes).thenReturn({'not-kind': 'no-matter'});
+    when(element.attributeNameSpans).thenReturn({'not-kind': null});
     expect(selector.match(element, template), equals(SelectorMatch.NoMatch));
     expect(selector.availableTo(element), true);
   }


### PR DESCRIPTION
Note: Looking at this code, its actually working incorrectly. It should
require a value, and [x*=y] should match attributes with name [x] when
it has a value containing "y". However, I'll fix the logic in a different
CL.