### PR TITLE
Use non-fasta parser for statements (we already do for expressions)

### DIFF
--- a/angular_analyzer_plugin/lib/src/converter.dart
+++ b/angular_analyzer_plugin/lib/src/converter.dart
@@ -337,7 +337,7 @@ class EmbeddedDartParser {
 
   /// Parse the Dart statement starting at the given [token].
   List<Statement> _parseDartStatementsAtToken(Token token) {
-    final parser = new Parser(templateSource, errorListener);
+    final parser = new Parser.withoutFasta(templateSource, errorListener);
     return parser.parseStatements(token);
   }
 


### PR DESCRIPTION
This unblocks the anlayzer from switching the default parser. With the
default constructor, we can get a different instance of parser which
expects a different token stream.