### PR TITLE
Validate basic @i18n usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unpublished Changes
 
+- Validate @i18n usage for markup that's not allowed, mustaches that aren't
+  allowed, and attribute i18n references that don't exist.
 - Better error message for when attribute selectors have an operator but no
   value.
 - In previous versions, the `x*=y` selector was working incorrectly. It matched

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Template syntax | Validation | Auto-Complete | Navigation | Refactoring
 `<p *myUnless="myExpression">...</p>` | :white_check_mark: desugared to `<template [myUnless]="myExpression"><p>...` and checked from there | :white_check_mark: | :white_check_mark: some bugs ,mostly works | :x:
 `<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :x: Pipes are not typechecked yet | :x: | :x: | :x:
 `<my-component @deferred>` | :x: | :x: | :x: | :x:
+`<div @i18n="description">content</div>` | :last_quarter_moon: basic usage checked with some limitations | :x: | :x: | :x:
+`<div foo="content" @i18n-foo="description"></div>` | :last_quarter_moon: basic usage checked with some limitations | :x: | :x: | :x:
 
 Built-in directives | Validation | Auto-Complete | Navigation | Refactoring
 --------------------|------------|---------------|------------|-------------

--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -64,6 +64,9 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.UNSAFE_BINDING,
   AngularWarningCode.EVENT_REDUCTION_NOT_ALLOWED,
   AngularWarningCode.FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED,
+  AngularWarningCode.MUSTACHE_BINDINGS_NOT_ALLOWED_IN_I18N,
+  AngularWarningCode.MARKUP_NOT_ALLOWED_IN_I18N,
+  AngularWarningCode.I18N_REFERENCES_MISSING_ATTRIBUTE,
   AngularHintCode.OFFSETS_CANNOT_BE_CREATED,
 ];
 
@@ -472,6 +475,28 @@ class AngularWarningCode extends ErrorCode {
           'FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED',
           'Function directives cannot have an exportAs setting, because they'
           " can't be exported");
+
+  /// An error indicating that a mustache was used inside of an @i18n-marked
+  /// node, which is not allowed.
+  static const MUSTACHE_BINDINGS_NOT_ALLOWED_IN_I18N = const AngularWarningCode(
+      'MUSTACHE_BINDINGS_NOT_ALLOWED_IN_I18N',
+      'Mustache bindings are not allowed in @i18n-annotated nodes. Try using'
+      ' package:intl directly instead the angular i18n support.');
+
+  /// An error indicating that markup was used inside of an @i18n-marked node,
+  /// which is not allowed.
+  static const MARKUP_NOT_ALLOWED_IN_I18N = const AngularWarningCode(
+      'TAGS_NOT_ALLOWED_IN_I18N',
+      'For security reasons, markup is not allowed in @i18n-annotated nodes.'
+      ' Try using package:intl directly with the markup bound as variables,'
+      ' instead of using the angular i18n support.');
+
+  /// An error indicating that an @i18n-attr annotation was used with no
+  /// corresponding "attr" attribute.
+  static const I18N_REFERENCES_MISSING_ATTRIBUTE = const AngularWarningCode(
+      'I18N_REFERENCES_MISSING_ATTRIBUTE',
+      'The binding @i18n-{0} marks an attribute {0} for internationalization,'
+      ' but no attribute named {0} exists on the element');
 
   /// Initialize a newly created error code to have the given [name].
   /// The message associated with the error will be created from the given

--- a/angular_analyzer_plugin/lib/src/converter.dart
+++ b/angular_analyzer_plugin/lib/src/converter.dart
@@ -51,6 +51,7 @@ class HtmlTreeConverter {
         properties: node.properties,
         references: node.references,
         stars: node.stars,
+        annotationBindings: node.annotations,
       )..sort((a, b) => a.offset.compareTo(b.offset));
       final closeComponent = node.closeComplement;
       SourceRange openingSpan;
@@ -255,6 +256,7 @@ class HtmlTreeConverter {
     List<ReferenceAst> references: const [],
     List<StarAst> stars: const [],
     List<LetBindingAst> letBindings: const [],
+    List<AnnotationAst> annotationBindings: const [],
   }) {
     final returnAttributes = <AttributeInfo>[];
 
@@ -317,6 +319,21 @@ class HtmlTreeConverter {
             value,
             valueOffset, <Mustache>[]));
       }
+    }
+
+    for (final annotationBinding in annotationBindings) {
+      String value;
+      int valueOffset;
+      // TODO(mfairhurst): use value in newest angular_ast
+      //if (annotationBinding.valueToken != null) {
+      //  value = letBinding.valueToken.innerValue.lexeme;
+      //  valueOffset = letBinding.valueToken.innerValue.offset;
+      //}
+      returnAttributes.add(new TextAttribute(
+          '@${annotationBinding.name}',
+          annotationBinding.beginToken.offset,
+          value,
+          valueOffset, <Mustache>[]));
     }
 
     stars.map(_convertTemplateAttribute).forEach(returnAttributes.add);

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -5334,6 +5334,95 @@ class UseTripleEq {
     errorListener.assertNoErrors();
   }
 
+  // ignore: non_constant_identifier_names
+  Future test_i18n_mustacheNotAllowed() async {
+    _addDartSource(r'''
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class TestComponent {
+}
+''');
+    final code = r'<div @i18n="foo">{{binding}}</div>';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertErrorsWithCodes([
+      AngularWarningCode.MUSTACHE_BINDINGS_NOT_ALLOWED_IN_I18N,
+      StaticWarningCode.UNDEFINED_IDENTIFIER, // the binding itself
+    ]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_i18n_markupNotAllowed() async {
+    _addDartSource(r'''
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class TestComponent {
+}
+''');
+    final code = r'<div @i18n="foo"><b>stuff</b></div>';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.MARKUP_NOT_ALLOWED_IN_I18N, code, r'<b>stuff</b>');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_i18n_ngContentNotAllowed() async {
+    _addDartSource(r'''
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class TestComponent {
+}
+''');
+    final code = r'<div @i18n="foo"><ng-content></ng-content></div>';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(AngularWarningCode.MARKUP_NOT_ALLOWED_IN_I18N,
+        code, r'<ng-content></ng-content>');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_i18n_attribute_mustachesNotAllowed() async {
+    _addDartSource(r'''
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class TestComponent {
+}
+''');
+    final code = r'<div foo="{{binding}}" @i18n-foo="foo"></div>';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertErrorsWithCodes([
+      AngularWarningCode.MUSTACHE_BINDINGS_NOT_ALLOWED_IN_I18N,
+      StaticWarningCode.UNDEFINED_IDENTIFIER, // the binding itself
+    ]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_i18n_attribute_missing() async {
+    _addDartSource(r'''
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class TestComponent {
+}
+''');
+    final code = r'<div @i18n-missing="foo"></div>';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.I18N_REFERENCES_MISSING_ATTRIBUTE,
+        code,
+        r'@i18n-missing');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_i18n_attribute_ok() async {
+    _addDartSource(r'''
+@Component(selector: 'a', templateUrl: 'test_panel.html')
+class TestComponent {
+}
+''');
+    final code = r'<div foo="bar" @i18n-foo="baz"></div>';
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    errorListener.assertNoErrors();
+  }
+
   void _addDartSource(final code) {
     dartCode = '''
 import 'package:angular2/angular2.dart';


### PR DESCRIPTION
Need to publish the version of angular_ast that supports annotations
with values, so that I can ensure that @i18n annotations have a value
specified. Otherwise it already validates (I'm pretty sure) everything
that could be validated.

Have not yet started changing the autocompletion, where I could suggest
@i18n, @i18n-eachattr, and I should not suggest markup inside @i18n
contents.