### PR TITLE
address a few analysis warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ angular2-dart-analyzer.iml
 
 .packages
 .pub
+.dart_tool/
 packages
 pubspec.lock
 deps/sdk

--- a/angular_analyzer_plugin/analysis_options.yaml
+++ b/angular_analyzer_plugin/analysis_options.yaml
@@ -1,8 +1,8 @@
 analyzer:
-  strong-mode: true
   exclude:
+    # TODO(devoncarew): We should remove this blanket exclusion as it could hide
+    # other issues.
     - lib/src/summary/format.dart
-    - lib/src/angular_html_parser.dart
 
 linter:
   rules:

--- a/angular_analyzer_plugin/lib/ast.dart
+++ b/angular_analyzer_plugin/lib/ast.dart
@@ -358,18 +358,17 @@ class TextInfo extends NodeInfo {
   void accept(AngularAstVisitor visitor) => visitor.visitTextInfo(this);
 }
 
-/// A wrapper for a given HTML document or
-/// dart-angular inline HTML template.
+/// A wrapper for a given HTML document or dart-angular inline HTML template.
 class DocumentInfo extends ElementInfo {
   factory DocumentInfo() = DocumentInfo._;
 
   DocumentInfo._()
       : super(
           '',
-          new SourceRange(0, 0),
-          new SourceRange(0, 0),
-          new SourceRange(0, 0),
-          new SourceRange(0, 0),
+          const SourceRange(0, 0),
+          const SourceRange(0, 0),
+          const SourceRange(0, 0),
+          const SourceRange(0, 0),
           [],
           null,
           null,

--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -472,7 +472,7 @@ class NgInheritedReferenceContributor extends CompletionContributor {
       ..parameterTypes =
           element.parameters.map((param) => param.type.toString()).toList()
       ..requiredParameterCount =
-          element.parameters.where((param) => param.isRequired).length
+          element.parameters.where((param) => param.hasRequired).length
       ..hasNamedParameters =
           element.parameters.any((param) => param.name != null);
   }

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -158,7 +158,7 @@ class AbstractAngularTest {
         new FileContentOverlay(),
         contextRoot,
         sf,
-        new AnalysisOptionsImpl()..strongMode = true);
+        new AnalysisOptionsImpl());
     angularDriver = new AngularDriver(
         resourceProvider,
         new MockNotificationManager(),

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -19,6 +19,8 @@ import 'package:test/test.dart';
 
 import 'abstract_angular.dart';
 
+// ignore_for_file: deprecated_member_use
+
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(AngularParseHtmlTest);

--- a/angular_analyzer_plugin/test/element_assert.dart
+++ b/angular_analyzer_plugin/test/element_assert.dart
@@ -5,6 +5,8 @@ import 'package:angular_analyzer_plugin/src/model.dart';
 import 'package:angular_analyzer_plugin/src/selector.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: deprecated_member_use
+
 class AngularElementAssert extends _AbstractElementAssert {
   final AngularElement element;
 


### PR DESCRIPTION
- address a few analysis warnings

This reduces the analysis issues reported from ~130 to 32.

Also, I notice that this package depends on package:tuple. That package has not updated its version constraint to include dart 2. We may want to in-line our use of the package (the Tuple2 and Tuple4 classes) so the angular plugin doesn't break once pub is updated to be strict about sdk deps.

@MichaelRFairhurst 