### PR TITLE
First pass at pipe support, check return type of pipes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unpublished
 
+- Typecheck the results of pipe expressions and the existence of a matching
+  pipe. Arguments are not yet typechecked.
+
 ## 0.0.17+3
 
 - Fixed an issue where a cast error from certain top-level getters would crash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unpublished
 
-- Typecheck the results of pipe expressions and the existence of a matching
-  pipe. Arguments are not yet typechecked.
+- Typecheck the results and input of pipe expressions and the existence of a
+  matching pipe. Optional arguments are not yet typechecked.
 
 ## 0.0.17+3
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Template syntax | Validation | Auto-Complete | Navigation | Refactoring
 `<video directiveWithExportAs #moviePlayer="exportAsValue">` | :white_check_mark: existence of exportAs value checked within bound directives | :white_check_mark: | :white_check_mark: | :x:
 `<video ref-movieplayer ...></video><button (click)="movieplayer.play()">` | :white_check_mark: |:white_check_mark: | :white_check_mark: | :x:
 `<p *myUnless="myExpression">...</p>` | :white_check_mark: desugared to `<template [myUnless]="myExpression"><p>...` and checked from there | :white_check_mark: | :white_check_mark: some bugs ,mostly works | :x:
-`<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :x: Pipes are not typechecked yet | :x: | :x: | :x:
+`<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :first_quarter_moon: Pipe name & return type checked, argument types not yet checked| :x: | :x: | :x:
 `<my-component @deferred>` | :x: | :x: | :x: | :x:
 
 Built-in directives | Validation | Auto-Complete | Navigation | Refactoring

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Template syntax | Validation | Auto-Complete | Navigation | Refactoring
 `<video directiveWithExportAs #moviePlayer="exportAsValue">` | :white_check_mark: existence of exportAs value checked within bound directives | :white_check_mark: | :white_check_mark: | :x:
 `<video ref-movieplayer ...></video><button (click)="movieplayer.play()">` | :white_check_mark: |:white_check_mark: | :white_check_mark: | :x:
 `<p *myUnless="myExpression">...</p>` | :white_check_mark: desugared to `<template [myUnless]="myExpression"><p>...` and checked from there | :white_check_mark: | :white_check_mark: some bugs ,mostly works | :x:
-`<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :first_quarter_moon: Pipe name & return type checked, argument types not yet checked| :x: | :x: | :x:
+`<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :first_quarter_moon: Pipe name, input, and return type checked, optional argument types not yet checked| :x: | :x: | :x:
 `<my-component @deferred>` | :x: | :x: | :x: | :x:
 
 Built-in directives | Validation | Auto-Complete | Navigation | Refactoring

--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -62,6 +62,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD,
   AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS,
   AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG,
+  AngularWarningCode.PIPE_NOT_FOUND,
   AngularWarningCode.UNSAFE_BINDING,
   AngularWarningCode.EVENT_REDUCTION_NOT_ALLOWED,
   AngularWarningCode.FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED,
@@ -474,6 +475,13 @@ class AngularWarningCode extends ErrorCode {
   static const PIPE_TRANSFORM_REQ_ONE_ARG = const AngularWarningCode(
       'PIPE_TRANSFORM_REQ_ONE_ARG',
       "'transform' method requires at least one argument");
+
+  /// An error indicating that pipe syntax was used in an angular template, but
+  /// the name of the pipe doesn't match one defined in the component
+  static const PIPE_NOT_FOUND = const AngularWarningCode(
+      'PIPE_NOT_FOUND',
+      "Pipe by name of {0} not found. Did you reference it in your @Component"
+      " configuration?");
 
   /// An error indicating that a security exception will be thrown by this input
   /// binding

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -632,6 +632,9 @@ class AngularDriver
       pipes.add(new Pipe(dirSum.pipeName, dirSum.pipeNameOffset, classElem,
           isPure: dirSum.isPure));
     }
+
+    final pipeExtractor = new PipeExtractor(null, unit.source, null);
+    pipes.forEach(pipeExtractor.loadTransformInformation);
     return pipes;
   }
 
@@ -722,6 +725,7 @@ class AngularDriver
         }
       }
       List<SummarizedDirectiveUseBuilder> dirUseSums;
+      List<SummarizedPipesUseBuilder> pipeUseSums;
       final ngContents = <SummarizedNgContentBuilder>[];
       String templateUrl;
       int templateUrlOffset;
