### PR TITLE
upgrade deps and sdk dep; resolve issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ angular2-dart-analyzer.iml
 
 .packages
 .pub
+.dart_tool
 packages
 pubspec.lock
 deps/sdk

--- a/angular_analyzer_plugin/analysis_options.yaml
+++ b/angular_analyzer_plugin/analysis_options.yaml
@@ -1,8 +1,8 @@
 analyzer:
-  strong-mode: true
   exclude:
+    # TODO(devoncarew): We should remove this blanket exclusion - it could mask
+    # other issues.
     - lib/src/summary/format.dart
-    - lib/src/angular_html_parser.dart
 
 linter:
   rules:

--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -167,6 +167,9 @@ class _ResolveResultShell implements ResolveResult {
   List<AnalysisError> get errors => const [];
 
   @override
+  bool get isPart => false;
+
+  @override
   LineInfo get lineInfo => null;
 
   @override

--- a/angular_analyzer_plugin/lib/src/facade/exports_compilation_unit_element.dart
+++ b/angular_analyzer_plugin/lib/src/facade/exports_compilation_unit_element.dart
@@ -85,6 +85,12 @@ class ExportsLimitedCompilationUnitFacade implements CompilationUnitElement {
   bool get hasJS => false;
 
   @override
+  bool get hasIsTest => _wrappedUnit.hasIsTest;
+
+  @override
+  bool get hasIsTestGroup => _wrappedUnit.hasIsTestGroup;
+
+  @override
   bool get hasOverride => _wrappedUnit.hasOverride;
 
   @override

--- a/angular_analyzer_plugin/lib/src/facade/exports_import_element.dart
+++ b/angular_analyzer_plugin/lib/src/facade/exports_import_element.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart' hide Directive;
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/resolver/scope.dart';
 import 'package:analyzer/src/generated/engine.dart' show AnalysisContext;
 import 'package:analyzer/src/generated/java_engine.dart';
 import 'package:analyzer/src/generated/source.dart';
@@ -60,6 +61,12 @@ class ExportsImportElementFacade implements ImportElement {
 
   @override
   bool get isJS => false;
+
+  @override
+  bool get hasIsTest => _wrappedImport.hasIsTest;
+
+  @override
+  bool get hasIsTestGroup => _wrappedImport.hasIsTestGroup;
 
   @override
   bool get isOverride => hasOverride;
@@ -123,6 +130,9 @@ class ExportsImportElementFacade implements ImportElement {
 
   @override
   CompilationUnit get unit => _wrappedImport.unit;
+
+  @override
+  Namespace get namespace => _wrappedImport.namespace;
 
   @override
   String computeDocumentationComment() => _wrappedImport

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -1718,8 +1718,7 @@ class AngularResolverVisitor extends _IntermediateResolverVisitor
     // Only block reassignment of locals, not poperties. Resolve elements to
     // check that.
     exp.leftHandSide.accept(elementResolver);
-    final variableElement = getOverridableStaticElement(exp.leftHandSide) ??
-        getOverridablePropagatedElement(exp.leftHandSide);
+    final variableElement = getOverridableStaticElement(exp.leftHandSide);
     if ((variableElement == null ||
             variableElement is PropertyInducingElement) &&
         acceptAssignment) {

--- a/angular_analyzer_plugin/pubspec.yaml
+++ b/angular_analyzer_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular_analyzer_plugin
-version: 0.0.16
+version: 0.0.17
 description: Dart analyzer plugin for Angular 2+
 authors:
   - Konstantin Scheglov <scheglov@google.com>
@@ -7,12 +7,12 @@ authors:
   - Max Kim <maxkim@google.com>
 homepage: https://github.com/dart-lang/angular_analyzer_plugin
 environment:
-  sdk: '>=1.24.0-dev.1.0 <2.0.0'
+  sdk: '>=1.24.0-dev.1.0 <3.0.0'
 dependencies:
-  analyzer: '0.31.2-alpha.2'
+  analyzer: 0.32.4
   plugin: '^0.2.0'
   tuple: '^1.0.1'
-  analyzer_plugin: '0.0.1-alpha.2'
+  analyzer_plugin: 0.0.1-alpha.4
   angular_ast: '^0.5.0'
   meta: ^1.0.2
   yaml: ^2.1.2


### PR DESCRIPTION
- upgrade deps on `package:analyzer` and `package:analyzer_plugin`
- widen the sdk dep to include `2.0.0`
- fix some issues due to rolling to the latest package:analyzer
- prep for publishing (so that we have a published package which doesn't use upper case sdk constants)

@MichaelRFairhurst, I don't think this follows the branch strategy that you have for this repo; happy to take advice here about how to better submit this, or have the PR chopped up into other PRs as necessary to support a new publish
