### PR TITLE
Stop passing "strong" argument to SummaryBuilder constructor.

### DIFF
--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -673,7 +673,7 @@ class MockSdk implements DartSdk {
   List<int> _computeLinkedBundleBytes() {
     final librarySources =
         sdkLibraries.map((library) => mapDartUri(library.shortName)).toList();
-    return new SummaryBuilder(librarySources, context, true).build();
+    return new SummaryBuilder(librarySources, context).build();
   }
 }
 


### PR DESCRIPTION
This argument is no longer needed, since the analyzer only supports
strong mode now.  It will be removed in a future version of the
analyzer, so we should stop passing it in.