### PR TITLE
Use new code UNDEFINED_PREFIXED_NAME

### DIFF
--- a/angular_analyzer_plugin/test/resolver_test.dart
+++ b/angular_analyzer_plugin/test/resolver_test.dart
@@ -3541,8 +3541,8 @@ component class can't be used with a prefix: {{prefixed.TestPanel}}
     await _resolveSingleTemplate(dartSource);
     expect(ranges, hasLength(2)); // the 'prefixed' prefixes only
     errorListener.assertErrorsWithCodes([
-      StaticTypeWarningCode.UNDEFINED_GETTER,
-      StaticTypeWarningCode.UNDEFINED_GETTER,
+      StaticTypeWarningCode.UNDEFINED_PREFIXED_NAME,
+      StaticTypeWarningCode.UNDEFINED_PREFIXED_NAME,
       StaticWarningCode.UNDEFINED_IDENTIFIER,
     ]);
   }


### PR DESCRIPTION
These tests expecting the old error code now fail, fixed.