### PR TITLE
Remove reference to InheritanceManager from AngularErrorVerifier.

### DIFF
--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -45,17 +45,12 @@ class AngularErrorVerifier extends _IntermediateErrorVerifier
   @override
   TypeProvider typeProvider;
 
-  AngularErrorVerifier(
-      ErrorReporter errorReporter,
-      LibraryElement library,
-      TypeProvider typeProvider,
-      InheritanceManager inheritanceManager,
-      InheritanceManager2 inheritanceManager2,
+  AngularErrorVerifier(ErrorReporter errorReporter, LibraryElement library,
+      TypeProvider typeProvider, InheritanceManager2 inheritanceManager2,
       {@required this.acceptAssignment})
       : errorReporter = errorReporter,
         typeProvider = typeProvider,
-        super(errorReporter, library, typeProvider, inheritanceManager,
-            inheritanceManager2);
+        super(errorReporter, library, typeProvider, inheritanceManager2);
 
   @override
   void visitAssignmentExpression(AssignmentExpression exp) {
@@ -1567,8 +1562,8 @@ class SingleScopeResolver extends AngularScopeVisitor {
     // do resolve
     astNode.accept(resolver);
     // verify
-    final verifier = new AngularErrorVerifier(errorReporter, library,
-        typeProvider, new InheritanceManager(library), inheritanceManager2,
+    final verifier = new AngularErrorVerifier(
+        errorReporter, library, typeProvider, inheritanceManager2,
         acceptAssignment: acceptAssignment)
       ..enclosingClass = classElement;
     astNode.accept(verifier);
@@ -1928,10 +1923,8 @@ class _IntermediateErrorVerifier extends ErrorVerifier {
     ErrorReporter errorReporter,
     LibraryElement library,
     TypeProvider typeProvider,
-    InheritanceManager inheritanceManager,
     InheritanceManager2 inheritanceManager2,
-  ) : super(errorReporter, library, typeProvider, inheritanceManager,
-            inheritanceManager2, false);
+  ) : super(errorReporter, library, typeProvider, inheritanceManager2, false);
 }
 
 /// Workaround for "This mixin application is invalid because all of the


### PR DESCRIPTION
This is needed to account for the changes to ErrorVerifier in
https://github.com/dart-lang/sdk/commit/fab5d0a50d1f26d3b7e1a7596707bc09b9a49b33.