### PR TITLE
Remove unnecessary explicit cast.

### DIFF
--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -1644,8 +1644,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
           library, view.source, typeProvider, errorListener);
       astNode.accept(visitor);
     }
-    final inheritanceManager2 =
-        new InheritanceManager2(typeSystem as StrongTypeSystemImpl);
+    final inheritanceManager2 = new InheritanceManager2(typeSystem);
     final resolver = new AngularResolverVisitor(inheritanceManager2, library,
         templateSource, typeProvider, errorListener,
         pipes: pipes);


### PR DESCRIPTION
Removing this cast allows the analyzer to rename its private class
StrongTypeSystemImpl without causing a breakage.