### PR TITLE
First pass at pipe support, check return type of pipes. (#621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unpublished
 
+- Typecheck the results and input of pipe expressions and the existence of a
+  matching pipe. Optional arguments are not yet typechecked.
+
 ## 0.0.17+3
 
 - Fixed an issue where a cast error from certain top-level getters would crash

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Template syntax | Validation | Auto-Complete | Navigation | Refactoring
 `<video directiveWithExportAs #moviePlayer="exportAsValue">` | :white_check_mark: existence of exportAs value checked within bound directives | :white_check_mark: | :white_check_mark: | :x:
 `<video ref-movieplayer ...></video><button (click)="movieplayer.play()">` | :white_check_mark: |:white_check_mark: | :white_check_mark: | :x:
 `<p *myUnless="myExpression">...</p>` | :white_check_mark: desugared to `<template [myUnless]="myExpression"><p>...` and checked from there | :white_check_mark: | :white_check_mark: some bugs ,mostly works | :x:
-`<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :x: Pipes are not typechecked yet | :x: | :x: | :x:
+`<p>Card No.: {{cardNumber \| myCardNumberFormatter}}</p>` | :first_quarter_moon: Pipe name, input, and return type checked, optional argument types not yet checked| :x: | :x: | :x:
 `<my-component @deferred>` | :x: | :x: | :x: | :x:
 
 Built-in directives | Validation | Auto-Complete | Navigation | Refactoring

--- a/angular_analyzer_plugin/lib/errors.dart
+++ b/angular_analyzer_plugin/lib/errors.dart
@@ -62,6 +62,7 @@ const _angularWarningCodeValues = const <AngularWarningCode>[
   AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD,
   AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS,
   AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG,
+  AngularWarningCode.PIPE_NOT_FOUND,
   AngularWarningCode.UNSAFE_BINDING,
   AngularWarningCode.EVENT_REDUCTION_NOT_ALLOWED,
   AngularWarningCode.FUNCTIONAL_DIRECTIVES_CANT_BE_EXPORTED,
@@ -474,6 +475,13 @@ class AngularWarningCode extends ErrorCode {
   static const PIPE_TRANSFORM_REQ_ONE_ARG = const AngularWarningCode(
       'PIPE_TRANSFORM_REQ_ONE_ARG',
       "'transform' method requires at least one argument");
+
+  /// An error indicating that pipe syntax was used in an angular template, but
+  /// the name of the pipe doesn't match one defined in the component
+  static const PIPE_NOT_FOUND = const AngularWarningCode(
+      'PIPE_NOT_FOUND',
+      "Pipe by name of {0} not found. Did you reference it in your @Component"
+      " configuration?");
 
   /// An error indicating that a security exception will be thrown by this input
   /// binding

--- a/angular_analyzer_plugin/lib/src/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/src/angular_driver.dart
@@ -632,6 +632,9 @@ class AngularDriver
       pipes.add(new Pipe(dirSum.pipeName, dirSum.pipeNameOffset, classElem,
           isPure: dirSum.isPure));
     }
+
+    final pipeExtractor = new PipeExtractor(null, unit.source, null);
+    pipes.forEach(pipeExtractor.loadTransformInformation);
     return pipes;
   }
 
@@ -722,6 +725,7 @@ class AngularDriver
         }
       }
       List<SummarizedDirectiveUseBuilder> dirUseSums;
+      List<SummarizedPipesUseBuilder> pipeUseSums;
       final ngContents = <SummarizedNgContentBuilder>[];
       String templateUrl;
       int templateUrlOffset;
@@ -745,6 +749,12 @@ class AngularDriver
                   ..length = reference.range.length)
                 .toList(),
             (constValue, _) => null);
+
+        pipeUseSums = directive.view.pipeReferences
+            .map((pipe) => new SummarizedPipesUseBuilder()
+              ..name = pipe.identifier
+              ..prefix = pipe.prefix)
+            .toList();
 
         constDirectivesSourceRange = directive.view.directivesStrategy.resolve(
             (references) => null, (constValue, sourceRange) => sourceRange);
@@ -774,6 +784,7 @@ class AngularDriver
         ..exports = exports
         ..usesArrayOfDirectiveReferencesStrategy = dirUseSums != null
         ..subdirectives = dirUseSums
+        ..pipesUse = pipeUseSums
         ..constDirectiveStrategyOffset = constDirectivesSourceRange?.offset
         ..constDirectiveStrategyLength = constDirectivesSourceRange?.length);
     }

--- a/angular_analyzer_plugin/lib/src/pipe_extraction.dart
+++ b/angular_analyzer_plugin/lib/src/pipe_extraction.dart
@@ -28,12 +28,50 @@ class PipeExtractor extends AnnotationProcessorMixin {
         for (final annotationNode in unitMember.metadata) {
           final pipe = _createPipe(unitMember, annotationNode);
           if (pipe != null) {
-            pipes.add(_loadTransformInformation(pipe));
+            pipes.add(loadTransformInformation(pipe));
           }
         }
       }
     }
     return pipes;
+  }
+
+  /// Looks for a 'transform' function, and if found, finds all the
+  /// important type information needed for resolution of pipe.
+  Pipe loadTransformInformation(Pipe pipe) {
+    final classElement = pipe.classElement;
+    if (classElement == null) {
+      return pipe;
+    }
+
+    final transformMethod =
+        classElement.lookUpMethod('transform', classElement.library);
+    if (transformMethod == null) {
+      errorReporter.reportErrorForElement(
+          AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD, classElement);
+      return pipe;
+    }
+
+    pipe.transformReturnType = transformMethod.returnType;
+    final parameters = transformMethod.parameters;
+    if (parameters == null || parameters.isEmpty) {
+      errorReporter.reportErrorForElement(
+          AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG, transformMethod);
+    }
+    for (final parameter in parameters) {
+      // If named or positional
+      if (parameter.parameterKind == analyzer.ParameterKind.NAMED) {
+        errorReporter.reportErrorForElement(
+            AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS, parameter);
+        continue;
+      }
+      if (parameters.first == parameter) {
+        pipe.requiredArgumentType = parameter.type;
+      } else {
+        pipe.optionalArgumentTypes.add(parameter.type);
+      }
+    }
+    return pipe;
   }
 
   /// Returns an Angular [Pipe] for the given [node].
@@ -94,43 +132,5 @@ class PipeExtractor extends AnnotationProcessorMixin {
           isPure: isPure);
     }
     return null;
-  }
-
-  /// Looks for a 'transform' function, and if found, finds all the
-  /// important type information needed for resolution of pipe.
-  Pipe _loadTransformInformation(Pipe pipe) {
-    final classElement = pipe.classElement;
-    if (classElement == null) {
-      return pipe;
-    }
-
-    final transformMethod =
-        classElement.lookUpMethod('transform', classElement.library);
-    if (transformMethod == null) {
-      errorReporter.reportErrorForElement(
-          AngularWarningCode.PIPE_REQUIRES_TRANSFORM_METHOD, classElement);
-      return pipe;
-    }
-
-    pipe.transformReturnType = transformMethod.returnType;
-    final parameters = transformMethod.parameters;
-    if (parameters == null || parameters.isEmpty) {
-      errorReporter.reportErrorForElement(
-          AngularWarningCode.PIPE_TRANSFORM_REQ_ONE_ARG, transformMethod);
-    }
-    for (final parameter in parameters) {
-      // If named or positional
-      if (parameter.parameterKind == analyzer.ParameterKind.NAMED) {
-        errorReporter.reportErrorForElement(
-            AngularWarningCode.PIPE_TRANSFORM_NO_NAMED_ARGS, parameter);
-        continue;
-      }
-      if (parameters.first == parameter) {
-        pipe.requiredArgumentType = parameter.type;
-      } else {
-        pipe.optionalArgumentTypes.add(parameter.type);
-      }
-    }
-    return pipe;
   }
 }

--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -1,5 +1,3 @@
-library angular2.src.analysis.analyzer_plugin.src.resolver;
-
 import 'dart:collection';
 
 import 'package:analyzer/dart/ast/ast.dart' hide Directive;
@@ -10,6 +8,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/src/dart/element/element.dart';
+import 'package:analyzer/src/error/codes.dart';
 import 'package:analyzer/src/generated/error_verifier.dart';
 import 'package:analyzer/src/generated/resolver.dart';
 import 'package:analyzer/src/generated/source.dart';
@@ -107,10 +106,11 @@ class AngularErrorVerifier extends _IntermediateErrorVerifier
 class AngularResolverVisitor extends _IntermediateResolverVisitor
     with ReportUnacceptableNodesMixin {
   final bool acceptAssignment;
+  final List<Pipe> pipes;
 
   AngularResolverVisitor(LibraryElement library, Source source,
       TypeProvider typeProvider, AnalysisErrorListener errorListener,
-      {@required this.acceptAssignment})
+      {@required this.acceptAssignment, @required this.pipes})
       : super(library, source, typeProvider, errorListener);
 
   @override
@@ -118,6 +118,24 @@ class AngularResolverVisitor extends _IntermediateResolverVisitor
     // This means we generated this in a pipe, and its OK.
     if (exp.asOperator.offset == 0) {
       super.visitAsExpression(exp);
+      final pipeName = exp.getProperty<SimpleIdentifier>('_ng_pipeName');
+      final matchingPipes =
+          pipes.where((pipe) => pipe.pipeName == pipeName.name);
+      if (matchingPipes.length != 1) {
+        errorReporter.reportErrorForNode(
+            AngularWarningCode.PIPE_NOT_FOUND, pipeName, [pipeName]);
+      } else {
+        final matchingPipe = matchingPipes.single;
+        exp.staticType = matchingPipe.transformReturnType;
+
+        if (!typeSystem.isAssignableTo(
+            exp.expression.staticType, matchingPipe.requiredArgumentType)) {
+          errorReporter.reportErrorForNode(
+              StaticWarningCode.ARGUMENT_TYPE_NOT_ASSIGNABLE,
+              exp.expression,
+              [exp.expression.staticType, matchingPipe.requiredArgumentType]);
+        }
+      }
     } else {
       _reportUnacceptableNode(exp, "As expression");
     }
@@ -1207,6 +1225,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
   static final RegExp _cssIdentifierRegexp =
       new RegExp(r"^(-?[a-zA-Z_]|\\.)([a-zA-Z0-9\-_]|\\.)*$");
   final Map<String, InputElement> standardHtmlAttributes;
+  final List<Pipe> pipes;
   List<AbstractDirective> directives;
   View view;
   Template template;
@@ -1223,6 +1242,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
 
   SingleScopeResolver(
       this.standardHtmlAttributes,
+      this.pipes,
       this.view,
       this.template,
       this.templateSource,
@@ -1466,7 +1486,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
     }
     final resolver = new AngularResolverVisitor(
         library, templateSource, typeProvider, errorListener,
-        acceptAssignment: acceptAssignment);
+        acceptAssignment: acceptAssignment, pipes: pipes);
     // fill the name scope
     final classScope = new ClassScope(resolver.nameScope, classElement);
     final localScope = new EnclosedScope(classScope);
@@ -1787,6 +1807,7 @@ class TemplateResolver {
         // Resolve the scopes
         ..accept(new SingleScopeResolver(
             standardHtmlAttributes,
+            view.pipes,
             view,
             template,
             templateSource,


### PR DESCRIPTION
* First pass at pipe support, check return+input type of pipes.

Some issues with pipe parsing offsets, and deserialization fixed.

Otherwise, we stick the pipe name & args into the AST properties, and
our already existing override of ResolverVisitor can find the synthetic
nodes for pipes and set the propagated type accordingly.

Haven't yet handled optional arguments -- I likely will run into issues where the
argument expressions need to be hit by each of the visitors. So I may be
better off doing a synthetic function call node that's treated
specially, rather than the previous cast technique which was more for
making an AST node that would result in the right analysis. That's no
longer necessary if we're hijacking analysis, and we want the children
of the pipe (when the pipe has optional arguments) to be typechecked safely which
means its probably best to make them first-class citizens.