### PR TITLE
address a few analysis nits

### DIFF
--- a/angular_analyzer_plugin/lib/ast.dart
+++ b/angular_analyzer_plugin/lib/ast.dart
@@ -1,10 +1,9 @@
 import 'dart:collection';
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:angular_analyzer_plugin/src/model.dart';
-import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/element/element.dart';
 import 'package:meta/meta.dart';
 
 enum ExpressionBoundType { input, twoWay, attr, clazz, style }

--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -673,9 +673,7 @@ class MockSdk implements DartSdk {
   List<int> _computeLinkedBundleBytes() {
     final librarySources =
         sdkLibraries.map((library) => mapDartUri(library.shortName)).toList();
-    return new SummaryBuilder(
-            librarySources, context, context.analysisOptions.strongMode)
-        .build();
+    return new SummaryBuilder(librarySources, context, true).build();
   }
 }
 

--- a/angular_analyzer_plugin/test/navigation_test.dart
+++ b/angular_analyzer_plugin/test/navigation_test.dart
@@ -15,6 +15,9 @@ import 'package:test/test.dart';
 
 import 'abstract_angular.dart';
 
+// 'typed' is deprecated and shouldn't be used.
+// ignore_for_file: deprecated_member_use
+
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(AngularNavigationTest);

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -134,7 +134,7 @@ class TestPanel {
   }
 }
 ''');
-    var code = r'''
+    final code = r'''
 <div (click.whatever)='handle($event)'></div>
 ''';
     _addHtmlSource(code);

--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -5,6 +5,9 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+// 'typed' is deprecated and shouldn't be used.
+// ignore_for_file: deprecated_member_use
+
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(AndSelectorTest);


### PR DESCRIPTION
- ignore some deprecated_member_use warnings in test files
- remove an unused import
- don't use the deprecated `strongMode` flag

@MichaelRFairhurst 