@@ -745,6 +749,12 @@ class AngularDriver
                   ..length = reference.range.length)
                 .toList(),
             (constValue, _) => null);
+
+        pipeUseSums = directive.view.pipeReferences
+            .map((pipe) => new SummarizedPipesUseBuilder()
+              ..name = pipe.identifier
+              ..prefix = pipe.prefix)
+            .toList();
 
         constDirectivesSourceRange = directive.view.directivesStrategy.resolve(
             (references) => null, (constValue, sourceRange) => sourceRange);
@@ -774,6 +784,7 @@ class AngularDriver
         ..exports = exports
         ..usesArrayOfDirectiveReferencesStrategy = dirUseSums != null
         ..subdirectives = dirUseSums
+        ..pipesUse = pipeUseSums
         ..constDirectiveStrategyOffset = constDirectivesSourceRange?.offset
         ..constDirectiveStrategyLength = constDirectivesSourceRange?.length);
     }

--- a/angular_analyzer_plugin/lib/src/pipe_extraction.dart
+++ b/angular_analyzer_plugin/lib/src/pipe_extraction.dart
@@ -28,12 +28,50 @@ class PipeExtractor extends AnnotationProcessorMixin {
         for (final annotationNode in unitMember.metadata) {
           final pipe = _createPipe(unitMember, annotationNode);
           if (pipe != null) {
-            pipes.add(_loadTransformInformation(pipe));
+            pipes.add(loadTransformInformation(pipe));
           }
         }
       }
     }
     return pipes;
+  }
+
+  /// Looks for a 'transform' function, and if found, finds all the
+  /// important type information needed for resolution of pipe.
+  Pipe loadTransformInformation(Pipe pipe) {
+    final classElement = pipe.classElement;
+    if (classElement == null) {
+      return pipe;
+    }
+
+    final transformMethod =
+        classElement.lookUpMethod('transform', classElement.library);
+    if (transformMethod == null) {
+      errorReporter.reportErrorForElement(
+          AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD, classElement);
+      return pipe;
+    }
+
+    pipe.transformReturnType = transformMethod.returnType;
+    final parameters = transformMethod.parameters;
+    if (parameters == null || parameters.isEmpty) {
+      errorReporter.reportErrorForElement(
+          AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG, transformMethod);
+    }
+    for (final parameter in parameters) {
+      // If named or positional
+      if (parameter.parameterKind == analyzer.ParameterKind.NAMED) {
+        errorReporter.reportErrorForElement(
+            AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS, parameter);
+        continue;
+      }
+      if (parameters.first == parameter) {
+        pipe.requiredArgumentType = parameter.type;
+      } else {
+        pipe.optionalArgumentTypes.add(parameter.type);
+      }
+    }
+    return pipe;
   }
 
   /// Returns an Angular [Pipe] for the given [node].
@@ -94,43 +132,5 @@ class PipeExtractor extends AnnotationProcessorMixin {
           isPure: isPure);
     }
     return null;
-  }
-
-  /// Looks for a 'transform' function, and if found, finds all the
-  /// important type information needed for resolution of pipe.
-  Pipe _loadTransformInformation(Pipe pipe) {
-    final classElement = pipe.classElement;
-    if (classElement == null) {
-      return pipe;
-    }
-
-    final transformMethod =
-        classElement.lookUpMethod('transform', classElement.library);
-    if (transformMethod == null) {
-      errorReporter.reportErrorForElement(
-          AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD, classElement);
-      return pipe;
-    }
-
-    pipe.transformReturnType = transformMethod.returnType;
-    final parameters = transformMethod.parameters;
-    if (parameters == null || parameters.isEmpty) {
-      errorReporter.reportErrorForElement(
-          AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG, transformMethod);
-    }
-    for (final parameter in parameters) {
-      // If named or positional
-      if (parameter.parameterKind == analyzer.ParameterKind.NAMED) {
-        errorReporter.reportErrorForElement(
-            AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS, parameter);
-        continue;
-      }
-      if (parameters.first == parameter) {
-        pipe.requiredArgumentType = parameter.type;
-      } else {
-        pipe.optionalArgumentTypes.add(parameter.type);
-      }
-    }
-    return pipe;
   }
 }

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/src/dart/element/element.dart';
+import 'package:analyzer/src/error/codes.dart';
 import 'package:analyzer/src/generated/error_verifier.dart';
 import 'package:analyzer/src/generated/resolver.dart';
 import 'package:analyzer/src/generated/source.dart';
