### PR TITLE
Fix (click) issues: Find events without @DomName, removed from dart:html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unpublished
+
+- Fixed an issue where standard HTML events weren't recognized due to changes
+  made to dart:html sources on newer SDKs.
+
 ## 0.0.17
 
 - More dart 2 runtime support.

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -312,14 +312,13 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
 
   List<OutputElement> _buildOutputs(bool globalOutputs) =>
       _captureAspects((outputMap, accessor) {
-        final domName = _getDomName(accessor);
+        final domName = accessor.name.toLowerCase();
         if (domName == null) {
           return;
         }
 
-        // Event domnames start with Element.on or Document.on
-        final offset = domName.indexOf(".") + ".on".length;
-        final name = domName.substring(offset);
+        // Event domnames start with on
+        final name = domName.substring("on".length);
 
         if (!outputMap.containsKey(name)) {
           if (accessor.isGetter) {
@@ -344,20 +343,6 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
           }
         }
       }, globalOutputs); // Either grabbing HtmlElement events or skipping them
-
-  String _getDomName(Element element) {
-    for (final annotation in element.metadata) {
-      // this has caching built in, so we can compute every time
-      final value = annotation.computeConstantValue();
-      if (value != null && value.type is InterfaceType) {
-        if (value.type.element.name == 'DomName') {
-          return value.getField("name").toStringValue();
-        }
-      }
-    }
-
-    return null;
-  }
 
   List<T> _captureAspects<T>(CaptureAspectFn<T> addAspect, bool globalAspects) {
     final aspectMap = <String, T>{};

--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -336,49 +336,31 @@ class MouseEvent extends Event {}
 class FocusEvent extends Event {}
 class KeyEvent extends Event {}
 
-class DomName {
-  final String name;
-  const DomName(this.name);
-}
-
 abstract class ElementStream<T extends Event> implements Stream<T> {}
 
 abstract class Element {
   /// Stream of `cut` events handled by this [Element].
-  @DomName('Element.oncut')
   ElementStream<Event> get onCut => null;
   
-  @DomName('Element.id')
   String get id => null;
   
-  @DomName('Element.id')
   set id(String value) => null;
 }
 
 class HtmlElement extends Element {
   int tabIndex;
-  @DomName('Element.onchange')
   ElementStream<Event> get onChange => null;
-  @DomName('Element.onclick')
   ElementStream<MouseEvent> get onClick => null;
-  @DomName('Element.onkeyup')
   ElementStream<KeyEvent> get onKeyUp => null;
-  @DomName('Element.onkeydown')
   ElementStream<KeyEvent> get onKeyDown => null;
   
-  @DomName('HTMLElement.hidden')
   bool get hidden => null;
-  @DomName('HTMLElement.hidden')
   set hidden(bool value) => null;
   
-  @DomName('HTMLElement.className')
   void set className(String s){}
-  @DomName('HTMLElement.readOnly')
   void set readOnly(bool b){}
-  @DomName('HTMLElement.tabIndex')
   void set tabIndex(int i){}
 
-  @DomName('HTMLElement.innerHTML')
   String _innerHtml;
   String get innerHtml {
     throw 'not the real implementation';
@@ -402,11 +384,9 @@ class AnchorElement extends HtmlElement {
   String _privateField;
 }
 
-@DomName('HTMLBodyElement')
 class BodyElement extends HtmlElement {
   factory BodyElement() => document.createElement("body");
 
-  @DomName('HTMLBodyElement.onunload')
   ElementStream<Event> get onUnload => null;
 }
 
@@ -437,7 +417,6 @@ class IFrameElement extends HtmlElement {
       '#.createElement(#)',
       document,
       "iframe");
-  @DomName('HTMLIFrameElement.src')
   String src;
 }
 
@@ -445,15 +424,12 @@ class OptionElement extends HtmlElement {
   factory OptionElement({String data: '', String value : '', bool selected: false}) {
   }                                                                              
                                                                                  
-  @DomName('HTMLOptionElement.HTMLOptionElement')                                
-  @DocsEditable()                                                                
   factory OptionElement._([String data, String value, bool defaultSelected, bool selected]) {
   }    
 }
 
 class TableSectionElement extends HtmlElement {
 
-  @DomName('HTMLTableSectionElement.rows')
   List<TableRowElement> get rows => null;
 
   TableRowElement addRow() {


### PR DESCRIPTION
It looks like DomName can be inferred by lowercasing the accessor name.
This is not reliable for inputs, but for events it seems to be fully
reliable.

Make the changes to the mock SDK, these changes have also been tested
against the latest real SDK. We need integration tests for this type of
thing.

Fix #591