### PR TITLE
Remove an unnecessary and problematic cast

### DIFF
--- a/angular_analyzer_plugin/lib/src/resolver.dart
+++ b/angular_analyzer_plugin/lib/src/resolver.dart
@@ -1664,8 +1664,7 @@ class SingleScopeResolver extends AngularScopeVisitor {
           library, view.source, typeProvider, errorListener);
       astNode.accept(visitor);
     }
-    final inheritanceManager2 =
-        new InheritanceManager2(typeSystem as StrongTypeSystemImpl);
+    final inheritanceManager2 = new InheritanceManager2(typeSystem);
     final resolver = new AngularResolverVisitor(inheritanceManager2, library,
         templateSource, typeProvider, errorListener,
         pipes: pipes);


### PR DESCRIPTION
The cast refers to a private class that is being renamed. Removing the cast doesn't have any effect because the invoked method only requires a `TypeProvider`.