@@ -126,6 +127,14 @@ class AngularResolverVisitor extends _IntermediateResolverVisitor
       } else {
         final matchingPipe = matchingPipes.single;
         exp.staticType = matchingPipe.transformReturnType;
+
+        if (!typeSystem.isAssignableTo(
+            exp.expression.staticType, matchingPipe.requiredArgumentType)) {
+          errorReporter.reportErrorForNode(
+              StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE,
+              exp.expression,
+              [exp.expression.staticType, matchingPipe.requiredArgumentType]);
+        }
       }
     } else {
       _reportUnacceptableNode(exp, "As expression");

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -1565,7 +1565,7 @@ class TestPanel {
 }
 @Pipe('pipe1')
 class Pipe1 extends PipeTransform {
-  String transform(String x) => "";
+  String transform(int x) => "";
 }
 ''');
     final code = r"""
@@ -1635,10 +1635,9 @@ class TestPanel {
   }
 
   // ignore: non_constant_identifier_names
-  @failingTest
   Future test_expression_pipe_in_moustache_typeErrorInput() async {
     _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: [StringPipe])
 class TestPanel {
 }
 @Pipe('stringPipe')
@@ -1652,14 +1651,14 @@ class StringPipe extends PipeTransform {
     _addHtmlSource(code);
     await _resolveSingleTemplate(dartSource);
     assertErrorInCodeAtPosition(
-        StaticWarningCode.UNDEFINED_IDENTIFIER, code, '1');
+        StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE, code, '1');
   }
 
   // ignore: non_constant_identifier_names
   @failingTest
   Future test_expression_pipe_in_moustache_typeErrorOptionalArg() async {
     _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: [StringPipe])
 class TestPanel {
 }
 @Pipe('stringPipe')
@@ -1679,7 +1678,7 @@ class StringPipe extends PipeTransform {
   // ignore: non_constant_identifier_names
   Future test_expression_pipe_in_moustache_typeErrorResult() async {
     _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: const [StringPipe])
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: [StringPipe])
 class TestPanel {
   String takeInt(int x) => "";
 }
@@ -1706,7 +1705,7 @@ class TestPanel {
 }
 @Pipe('pipe1')
 class Pipe1 extends PipeTransform {
-  String transform(String x) => "";
+  int transform(int x) => "";
 }
 ''');
     final code = r"""
@@ -1749,7 +1748,7 @@ class TestPanel {
 }
 @Pipe('pipe1')
 class Pipe1 extends PipeTransform {
-  String transform(String x) => "";
+  List<String> transform(List<String> x) => [];
 }
 ''');
     _addHtmlSource(r"""

--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -1541,9 +1541,13 @@ class NamePanel {
   @Input() int value;
 }
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html',
-    directives: const [NamePanel])
+    directives: const [NamePanel], pipes: [Pipe1])
 class TestPanel {
   int value;
+}
+@Pipe('pipe1')
+class Pipe1 extends PipeTransform {
+  int transform(int x) => "";
 }
 ''');
     _addHtmlSource(r"""
@@ -1556,13 +1560,16 @@ class TestPanel {
   // ignore: non_constant_identifier_names
   Future test_expression_pipe_in_moustache() async {
     _addDartSource(r'''
