### PR TITLE
Fix #567 enable static references to the component class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unpublished Changes
 
+- Fixed an issue where you couldn't reference a static member of the component
+  class without a warning.
 - Support dart 2 runtimes
 - Better error message for when attribute selectors have an operator but no
   value.

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -1603,7 +1603,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
     // verify
     final verifier = new AngularErrorVerifier(
         errorReporter, library, typeProvider, new InheritanceManager(library),
-        acceptAssignment: acceptAssignment);
+        acceptAssignment: acceptAssignment)
+      ..enclosingClass = classElement;
     astNode.accept(verifier);
   }
 

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -5334,6 +5334,40 @@ class UseTripleEq {
     errorListener.assertNoErrors();
   }
 
+  // ignore: non_constant_identifier_names
+  Future test_staticSelfReferenceOk() async {
+    _addDartSource(r'''
+import 'dart:async';
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class HasStatic {
+  static bool myStatic;
+}
+''');
+    final code = r'{{myStatic}}';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_staticParentReferenceNotOk() async {
+    _addDartSource(r'''
+import 'dart:async';
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class ChildOfHasStatic extends HasStatic {
+}
+class HasStatic {
+  static bool myParentsStatic;
+}
+''');
+    final code = r'{{myParentsStatic}}';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertErrorsWithCodes([
+      StaticTypeWarningCode.UNQUALIFIED_REFERENCE_TO_NON_LOCAL_STATIC_MEMBER
+    ]);
+  }
+
   void _addDartSource(final code) {
     dartCode = '''
 import 'package:angular2/angular2.dart';


### PR DESCRIPTION
Build will fail until https://dart-review.googlesource.com/c/sdk/+/54703 is merged.