### PR TITLE
Fix declaration casts, now that implicit downcasts are off.

### DIFF
--- a/angular_analyzer_plugin/lib/plugin.dart
+++ b/angular_analyzer_plugin/lib/plugin.dart
@@ -153,7 +153,7 @@ class AngularAnalyzerPlugin extends ServerPlugin
   @override
   Future<NavigationRequest> getNavigationRequest(
       plugin.AnalysisGetNavigationParams parameters) async {
-    final AngularDriver driver = driverForPath(parameters.file);
+    final driver = driverForPath(parameters.file) as AngularDriver;
     final isHtml = parameters.file.endsWith('.html');
     final result = isHtml
         ? await driver.requestHtmlResult(parameters.file)

--- a/angular_analyzer_plugin/lib/src/completion.dart
+++ b/angular_analyzer_plugin/lib/src/completion.dart
@@ -1011,7 +1011,7 @@ class TemplateCompleter {
         continue;
       }
 
-      final Component component = directive;
+      final component = directive as Component;
       final view = component?.view;
       if (view == null) {
         continue;

--- a/angular_analyzer_plugin/lib/src/directive_linking.dart
+++ b/angular_analyzer_plugin/lib/src/directive_linking.dart
@@ -849,7 +849,7 @@ class ExportLinker {
       return;
     }
 
-    final Component component = directive;
+    final component = directive as Component;
 
     if (component?.view?.exports == null) {
       return;

--- a/angular_analyzer_plugin/lib/src/navigation.dart
+++ b/angular_analyzer_plugin/lib/src/navigation.dart
@@ -18,7 +18,7 @@ class AngularNavigation implements NavigationContributor {
       NavigationRequest baseRequest, NavigationCollector collector,
       {bool templatesOnly: false}) {
     // cast this
-    final AngularNavigationRequest request = baseRequest;
+    final request = baseRequest as AngularNavigationRequest;
     final length = request.length;
     final offset = request.offset;
     final result = request.result;

--- a/angular_analyzer_plugin/lib/src/standard_components.dart
+++ b/angular_analyzer_plugin/lib/src/standard_components.dart
@@ -86,7 +86,7 @@ class BuildStandardHtmlComponentsVisitor extends RecursiveAstVisitor {
 
     missingOutputs.forEach((name, type) {
       final namespace = unit.element.library.publicNamespace;
-      final ClassElement eventClass = namespace.get(type);
+      final eventClass = namespace.get(type) as ClassElement;
       events[name] = new OutputElement(
           name, null, null, unit.element.source, null, null, eventClass.type);
     });

--- a/angular_analyzer_plugin/test/abstract_angular.dart
+++ b/angular_analyzer_plugin/test/abstract_angular.dart
@@ -28,15 +28,15 @@ import 'mock_sdk.dart';
 
 void assertComponentReference(
     ResolvedRange resolvedRange, Component component) {
-  final ElementNameSelector selector = component.selector;
+  final selector = component.selector as ElementNameSelector;
   final element = resolvedRange.element;
   expect(element, selector.nameElement);
   expect(resolvedRange.range.length, selector.nameElement.name.length);
 }
 
 PropertyAccessorElement assertGetter(ResolvedRange resolvedRange) {
-  final PropertyAccessorElement element =
-      (resolvedRange.element as DartElement).element;
+  final element =
+      (resolvedRange.element as DartElement).element as PropertyAccessorElement;
   expect(element.isGetter, isTrue);
   return element;
 }

--- a/angular_analyzer_plugin/test/angular_driver_test.dart
+++ b/angular_analyzer_plugin/test/angular_driver_test.dart
@@ -966,14 +966,14 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
 
     expect(children.directive, equals(directives[1]));
 
     final childs = component.contentChilds;
     expect(childs, hasLength(1));
     expect(childs.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType child = childs.first.query;
+    final child = childs.first.query as DirectiveQueriedChildType;
 
     expect(child.directive, equals(directives[1]));
     // validate
@@ -1000,7 +1000,7 @@ class ContentChildComp {}
     final childs = component.contentChilds;
     expect(childs, hasLength(1));
     expect(childs.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType child = childs.first.query;
+    final child = childs.first.query as DirectiveQueriedChildType;
 
     expect(child.directive, equals(directives[1]));
     // validate
@@ -1027,7 +1027,7 @@ class ContentChildComp {}
     final childs = component.contentChilds;
     expect(childs, hasLength(1));
     expect(childs.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType child = childs.first.query;
+    final child = childs.first.query as DirectiveQueriedChildType;
 
     expect(child.directive, equals(directives[1]));
     // validate
@@ -1077,7 +1077,7 @@ class ContentChildComp {}
     final childs = component.contentChilds;
     expect(childs, hasLength(1));
     expect(childs.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType child = childs.first.query;
+    final child = childs.first.query as DirectiveQueriedChildType;
     expect(child.directive, equals(directives[1]));
 
     // validate
@@ -1151,7 +1151,7 @@ class ContentChildCompSub extends ContentChildComp {}
     final childs = component.contentChilds;
     expect(childs, hasLength(1));
     expect(childs.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType child = childs.first.query;
+    final child = childs.first.query as DirectiveQueriedChildType;
     expect(child.directive, equals(directives[1]));
 
     // validate
@@ -1237,43 +1237,44 @@ class ContentChildComp {}
     final childs = component.contentChilds;
     expect(childs, hasLength(6));
 
-    final LetBoundQueriedChildType childDirective = childs
+    final childDirective = childs
         .singleWhere((c) => c.field.fieldName == "contentChildDirective")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childDirective, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childDirective.letBoundName, equals("foo"));
     expect(childDirective.containerType.toString(), equals("ContentChildComp"));
 
-    final LetBoundQueriedChildType childTemplate =
-        childs.singleWhere((c) => c.field.fieldName == "contentChildTpl").query;
+    final childTemplate = childs
+        .singleWhere((c) => c.field.fieldName == "contentChildTpl")
+        .query as LetBoundQueriedChildType;
     expect(childTemplate, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childTemplate.letBoundName, equals("fooTpl"));
     expect(childTemplate.containerType.toString(), equals("TemplateRef"));
 
-    final LetBoundQueriedChildType childElement = childs
+    final childElement = childs
         .singleWhere((c) => c.field.fieldName == "contentChildElem")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childElement, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childElement.letBoundName, equals("fooElem"));
     expect(childElement.containerType.toString(), equals("Element"));
 
-    final LetBoundQueriedChildType childHtmlElement = childs
+    final childHtmlElement = childs
         .singleWhere((c) => c.field.fieldName == "contentChildHtmlElem")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childHtmlElement, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childHtmlElement.letBoundName, equals("fooHtmlElem"));
     expect(childHtmlElement.containerType.toString(), equals("HtmlElement"));
 
-    final LetBoundQueriedChildType childElementRef = childs
+    final childElementRef = childs
         .singleWhere((c) => c.field.fieldName == "contentChildElemRef")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childElementRef, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childElementRef.letBoundName, equals("fooElemRef"));
     expect(childElementRef.containerType.toString(), equals("ElementRef"));
 
-    final LetBoundQueriedChildType childDynamic = childs
+    final childDynamic = childs
         .singleWhere((c) => c.field.fieldName == "contentChildDynamic")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childDynamic, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childDynamic.letBoundName, equals("fooDynamic"));
     expect(childDynamic.containerType.toString(), equals("dynamic"));
@@ -1303,7 +1304,7 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
 
     expect(children.directive, equals(directives[1]));
     // validate
@@ -1331,7 +1332,7 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
 
     expect(children.directive, equals(directives[1]));
     // validate
@@ -1359,7 +1360,7 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
 
     expect(children.directive, equals(directives[1]));
     // validate
@@ -1387,7 +1388,7 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
 
     expect(children.directive, equals(directives[1]));
     // validate
@@ -1437,7 +1438,7 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
 
     expect(children.directive, equals(directives[1]));
     // validate
@@ -1487,7 +1488,7 @@ class ContentChildComp {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
     expect(children.directive, equals(directives[1]));
 
     // validate
@@ -1521,7 +1522,7 @@ abstract class CannotSubtypeList extends List {}
     expect(childrens, hasLength(1));
     expect(
         childrens.first.query, const isInstanceOf<DirectiveQueriedChildType>());
-    final DirectiveQueriedChildType children = childrens.first.query;
+    final children = childrens.first.query as DirectiveQueriedChildType;
     expect(children.directive, equals(directives[1]));
 
     // validate
@@ -1638,52 +1639,52 @@ class ContentChildComp {}
     final childrens = component.contentChildren;
     expect(childrens, hasLength(7));
 
-    final LetBoundQueriedChildType childrenDirective = childrens
+    final childrenDirective = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildDirective")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenDirective, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenDirective.letBoundName, equals("foo"));
     expect(
         childrenDirective.containerType.toString(), equals("ContentChildComp"));
 
-    final LetBoundQueriedChildType childrenTemplate = childrens
+    final childrenTemplate = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildTpl")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenTemplate, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenTemplate.letBoundName, equals("fooTpl"));
     expect(childrenTemplate.containerType.toString(), equals("TemplateRef"));
 
-    final LetBoundQueriedChildType childrenElement = childrens
+    final childrenElement = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildElem")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenElement, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenElement.letBoundName, equals("fooElem"));
     expect(childrenElement.containerType.toString(), equals("Element"));
 
-    final LetBoundQueriedChildType childrenHtmlElement = childrens
+    final childrenHtmlElement = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildHtmlElem")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenHtmlElement, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenHtmlElement.letBoundName, equals("fooHtmlElem"));
     expect(childrenHtmlElement.containerType.toString(), equals("HtmlElement"));
 
-    final LetBoundQueriedChildType childrenElementRef = childrens
+    final childrenElementRef = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildElemRef")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenElementRef, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenElementRef.letBoundName, equals("fooElemRef"));
     expect(childrenElementRef.containerType.toString(), equals("ElementRef"));
 
-    final LetBoundQueriedChildType childrenDynamic = childrens
+    final childrenDynamic = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildDynamic")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenDynamic, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenDynamic.letBoundName, equals("fooDynamic"));
     expect(childrenDynamic.containerType.toString(), equals("dynamic"));
 
-    final LetBoundQueriedChildType childrenQueryList = childrens
+    final childrenQueryList = childrens
         .singleWhere((c) => c.field.fieldName == "contentChildQueryList")
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(childrenQueryList, const isInstanceOf<LetBoundQueriedChildType>());
     expect(childrenQueryList.letBoundName, equals("fooQueryList"));
     expect(
@@ -1776,22 +1777,23 @@ class ComponentA {
     final children = component.contentChilds;
     expect(children, hasLength(3));
 
-    final LetBoundQueriedChildType objectNotElem =
-        children.singleWhere((c) => c.field.fieldName == 'objectNotElem').query;
+    final objectNotElem = children
+        .singleWhere((c) => c.field.fieldName == 'objectNotElem')
+        .query as LetBoundQueriedChildType;
     expect(objectNotElem, const isInstanceOf<LetBoundQueriedChildType>());
     expect(objectNotElem.letBoundName, equals('el'));
     expect(objectNotElem.containerType.toString(), equals('Element'));
 
-    final LetBoundQueriedChildType elemNotHtmlElem = children
+    final elemNotHtmlElem = children
         .singleWhere((c) => c.field.fieldName == 'elemNotHtmlElem')
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(elemNotHtmlElem, const isInstanceOf<LetBoundQueriedChildType>());
     expect(elemNotHtmlElem.letBoundName, equals('el'));
     expect(elemNotHtmlElem.containerType.toString(), equals('HtmlElement'));
 
-    final LetBoundQueriedChildType objectNotHtmlElem = children
+    final objectNotHtmlElem = children
         .singleWhere((c) => c.field.fieldName == 'objectNotHtmlElem')
-        .query;
+        .query as LetBoundQueriedChildType;
     expect(objectNotHtmlElem, const isInstanceOf<LetBoundQueriedChildType>());
     expect(objectNotHtmlElem.letBoundName, equals('el'));
     expect(objectNotHtmlElem.containerType.toString(), equals('HtmlElement'));
@@ -3124,7 +3126,7 @@ class ComponentA {
 ''';
     final source = newSource('/test.dart', code);
     await getDirectives(source);
-    final Component component = directives.first;
+    final component = directives.first as Component;
     expect(component.view, isNotNull);
     expect(component.view.exports, hasLength(3));
     {
@@ -3959,7 +3961,7 @@ class ComponentA {
 ''';
     final source = newSource('/test.dart', code);
     await getDirectives(source);
-    final Component component = directives.first;
+    final component = directives.first as Component;
     expect(component.view, isNotNull);
     expect(component.view.exports, hasLength(2));
     {
@@ -4740,7 +4742,7 @@ class ComponentA {
 ''';
     final source = newSource('/test.dart', code);
     await getDirectives(source);
-    final Component component = directives.first;
+    final component = directives.first as Component;
     expect(component.view, isNotNull);
     expect(component.view.exports, hasLength(3));
     {
@@ -5038,7 +5040,7 @@ class ComponentA {
 ''';
     final source = newSource('/test.dart', code);
     await getDirectives(source);
-    final Component component = directives.first;
+    final component = directives.first as Component;
     expect(component.view, isNotNull);
     expect(component.view.exports, hasLength(2));
     {

--- a/angular_analyzer_plugin/test/element_assert.dart
+++ b/angular_analyzer_plugin/test/element_assert.dart
@@ -90,7 +90,7 @@ class ElementAssert {
 
   DartElementAssert get dart {
     expect(element, const isInstanceOf<DartElement>());
-    final DartElement dartElement = element;
+    final dartElement = element as DartElement;
     return new DartElementAssert(dartElement.element, _dartSource, _dartCode);
   }
 

--- a/angular_analyzer_plugin/test/mock_sdk.dart
+++ b/angular_analyzer_plugin/test/mock_sdk.dart
@@ -545,7 +545,7 @@ class MockSdk implements DartSdk {
       : provider = resourceProvider ?? new resource.MemoryResourceProvider(),
         sdkLibraries = dartAsync ? _LIBRARIES : [_LIB_CORE],
         uriMap = dartAsync ? FULL_URI_MAP : NO_ASYNC_URI_MAP {
-    for (_MockSdkLibrary library in sdkLibraries) {
+    for (var library in sdkLibraries.cast<_MockSdkLibrary>()) {
       provider.newFile(provider.convertPath(library.path), library.content);
       library.parts.forEach((path, content) {
         provider.newFile(provider.convertPath(path), content);
@@ -592,7 +592,7 @@ class MockSdk implements DartSdk {
       final libraryPath = provider.convertPath(library.path);
       if (filePath == libraryPath) {
         try {
-          final resource.File file = provider.getResource(filePath);
+          final file = provider.getResource(filePath) as resource.File;
           final dartUri = Uri.parse(library.shortName);
           return file.createSource(dartUri);
         } catch (exception) {
@@ -606,7 +606,7 @@ class MockSdk implements DartSdk {
         final pathInLibrary = filePath.substring(libraryRootPath.length);
         final uriStr = '${library.shortName}/$pathInLibrary';
         try {
-          final resource.File file = provider.getResource(filePath);
+          final file = provider.getResource(filePath) as resource.File;
           final dartUri = Uri.parse(uriStr);
           return file.createSource(dartUri);
         } catch (exception) {
@@ -647,8 +647,8 @@ class MockSdk implements DartSdk {
   Source mapDartUri(String dartUri) {
     final path = uriMap[dartUri];
     if (path != null) {
-      final resource.File file =
-          provider.getResource(provider.convertPath(path));
+      final file =
+          provider.getResource(provider.convertPath(path)) as resource.File;
       final uri = new Uri(scheme: 'dart', path: dartUri.substring(5));
       return file.createSource(uri);
     }

--- a/angular_analyzer_plugin/test/plugin_test.dart
+++ b/angular_analyzer_plugin/test/plugin_test.dart
@@ -139,7 +139,7 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
   // ignore: non_constant_identifier_names
   void test_createAnalysisDriver() {
     enableAnalyzerPluginsAngular();
-    final AngularDriver driver = plugin.createAnalysisDriver(root);
+    final driver = plugin.createAnalysisDriver(root) as AngularDriver;
 
     expect(driver, isNotNull);
     expect(driver.byteStore, isNotNull);
@@ -148,7 +148,7 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
   // ignore: non_constant_identifier_names
   void test_createAnalysisDriver_containsDartDriver() {
     enableAnalyzerPluginsAngular();
-    final AngularDriver driver = plugin.createAnalysisDriver(root);
+    final driver = plugin.createAnalysisDriver(root) as AngularDriver;
 
     expect(driver, isNotNull);
     expect(driver.dartDriver, isNotNull);
@@ -167,7 +167,7 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
       '  - bar',
       '  - baz',
     ]);
-    final AngularDriver driver = plugin.createAnalysisDriver(root);
+    final driver = plugin.createAnalysisDriver(root) as AngularDriver;
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
@@ -183,7 +183,7 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
       '  - bar',
       '  - baz',
     ]);
-    final AngularDriver driver = plugin.createAnalysisDriver(root);
+    final driver = plugin.createAnalysisDriver(root) as AngularDriver;
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);
@@ -194,7 +194,7 @@ class PluginIntegrationTest extends AnalysisOptionsUtilsBase {
   // ignore: non_constant_identifier_names
   void test_createAnalysisDriver_defaultOptions() {
     enableAnalyzerPluginsAngular();
-    final AngularDriver driver = plugin.createAnalysisDriver(root);
+    final driver = plugin.createAnalysisDriver(root) as AngularDriver;
 
     expect(driver, isNotNull);
     expect(driver.options, isNotNull);

--- a/angular_analyzer_plugin/test/selector_test.dart
+++ b/angular_analyzer_plugin/test/selector_test.dart
@@ -930,11 +930,11 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_and() {
-    final AndSelector selector =
-        new SelectorParser(source, 10, '[ng-for][ng-for-of]').parse();
+    final selector = new SelectorParser(source, 10, '[ng-for][ng-for-of]')
+        .parse() as AndSelector;
     expect(selector.selectors, hasLength(2));
     {
-      final AttributeSelector subSelector = selector.selectors[0];
+      final subSelector = selector.selectors[0] as AttributeSelector;
       final nameElement = subSelector.nameElement;
       expect(nameElement.source, source);
       expect(nameElement.name, 'ng-for');
@@ -942,7 +942,7 @@ class SelectorParserTest {
       expect(nameElement.nameLength, 'ng-for'.length);
     }
     {
-      final AttributeSelector subSelector = selector.selectors[1];
+      final subSelector = selector.selectors[1] as AttributeSelector;
       final nameElement = subSelector.nameElement;
       expect(nameElement.source, source);
       expect(nameElement.name, 'ng-for-of');
@@ -977,8 +977,8 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_attribute_hasValue() {
-    final AttributeSelector selector =
-        new SelectorParser(source, 10, '[kind=pretty]').parse();
+    final selector = new SelectorParser(source, 10, '[kind=pretty]').parse()
+        as AttributeSelector;
     {
       final nameElement = selector.nameElement;
       expect(nameElement.source, source);
@@ -991,12 +991,12 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_attribute_hasValueWithQuotes() {
-    final AndSelector selector =
+    final selector =
         new SelectorParser(source, 10, '''[single='quotes'][double="quotes"]''')
-            .parse();
+            .parse() as AndSelector;
     expect(selector.selectors, hasLength(2));
     {
-      final AttributeSelector subSelector = selector.selectors[0];
+      final subSelector = selector.selectors[0] as AttributeSelector;
       {
         final nameElement = subSelector.nameElement;
         expect(nameElement.source, source);
@@ -1006,7 +1006,7 @@ class SelectorParserTest {
       expect(subSelector.value, 'quotes');
     }
     {
-      final AttributeSelector subSelector = selector.selectors[1];
+      final subSelector = selector.selectors[1] as AttributeSelector;
       {
         final nameElement = subSelector.nameElement;
         expect(nameElement.source, source);
@@ -1019,8 +1019,8 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_attribute_hasWildcard() {
-    final AttributeContainsSelector selector =
-        new SelectorParser(source, 10, '[kind*=pretty]').parse();
+    final selector = new SelectorParser(source, 10, '[kind*=pretty]').parse()
+        as AttributeContainsSelector;
     {
       final nameElement = selector.nameElement;
       expect(nameElement.source, source);
@@ -1033,8 +1033,8 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_attribute_noValue() {
-    final AttributeSelector selector =
-        new SelectorParser(source, 10, '[ng-for]').parse();
+    final selector =
+        new SelectorParser(source, 10, '[ng-for]').parse() as AttributeSelector;
     {
       final nameElement = selector.nameElement;
       expect(nameElement.source, source);
@@ -1059,24 +1059,24 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_attribute_startsWith() {
-    final AttributeStartsWithSelector selector =
-        new SelectorParser(source, 10, '[foo^=bar]').parse();
+    final selector = new SelectorParser(source, 10, '[foo^=bar]').parse()
+        as AttributeStartsWithSelector;
     expect(selector.nameElement.name, 'foo');
     expect(selector.value, 'bar');
   }
 
   // ignore: non_constant_identifier_names
   void test_attribute_startsWith_quoted() {
-    final AttributeStartsWithSelector selector =
-        new SelectorParser(source, 10, '[foo^="bar"]').parse();
+    final selector = new SelectorParser(source, 10, '[foo^="bar"]').parse()
+        as AttributeStartsWithSelector;
     expect(selector.nameElement.name, 'foo');
     expect(selector.value, 'bar');
   }
 
   // ignore: non_constant_identifier_names
   void test_attribute_textRegex() {
-    final AttributeValueRegexSelector selector =
-        new SelectorParser(source, 10, '[*=/pretty/]').parse();
+    final selector = new SelectorParser(source, 10, '[*=/pretty/]').parse()
+        as AttributeValueRegexSelector;
     expect(selector.regexpStr, 'pretty');
   }
 
@@ -1092,8 +1092,8 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_class() {
-    final ClassSelector selector =
-        new SelectorParser(source, 10, '.nice').parse();
+    final selector =
+        new SelectorParser(source, 10, '.nice').parse() as ClassSelector;
     final nameElement = selector.nameElement;
     expect(nameElement.source, source);
     expect(nameElement.name, 'nice');
@@ -1103,66 +1103,68 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_complex_ast() {
-    final OrSelector selector = new SelectorParser(
+    final selector = new SelectorParser(
             source, 10, 'aaa, bbb:not(ccc), :not(:not(ddd)[eee], fff[ggg])')
-        .parse();
+        .parse() as OrSelector;
 
     expect(
         selector.toString(),
         equals('aaa || bbb && :not(ccc) || '
             ':not(:not(ddd) && [eee] || fff && [ggg])'));
     {
-      final ElementNameSelector subSelector = selector.selectors[0];
+      final subSelector = selector.selectors[0] as ElementNameSelector;
       expect(subSelector.toString(), "aaa");
     }
     {
-      final AndSelector subSelector = selector.selectors[1];
+      final subSelector = selector.selectors[1] as AndSelector;
       expect(subSelector.toString(), "bbb && :not(ccc)");
       {
-        final ElementNameSelector subSelector2 = subSelector.selectors[0];
+        final subSelector2 = subSelector.selectors[0] as ElementNameSelector;
         expect(subSelector2.toString(), "bbb");
       }
       {
-        final NotSelector subSelector2 = subSelector.selectors[1];
+        final subSelector2 = subSelector.selectors[1] as NotSelector;
         expect(subSelector2.toString(), ":not(ccc)");
         {
-          final ElementNameSelector subSelector3 = subSelector2.condition;
+          final subSelector3 = subSelector2.condition as ElementNameSelector;
           expect(subSelector3.toString(), "ccc");
         }
       }
     }
     {
-      final NotSelector subSelector = selector.selectors[2];
+      final subSelector = selector.selectors[2] as NotSelector;
       expect(
           subSelector.toString(), ":not(:not(ddd) && [eee] || fff && [ggg])");
       {
-        final OrSelector subSelector2 = subSelector.condition;
+        final subSelector2 = subSelector.condition as OrSelector;
         expect(subSelector2.toString(), ":not(ddd) && [eee] || fff && [ggg]");
         {
-          final AndSelector subSelector3 = subSelector2.selectors[0];
+          final subSelector3 = subSelector2.selectors[0] as AndSelector;
           expect(subSelector3.toString(), ":not(ddd) && [eee]");
           {
-            final NotSelector subSelector4 = subSelector3.selectors[0];
+            final subSelector4 = subSelector3.selectors[0] as NotSelector;
             expect(subSelector4.toString(), ":not(ddd)");
             {
-              final ElementNameSelector subSelector5 = subSelector4.condition;
+              final subSelector5 =
+                  subSelector4.condition as ElementNameSelector;
               expect(subSelector5.toString(), "ddd");
             }
           }
           {
-            final AttributeSelector subSelector4 = subSelector3.selectors[1];
+            final subSelector4 = subSelector3.selectors[1] as AttributeSelector;
             expect(subSelector4.toString(), "[eee]");
           }
         }
         {
-          final AndSelector subSelector3 = subSelector2.selectors[1];
+          final subSelector3 = subSelector2.selectors[1] as AndSelector;
           expect(subSelector3.toString(), "fff && [ggg]");
           {
-            final ElementNameSelector subSelector4 = subSelector3.selectors[0];
+            final subSelector4 =
+                subSelector3.selectors[0] as ElementNameSelector;
             expect(subSelector4.toString(), "fff");
           }
           {
-            final AttributeSelector subSelector4 = subSelector3.selectors[1];
+            final subSelector4 = subSelector3.selectors[1] as AttributeSelector;
             expect(subSelector4.toString(), "[ggg]");
           }
         }
@@ -1172,15 +1174,15 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_contains() {
-    final ContainsSelector selector =
-        new SelectorParser(source, 10, ':contains(/aaa/)').parse();
+    final selector = new SelectorParser(source, 10, ':contains(/aaa/)').parse()
+        as ContainsSelector;
     expect(selector.regex, 'aaa');
   }
 
   // ignore: non_constant_identifier_names
   void test_elementName() {
-    final ElementNameSelector selector =
-        new SelectorParser(source, 10, 'text-panel').parse();
+    final selector = new SelectorParser(source, 10, 'text-panel').parse()
+        as ElementNameSelector;
     final nameElement = selector.nameElement;
     expect(nameElement.source, source);
     expect(nameElement.name, 'text-panel');
@@ -1190,10 +1192,10 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_not() {
-    final NotSelector selector =
-        new SelectorParser(source, 10, ':not(aaa)').parse();
+    final selector =
+        new SelectorParser(source, 10, ':not(aaa)').parse() as NotSelector;
     {
-      final ElementNameSelector condition = selector.condition;
+      final condition = selector.condition as ElementNameSelector;
       final nameElement = condition.nameElement;
       expect(nameElement.source, source);
       expect(nameElement.name, 'aaa');
@@ -1204,11 +1206,11 @@ class SelectorParserTest {
 
   // ignore: non_constant_identifier_names
   void test_or() {
-    final OrSelector selector =
-        new SelectorParser(source, 10, 'aaa,bbb').parse();
+    final selector =
+        new SelectorParser(source, 10, 'aaa,bbb').parse() as OrSelector;
     expect(selector.selectors, hasLength(2));
     {
-      final ElementNameSelector subSelector = selector.selectors[0];
+      final subSelector = selector.selectors[0] as ElementNameSelector;
       final nameElement = subSelector.nameElement;
       expect(nameElement.source, source);
       expect(nameElement.name, 'aaa');
@@ -1216,7 +1218,7 @@ class SelectorParserTest {
       expect(nameElement.nameLength, 'aaa'.length);
     }
     {
-      final ElementNameSelector subSelector = selector.selectors[1];
+      final subSelector = selector.selectors[1] as ElementNameSelector;
       final nameElement = subSelector.nameElement;
       expect(nameElement.source, source);
       expect(nameElement.name, 'bbb');


### PR DESCRIPTION
2.1.0 stable does not catch declaration casts when implicit downcasts
are disabled, which is when I migrated this project and turned that flag
on.

Fix for 2.1.1-dev.1 which does not even accept declaration casts.