### PR TITLE
export angular_driver to be used outside as external tool

### DIFF
--- a/angular_analyzer_plugin/lib/angular_driver.dart
+++ b/angular_analyzer_plugin/lib/angular_driver.dart
@@ -1,0 +1,1 @@
+export 'src/angular_driver.dart';


### PR DESCRIPTION
Hello!

This pull request is intended to close this issue: https://github.com/dart-lang/angular_analyzer_plugin/issues/687.

AngularDriver class (requestHtmlResult, requestDartResult methods) can be used outside the plugin to check quality of angular templates as external tool,  for example, as hook to not commit dirty and not approved code to repository. Or to check the code quality in CI process before its publishing to production.


Please review and approve this export.

Regards, 
Andrey Smirnov