-@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: [Pipe1])
 class TestPanel {
-  String name = "TestPanel";
+}
+@Pipe('pipe1')
+class Pipe1 extends PipeTransform {
+  String transform(String x) => "";
 }
 ''');
     final code = r"""
-<p>{{((1 | pipe1:(2+2):(5 | pipe2:1:2)) + (2 | pipe3:4:2))}}</p>
+<p>{{((1 | pipe1:(2+2):(5 | pipe1:1:2)) + (2 | pipe1:4:2))}}</p>
 """;
     _addHtmlSource(code);
     await _resolveSingleTemplate(dartSource);
@@ -1570,15 +1577,161 @@ class TestPanel {
   }
 
   // ignore: non_constant_identifier_names
-  Future test_expression_pipe_in_moustache_with_error() async {
+  @failingTest
+  Future test_expression_pipe_in_moustache_extraArg() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html')
 class TestPanel {
-  String name = "TestPanel";
+}
+@Pipe('stringPipe')
+class StringPipe extends PipeTransform {
+  String transform(String x) => "";
 }
 ''');
     final code = r"""
-<p>{{((1 | pipe1:(2+2):(5 | pipe2:1:2)) + (error1 | pipe3:4:2))}}</p>
+{{"" | stringPipe: "extra"}}
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.EXTRA_POSITIONAL_ARGUMENTS, code, '"extra"');
+  }
+
+  // ignore: non_constant_identifier_names
+  @failingTest
+  Future test_expression_pipe_in_moustache_extraExtraArg() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+}
+@Pipe('stringPipe')
+class StringPipe extends PipeTransform {
+  String transform(String x, [String y]) => "";
+}
+''');
+    final code = r"""
+{{"" | stringPipe: "": "extra"}}
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.EXTRA_POSITIONAL_ARGUMENTS, code, '"extra"');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_expression_pipe_in_moustache_noSuchPipe() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+}
+''');
+    final code = r"""
+{{1 | noSuchPipe}}
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.PIPE_NOT_FOUND, code, 'noSuchPipe');
+  }
+
+  // ignore: non_constant_identifier_names
+  @failingTest
+  Future test_expression_pipe_in_moustache_typeErrorInput() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+}
+@Pipe('stringPipe')
+class StringPipe extends PipeTransform {
+  String transform(String x) => "";
+}
+''');
+    final code = r"""
+{{1 | stringPipe}}
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.UNDEFINED_IDENTIFIER, code, '1');
+  }
+
+  // ignore: non_constant_identifier_names
+  @failingTest
+  Future test_expression_pipe_in_moustache_typeErrorOptionalArg() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html')
+class TestPanel {
+}
+@Pipe('stringPipe')
+class StringPipe extends PipeTransform {
+  String transform(String x, [String y]) => "";
+}
+''');
+    final code = r"""
+{{"" | stringPipe: 1}}
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE, code, '1');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_expression_pipe_in_moustache_typeErrorResult() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: const [StringPipe])
+class TestPanel {
+  String takeInt(int x) => "";
+}
+@Pipe('stringPipe')
+class StringPipe extends PipeTransform {
+  String transform(String x) => "";
+}
+''');
+    final code = r"""
+{{takeInt("" | stringPipe)}}
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE,
+        code, '"" | stringPipe');
+  }
+
+  // ignore: non_constant_identifier_names
+  Future test_expression_pipe_in_moustache_with_error() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: [Pipe1])
+class TestPanel {
+  String name = "TestPanel";
+}
+@Pipe('pipe1')
+class Pipe1 extends PipeTransform {
+  String transform(String x) => "";
+}
+''');
+    final code = r"""
+<p>{{((1 | pipe1:(2+2):(5 | pipe1:1:2)) + (error1 | pipe1:4:2))}}</p>
+""";
+    _addHtmlSource(code);
+    await _resolveSingleTemplate(dartSource);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.UNDEFINED_IDENTIFIER, code, "error1");
+  }
+
+  // ignore: non_constant_identifier_names
+  @failingTest
+  Future test_expression_pipe_in_moustache_with_error_inArg() async {
+    _addDartSource(r'''
+@Component(selector: 'test-panel', templateUrl: 'test_panel.html', pipes: [Pipe1])
+class TestPanel {
+}
+@Pipe('pipe1')
+class Pipe1 extends PipeTransform {
+  String transform(String x) => "";
+}
+''');
+    final code = r"""
+<p>{{1 | pipe1:error1}}
 """;
     _addHtmlSource(code);
     await _resolveSingleTemplate(dartSource);
@@ -1590,9 +1743,13 @@ class TestPanel {
   Future test_expression_pipe_in_ngFor() async {
     _addDartSource(r'''
 @Component(selector: 'test-panel', templateUrl: 'test_panel.html',
-    directives: const [NgFor])
+    directives: const [NgFor], pipes: [Pipe1])
 class TestPanel {
   List<String> operators = [];
+}
+@Pipe('pipe1')
+class Pipe1 extends PipeTransform {
+  String transform(String x) => "";
 }
 ''');
     _addHtmlSource(r"""


### PR DESCRIPTION
Some issues with pipe parsing offsets, and deserialization fixed.

Otherwise, we stick the pipe name & args into the AST properties, and
our already existing override of ResolverVisitor can find the synthetic
nodes for pipes and set the propagated type accordingly.

Haven't yet handled arguments -- I likely will run into issues where the
argument expressions need to be hit by each of the visitors. So I may be
better off doing a synthetic function call node that's treated
specially, rather than the previous cast technique which was more for
making an AST node that would result in the right analysis. That's no
longer necessary if we're hijacking analysis, and we want the children
of the pipe (when the pipe has arguments) to be typechecked safely which
means its probably best to make them first-class citizens.