### PR TITLE
Remove argument in CompilationUnitElementImpl constructor invocation.

### DIFF
--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -406,9 +406,8 @@ class DartVariableManager {
       int offset, String name, DartType type) {
     // ensure artificial Dart elements in the template source
     if (htmlMethodElement == null) {
-      htmlCompilationUnitElement =
-          new CompilationUnitElementImpl(templateSource.fullName)
-            ..source = templateSource;
+      htmlCompilationUnitElement = new CompilationUnitElementImpl()
+        ..source = templateSource;
       htmlClassElement = new ClassElementImpl('AngularTemplateClass', -1);
       htmlCompilationUnitElement.types = <ClassElement>[htmlClassElement];
       htmlMethodElement = new MethodElementImpl('angularTemplateMethod', -1);


### PR DESCRIPTION
The corresponding parameter was removed in
https://github.com/dart-lang/sdk/commit/1bceca91b06ac7311e92cd0da0c29b9c8f09c189.